### PR TITLE
CLOUD-311: stack status response extended with clusterstatus

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/converter/StackConverter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/converter/StackConverter.java
@@ -18,6 +18,7 @@ import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.json.ClusterResponse;
 import com.sequenceiq.cloudbreak.controller.json.StackJson;
 import com.sequenceiq.cloudbreak.controller.json.InstanceGroupJson;
+import com.sequenceiq.cloudbreak.domain.Cluster;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.domain.Status;
 import com.sequenceiq.cloudbreak.repository.CredentialRepository;
@@ -152,6 +153,10 @@ public class StackConverter extends AbstractConverter<StackJson, Stack> {
         Map<String, Object> stackStatus = new HashMap<>();
         stackStatus.put("id", stack.getId());
         stackStatus.put("status", stack.getStatus().name());
+        Cluster cluster = stack.getCluster();
+        if (cluster != null) {
+            stackStatus.put("clusterStatus", cluster.getStatus().name());
+        }
         return stackStatus;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
@@ -276,17 +276,17 @@ public class AwsConnector implements CloudPlatformConnector {
                     amazonASClient.suspendProcesses(new SuspendProcessesRequest().withAutoScalingGroupName(asGroupName));
                     amazonEC2Client.stopInstances(new StopInstancesRequest().withInstanceIds(instances));
                 } else {
-                    amazonASClient.resumeProcesses(new ResumeProcessesRequest().withAutoScalingGroupName(asGroupName));
                     amazonEC2Client.startInstances(new StartInstancesRequest().withInstanceIds(instances));
                     awsPollingService.pollWithTimeout(
                             new AwsInstanceStatusCheckerTask(),
                             new AwsInstances(stack, amazonEC2Client, new ArrayList(instances), "Running"),
                             AmbariClusterConnector.POLLING_INTERVAL,
                             AmbariClusterConnector.MAX_ATTEMPTS_FOR_AMBARI_OPS);
+                    amazonASClient.resumeProcesses(new ResumeProcessesRequest().withAutoScalingGroupName(asGroupName));
                     updateInstanceMetadata(stack, amazonEC2Client, stack.getAllInstanceMetaData(), instances);
                 }
             } catch (Exception e) {
-                LOGGER.error(String.format("Failed to %s AWS instances on stack: %s", stopped ? "stop" : "start", stack.getId()));
+                LOGGER.error(String.format("Failed to %s AWS instances on stack: %s", stopped ? "stop" : "start", stack.getId()), e);
                 result = false;
             }
         }


### PR DESCRIPTION
please review @keyki or @martonsereg or @doktoric

/stacks/{id}/status response is extended with cluster status. It is needed for integration tests. 