### PR TITLE
CLOUD-457 Do not delete consul servers during downscale

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/domain/InstanceMetaData.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/InstanceMetaData.java
@@ -41,6 +41,7 @@ public class InstanceMetaData implements ProvisionEntity {
     private Integer volumeCount;
     private String instanceId;
     private Boolean ambariServer;
+    private Boolean consulServer;
     private String dockerSubnet;
     private String longName;
     private Boolean removable;
@@ -169,5 +170,13 @@ public class InstanceMetaData implements ProvisionEntity {
 
     public void setTerminated(Boolean terminated) {
         this.terminated = terminated;
+    }
+
+    public Boolean getConsulServer() {
+        return consulServer;
+    }
+
+    public void setConsulServer(Boolean consulServer) {
+        this.consulServer = consulServer;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/AmbariServerFilter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/AmbariServerFilter.java
@@ -1,0 +1,33 @@
+package com.sequenceiq.cloudbreak.service.cluster.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.HostMetadata;
+import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
+
+@Component
+public class AmbariServerFilter implements HostFilter {
+
+    @Autowired
+    private InstanceMetaDataRepository instanceMetadataRepository;
+
+    @Override
+    public List<HostMetadata> filter(long stackId, Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException {
+        List<HostMetadata> copy = new ArrayList<>(hosts);
+        for (HostMetadata host : hosts) {
+            InstanceMetaData instanceMetaData = instanceMetadataRepository.findHostInStack(stackId, host.getHostName());
+            if (instanceMetaData.getAmbariServer()) {
+                copy.remove(host);
+                break;
+            }
+        }
+        return copy;
+    }
+
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/AppMasterFilter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/AppMasterFilter.java
@@ -19,7 +19,7 @@ import com.sequenceiq.cloudbreak.domain.HostMetadata;
 import com.sequenceiq.cloudbreak.service.cluster.ConfigParam;
 
 @Component
-public class AppMasterFilter implements AmbariHostFilter {
+public class AppMasterFilter implements HostFilter {
 
     private static final String AM_KEY = "amHostHttpAddress";
     private static final String APPS_NODE = "apps";
@@ -31,12 +31,12 @@ public class AppMasterFilter implements AmbariHostFilter {
 
     @Override
     @SuppressWarnings("unchecked")
-    public List<HostMetadata> filter(Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException {
+    public List<HostMetadata> filter(long stackId, Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException {
         List<HostMetadata> result = new ArrayList<>(hosts);
         try {
             String resourceManagerAddress = config.get(ConfigParam.YARN_RM_WEB_ADDRESS.key());
             String appResponse = restTemplate.exchange(
-                    String.format("http://%s", resourceManagerAddress + AmbariHostFilterService.RM_WS_PATH + "/apps?state=RUNNING"),
+                    String.format("http://%s", resourceManagerAddress + HostFilterService.RM_WS_PATH + "/apps?state=RUNNING"),
                     HttpMethod.GET, null, String.class).getBody();
             ObjectMapper objectMapper = new ObjectMapper();
             JsonNode jsonNode = objectMapper.readTree(appResponse);

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/ConsulServerFilter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/ConsulServerFilter.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.service.cluster.filter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.domain.HostMetadata;
+import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
+
+@Component
+public class ConsulServerFilter implements HostFilter {
+
+    @Autowired
+    private InstanceMetaDataRepository instanceMetadataRepository;
+
+    @Override
+    public List<HostMetadata> filter(long stackId, Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException {
+        List<HostMetadata> copy = new ArrayList<>(hosts);
+        for (HostMetadata host : hosts) {
+            InstanceMetaData instanceMetaData = instanceMetadataRepository.findHostInStack(stackId, host.getHostName());
+            if (instanceMetaData.getConsulServer()) {
+                copy.remove(host);
+            }
+        }
+        return copy;
+    }
+
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/HostFilter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/HostFilter.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 import com.sequenceiq.cloudbreak.domain.HostMetadata;
 
-public interface AmbariHostFilter {
+public interface HostFilter {
 
-    List<HostMetadata> filter(Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException;
+    List<HostMetadata> filter(long stackId, Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException;
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/HostFilterService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/HostFilterService.java
@@ -20,13 +20,13 @@ import com.sequenceiq.cloudbreak.service.cluster.AmbariConfigurationService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.AmbariClusterConnector;
 
 @Service
-public class AmbariHostFilterService {
+public class HostFilterService {
 
     public static final String RM_WS_PATH = "/ws/v1/cluster";
     private static final Logger LOGGER = LoggerFactory.getLogger(AmbariClusterConnector.class);
 
     @Autowired
-    private List<AmbariHostFilter> hostFilters;
+    private List<HostFilter> hostFilters;
 
     @Autowired
     private AmbariConfigurationService configurationService;
@@ -40,9 +40,9 @@ public class AmbariHostFilterService {
         try {
             AmbariClient ambariClient = clientService.create(stack);
             Map<String, String> config = configurationService.getConfiguration(ambariClient, hostGroup);
-            for (AmbariHostFilter hostFilter : hostFilters) {
+            for (HostFilter hostFilter : hostFilters) {
                 try {
-                    filteredList = hostFilter.filter(config, filteredList);
+                    filteredList = hostFilter.filter(stack.getId(), config, filteredList);
                 } catch (HostFilterException e) {
                     LOGGER.warn("Filter didn't succeed, moving to next filter", e);
                 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/NameNodeFilter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/filter/NameNodeFilter.java
@@ -11,10 +11,10 @@ import com.sequenceiq.cloudbreak.domain.HostMetadata;
 import com.sequenceiq.cloudbreak.service.cluster.ConfigParam;
 
 @Component
-public class NameNodeFilter implements AmbariHostFilter {
+public class NameNodeFilter implements HostFilter {
 
     @Override
-    public List<HostMetadata> filter(Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException {
+    public List<HostMetadata> filter(long stackId, Map<String, String> config, List<HostMetadata> hosts) throws HostFilterException {
         List<HostMetadata> result = new ArrayList<>(hosts);
         try {
             String nameNode = config.get(ConfigParam.NAMENODE_HTTP_ADDRESS.key());

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -53,7 +53,7 @@ import com.sequenceiq.cloudbreak.service.cluster.event.ClusterCreationFailure;
 import com.sequenceiq.cloudbreak.service.cluster.event.ClusterCreationSuccess;
 import com.sequenceiq.cloudbreak.service.cluster.event.UpdateAmbariHostsFailure;
 import com.sequenceiq.cloudbreak.service.cluster.event.UpdateAmbariHostsSuccess;
-import com.sequenceiq.cloudbreak.service.cluster.filter.AmbariHostFilterService;
+import com.sequenceiq.cloudbreak.service.cluster.filter.HostFilterService;
 import com.sequenceiq.cloudbreak.service.cluster.flow.status.AmbariClusterStatusUpdater;
 import com.sequenceiq.cloudbreak.service.events.CloudbreakEventService;
 
@@ -102,7 +102,7 @@ public class AmbariClusterConnector {
     private AmbariClientService clientService;
 
     @Autowired
-    private AmbariHostFilterService hostFilterService;
+    private HostFilterService hostFilterService;
 
     @Autowired
     private CloudbreakEventService eventService;

--- a/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterServiceTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterServiceTest.java
@@ -47,7 +47,7 @@ import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
 import com.sequenceiq.cloudbreak.repository.RetryingStackUpdater;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.service.cluster.event.UpdateAmbariHostsRequest;
-import com.sequenceiq.cloudbreak.service.cluster.filter.AmbariHostFilterService;
+import com.sequenceiq.cloudbreak.service.cluster.filter.HostFilterService;
 
 import groovyx.net.http.HttpResponseException;
 import reactor.core.Reactor;
@@ -84,7 +84,7 @@ public class AmbariClusterServiceTest {
     private AmbariClientService clientService;
 
     @Mock
-    private AmbariHostFilterService hostFilterService;
+    private HostFilterService hostFilterService;
 
     @Mock
     private HostMetadataRepository hostMetadataRepository;
@@ -202,7 +202,7 @@ public class AmbariClusterServiceTest {
         when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
-        when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "1"));
+        when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "2"));
         when(hostFilterService.filterHostsForDecommission(stack, hostsMetaData, "slave_1")).thenReturn(asList(metadata2, metadata3));
 
         Exception result = null;


### PR DESCRIPTION
`Problem`: During downscale there is a high chance we remove a host which acts as a consul server thus the cluster becomes unreliable.

`Solution`: We keep track of the consul servers and exclude them from the decommission candidates as reserved instances.

@martonsereg 