### PR TITLE
CLOUD-449 avoid IP collision in Azure VPC

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ dependencies {
         exclude group: 'commons-logging'
     }
     compile 'org.hibernate:hibernate-validator:5.1.1.Final'
-    compile('com.sequenceiq:azure-rest-client:0.1.19') {
+    compile('com.sequenceiq:azure-rest-client:0.1.20') {
         exclude group: 'log4j';
     }
     compile('com.sequenceiq:ambari-client17:1.7.32') {

--- a/config/checkstyle/checkstyle-suppressions.xml
+++ b/config/checkstyle/checkstyle-suppressions.xml
@@ -29,6 +29,7 @@
     <suppress checks="IllegalCatch" files="GccStackUtil.java"/>
     <suppress checks="IllegalCatch" files="GccProvisionSetup.java"/>
     <suppress checks="CyclomaticComplexity" files="MDCBuilder.java"/>
+    <suppress checks="MagicNumber" files="AzureStackUtil.java"/>
 
     <!-- -->
 

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureSimpleInstanceResourceBuilder.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureSimpleInstanceResourceBuilder.java
@@ -28,7 +28,6 @@ public abstract class AzureSimpleInstanceResourceBuilder implements
     protected static final int MAX_NAME_LENGTH = 50;
     protected static final int MAX_ATTEMPTS_FOR_AMBARI_OPS = -1;
     protected static final int NOT_FOUND = 404;
-    protected static final int VALID_IP_RANGE_START = 4;
     protected static final String DESCRIPTION = "description";
     protected static final String AFFINITYGROUP = "affinityGroup";
     protected static final String DEPLOYMENTSLOT = "deploymentSlot";

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/network/AzureNetworkResourceBuilder.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/network/AzureNetworkResourceBuilder.java
@@ -16,10 +16,10 @@ import com.google.common.base.Optional;
 import com.sequenceiq.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.controller.InternalServerException;
 import com.sequenceiq.cloudbreak.domain.AzureCredential;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.ResourceType;
 import com.sequenceiq.cloudbreak.domain.Stack;
-import com.sequenceiq.cloudbreak.domain.InstanceGroup;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.service.PollingService;
 import com.sequenceiq.cloudbreak.service.stack.connector.azure.AzureStackUtil;
@@ -97,8 +97,8 @@ public class AzureNetworkResourceBuilder extends AzureSimpleNetworkResourceBuild
         props.put(NAME, buildResources.get(0).getResourceName());
         props.put(AFFINITYGROUP, filterResourcesByType(resources, ResourceType.AZURE_AFFINITY_GROUP).get(0).getResourceName());
         props.put(SUBNETNAME, buildResources.get(0).getResourceName());
-        props.put(ADDRESSPREFIX, "172.16.0.0/16");
-        props.put(SUBNETADDRESSPREFIX, "172.16.0.0/24");
+        props.put(ADDRESSPREFIX, "172.0.0.0/8");
+        props.put(SUBNETADDRESSPREFIX, "172.16.0.0/16");
         AzureClient azureClient = azureStackUtil.createAzureClient(credential);
         return new AzureNetworkCreateRequest(buildResources.get(0).getResourceName(), provisionContextObject.getStackId(), props, azureClient,
                 resources, buildResources);

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/model/AzureProvisionContextObject.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/model/AzureProvisionContextObject.java
@@ -1,21 +1,27 @@
 package com.sequenceiq.cloudbreak.service.stack.resource.azure.model;
 
-import com.sequenceiq.cloud.azure.client.AzureClient;
+import java.util.HashSet;
+import java.util.Set;
+
 import com.sequenceiq.cloudbreak.service.stack.resource.ProvisionContextObject;
 
 public class AzureProvisionContextObject extends ProvisionContextObject {
 
-    private AzureClient azureClient;
     private String commonName;
     private String osImageName;
     private String userData;
+    private volatile Set<String> allocatedIPs;
 
-    public AzureProvisionContextObject(Long stackId, String commonName, AzureClient azureClient, String osImageName, String userData) {
+    public AzureProvisionContextObject(long stackId, String commonName, String osImageName, String userData) {
+        this(stackId, commonName, osImageName, userData, new HashSet<String>());
+    }
+
+    public AzureProvisionContextObject(long stackId, String commonName, String osImageName, String userData, Set<String> ips) {
         super(stackId);
-        this.azureClient = azureClient;
         this.commonName = commonName;
         this.osImageName = osImageName;
         this.userData = userData;
+        this.allocatedIPs = new HashSet<>(ips);
     }
 
     public String getOsImageName() {
@@ -26,16 +32,17 @@ public class AzureProvisionContextObject extends ProvisionContextObject {
         return userData;
     }
 
-    public AzureClient getAzureClient() {
-        return azureClient;
-    }
-
-    public void setAzureClient(AzureClient azureClient) {
-        this.azureClient = azureClient;
-    }
-
     public String getCommonName() {
         return commonName;
+    }
+
+    public synchronized boolean putIfAbsent(String ip) {
+        boolean added = false;
+        if (!allocatedIPs.contains(ip)) {
+            allocatedIPs.add(ip);
+            added = true;
+        }
+        return added;
     }
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/model/AzureStartStopContextObject.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/model/AzureStartStopContextObject.java
@@ -1,20 +1,12 @@
 package com.sequenceiq.cloudbreak.service.stack.resource.azure.model;
 
-import com.sequenceiq.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.service.stack.resource.StartStopContextObject;
 
 public class AzureStartStopContextObject extends StartStopContextObject {
 
-    private AzureClient azureClient;
-
-    public AzureStartStopContextObject(Stack stack, AzureClient azureClient) {
+    public AzureStartStopContextObject(Stack stack) {
         super(stack);
-        this.azureClient = azureClient;
-    }
-
-    public AzureClient getAzureClient() {
-        return azureClient;
     }
 
 }

--- a/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureStackUtilTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureStackUtilTest.java
@@ -1,0 +1,29 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AzureStackUtilTest {
+
+    @InjectMocks
+    private AzureStackUtil util;
+
+    @Test
+    public void testGetNextIPAddress() {
+        String startIp = "172.16.0.253";
+
+        String next1 = util.getNextIPAddress(startIp);
+        String next2 = util.getNextIPAddress(next1);
+        String next3 = util.getNextIPAddress(next2);
+
+        assertEquals("172.16.0.254", next1);
+        assertEquals("172.16.0.255", next2);
+        assertEquals("172.16.1.0", next3);
+    }
+
+}


### PR DESCRIPTION
`Problem`: The way we currently allocate IP addresses in the VPC on Azure is wrong. 

`Solution`: Every instance builder tries to find a valid IP, by starting from the first available IP in the subnet and incrementing the address until they find an available one. All resource builders share a context object which got extended with a volatile Set IP pool to avoid allocating the same IP to multiple instances. If a builder finds a free IP it writes it to the pool so others will see that it is already taken. It means multiple threads try to read and write the same pool concurrently so synchronization is a crucial point. On upscale a set of IP is already provided, by the running instances. 

@martonsereg @doktoric 