### PR TITLE
CLOUD-455 remove nodes from consul and deal with alive members only

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/ConsulHostCheckerTask.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/ConsulHostCheckerTask.java
@@ -21,7 +21,7 @@ public class ConsulHostCheckerTask implements StatusCheckerTask<ConsulContext> {
         List<String> privateIps = consulContext.getTargets();
         List<ConsulClient> clients = consulContext.getConsulClients();
         LOGGER.info("Checking '{}' different hosts for consul agents: '{}'", clients.size(), privateIps);
-        Map<String, String> members = ConsulUtils.getMembers(clients);
+        Map<String, String> members = ConsulUtils.getAliveMembers(clients);
         for (String ip : privateIps) {
             if (members.get(ip) == null) {
                 LOGGER.info("Consul agent didn't join on host: {}", ip);


### PR DESCRIPTION
`Problem1`: During decommission we remove nodes from the consul cluster, but they remain with a failed state so consul can keep trying to reach them. In case if we add new nodes to the cluster with the same IP address which we just removed during decommission, but with different hostname consul will return the wrong PTR record during reverse lookup (it returns to name of the node with the failed state). YARN RM maintains an exclusion list which will contain this hostname, thus the new nodes with the same IP but different hostname cannot join to the Hadoop cluster.

`Solution1`: During stack termination we force the removed nodes to leave the consul cluster, so their state become `left`. In this way consul will resolve properly the newly added hosts.

`Problem2`: Result of Problem1. In case of upscale we update the nodes hostname to use the ones they got from consul. If multiple hosts exist with the same IP, but with different state and name, the wrong got resolved.

`Solution2`: We only consider the `alive` members during hostname update.

I choose @martonsereg @biharitomi to do the ice bucket challenge. 