### PR TITLE
CLOUD-401 configurable consul server count with defaults

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/FailurePolicyJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/FailurePolicyJson.java
@@ -5,14 +5,14 @@ import com.sequenceiq.cloudbreak.domain.AdjustmentType;
 public class FailurePolicyJson implements JsonEntity {
 
     private Long id;
-    private Long threshold;
+    private long threshold;
     private AdjustmentType adjustmentType;
 
-    public Long getThreshold() {
+    public long getThreshold() {
         return threshold;
     }
 
-    public void setThreshold(Long threshold) {
+    public void setThreshold(long threshold) {
         this.threshold = threshold;
     }
 
@@ -25,7 +25,6 @@ public class FailurePolicyJson implements JsonEntity {
     }
 
     public Long getId() {
-
         return id;
     }
 

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackJson.java
@@ -47,6 +47,7 @@ public class StackJson implements JsonEntity {
     private OnFailureAction onFailureAction = OnFailureAction.ROLLBACK;
     private FailurePolicyJson failurePolicy;
     private List<InstanceGroupJson> instanceGroups = new ArrayList<>();
+    private Integer consulServerCount;
 
     public StackJson() {
     }
@@ -221,5 +222,13 @@ public class StackJson implements JsonEntity {
     @JsonIgnore
     public void setPublicInAccount(boolean publicInAccount) {
         this.publicInAccount = publicInAccount;
+    }
+
+    public Integer getConsulServerCount() {
+        return consulServerCount;
+    }
+
+    public void setConsulServerCount(Integer consulServerCount) {
+        this.consulServerCount = consulServerCount;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
@@ -175,6 +175,8 @@ public class Stack implements ProvisionEntity {
 
     private String hash;
 
+    private int consulServers;
+
     private boolean metadataReady;
 
     @OneToOne
@@ -364,6 +366,14 @@ public class Stack implements ProvisionEntity {
 
     public void setImage(String image) {
         this.image = image;
+    }
+
+    public int getConsulServers() {
+        return consulServers;
+    }
+
+    public void setConsulServers(int consulServers) {
+        this.consulServers = consulServers;
     }
 
     public OnFailureAction getOnFailureActionAction() {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/UserDataBuilder.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/UserDataBuilder.java
@@ -32,9 +32,10 @@ public class UserDataBuilder {
         }
     }
 
-    public String build(CloudPlatform cloudPlatform, String metadataHash, Map<String, String> parameters) {
+    public String build(CloudPlatform cloudPlatform, String metadataHash, int consulServers, Map<String, String> parameters) {
         parameters.put("METADATA_ADDRESS", hostAddress);
         parameters.put("METADATA_HASH", metadataHash);
+        parameters.put("CONSUL_SERVER_COUNT", "" + consulServers);
         String userDataScript = userDataScripts.get(cloudPlatform);
         StringBuilder stringBuilder = new StringBuilder("#!/bin/bash\n");
         for (Entry<String, String> parameter : parameters.entrySet()) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/ConsulUtils.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/ConsulUtils.java
@@ -184,4 +184,42 @@ public final class ConsulUtils {
         }
     }
 
+    public static int getConsulServerCount(int nodeCount) {
+        if (nodeCount < ConsulServers.NODE_COUNT_LOW.getMax()) {
+            return ConsulServers.NODE_COUNT_LOW.getConsulServerCount();
+        } else if (nodeCount < ConsulServers.NODE_COUNT_MEDIUM.getMax()) {
+            return ConsulServers.NODE_COUNT_MEDIUM.getConsulServerCount();
+        } else {
+            return ConsulServers.NODE_COUNT_HIGH.getConsulServerCount();
+        }
+    }
+
+    public enum ConsulServers {
+        NODE_COUNT_LOW(3, 1000, 3),
+        NODE_COUNT_MEDIUM(1001, 5000, 5),
+        NODE_COUNT_HIGH(5001, 100_000, 7);
+
+        private final int min;
+        private final int max;
+        private final int consulServerCount;
+
+        private ConsulServers(int min, int max, int consulServerCount) {
+            this.min = min;
+            this.max = max;
+            this.consulServerCount = consulServerCount;
+        }
+
+        public int getMin() {
+            return min;
+        }
+
+        public int getMax() {
+            return max;
+        }
+
+        public int getConsulServerCount() {
+            return consulServerCount;
+        }
+    }
+
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/ProvisionContext.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/ProvisionContext.java
@@ -87,12 +87,12 @@ public class ProvisionContext {
                 String statusReason = "Creation of cluster infrastructure has started on the cloud provider.";
                 stack = stackUpdater.updateStackStatus(stack.getId(), Status.CREATE_IN_PROGRESS, statusReason);
                 stackUpdater.updateStackStatusReason(stack.getId(), stack.getStatus().name());
+                String userDataScript = userDataBuilder.build(cloudPlatform, stack.getHash(), stack.getConsulServers(), userDataParams);
                 if (!cloudPlatform.isWithTemplate()) {
                     stackUpdater.updateStackStatus(stack.getId(), Status.REQUESTED, "Creation of cluster infrastructure has been requested.");
                     Set<Resource> resourceSet = new HashSet<>();
                     ResourceBuilderInit resourceBuilderInit = resourceBuilderInits.get(cloudPlatform);
-                    final ProvisionContextObject pCO =
-                            resourceBuilderInit.provisionInit(stack, userDataBuilder.build(cloudPlatform, stack.getHash(), userDataParams));
+                    final ProvisionContextObject pCO = resourceBuilderInit.provisionInit(stack, userDataScript);
                     for (ResourceBuilder resourceBuilder : networkResourceBuilders.get(cloudPlatform)) {
                         List<Resource> buildResources = resourceBuilder.buildResources(pCO, 0, Arrays.asList(resourceSet), Optional.<InstanceGroup>absent());
                         CreateResourceRequest createResourceRequest =
@@ -134,7 +134,7 @@ public class ProvisionContext {
                     reactor.notify(ReactorConfig.PROVISION_COMPLETE_EVENT, Event.wrap(new ProvisionComplete(cloudPlatform, stack.getId(), resourceSet)));
                 } else {
                     CloudPlatformConnector cloudPlatformConnector = cloudPlatformConnectors.get(cloudPlatform);
-                    cloudPlatformConnector.buildStack(stack, userDataBuilder.build(cloudPlatform, stack.getHash(), userDataParams), setupProperties);
+                    cloudPlatformConnector.buildStack(stack, userDataScript, setupProperties);
                 }
             } else {
                 LOGGER.info("CloudFormation stack creation was requested for a stack, that is not in REQUESTED status anymore. [stackId: '{}', status: '{}']",

--- a/src/main/resources/azure-init.sh
+++ b/src/main/resources/azure-init.sh
@@ -63,8 +63,8 @@ get_consul_opts() {
       CONSUL_OPTIONS="$CONSUL_OPTIONS -retry-join $(consul_join_ip)"
     fi
 
-    if [ $(my_order) -le 3 ]; then
-      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect 3"
+    if [ $(my_order) -le "$CONSUL_SERVER_COUNT" ]; then
+      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect $CONSUL_SERVER_COUNT"
     fi
   fi
 }

--- a/src/main/resources/ec2-init.sh
+++ b/src/main/resources/ec2-init.sh
@@ -63,8 +63,8 @@ get_consul_opts() {
       CONSUL_OPTIONS="$CONSUL_OPTIONS -retry-join $(consul_join_ip)"
     fi
 
-    if [ $(my_order) -le 3 ]; then
-      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect 3"
+    if [ $(my_order) -le "$CONSUL_SERVER_COUNT" ]; then
+      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect $CONSUL_SERVER_COUNT"
     fi
   fi
 }

--- a/src/main/resources/gcc-init.sh
+++ b/src/main/resources/gcc-init.sh
@@ -63,8 +63,8 @@ get_consul_opts() {
       CONSUL_OPTIONS="$CONSUL_OPTIONS -retry-join $(consul_join_ip)"
     fi
 
-    if [ $(my_order) -le 3 ]; then
-      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect 3"
+    if [ $(my_order) -le "$CONSUL_SERVER_COUNT" ]; then
+      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect $CONSUL_SERVER_COUNT"
     fi
   fi
 }

--- a/src/main/resources/openstack-init.sh
+++ b/src/main/resources/openstack-init.sh
@@ -63,8 +63,8 @@ get_consul_opts() {
       CONSUL_OPTIONS="$CONSUL_OPTIONS -retry-join $(consul_join_ip)"
     fi
 
-    if [ $(my_order) -le 3 ]; then
-      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect 3"
+    if [ $(my_order) -le "$CONSUL_SERVER_COUNT" ]; then
+      CONSUL_OPTIONS="$CONSUL_OPTIONS -server -bootstrap-expect $CONSUL_SERVER_COUNT"
     fi
   fi
 }

--- a/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/UserDataBuilderTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/UserDataBuilderTest.java
@@ -32,7 +32,7 @@ public class UserDataBuilderTest {
         Map<String, String> map = new HashMap<>();
         map.put("NODE_PREFIX", "testamb");
         map.put("MYDOMAIN", "test.kom");
-        Assert.assertEquals(expectedScript, userDataBuilder.build(CloudPlatform.AWS, "hash123", map));
+        Assert.assertEquals(expectedScript, userDataBuilder.build(CloudPlatform.AWS, "hash123", 3, map));
     }
 
     @Test
@@ -41,7 +41,7 @@ public class UserDataBuilderTest {
         Map<String, String> map = new HashMap<>();
         map.put("NODE_PREFIX", "testamb");
         map.put("MYDOMAIN", "test.kom");
-        Assert.assertEquals(expectedScript, userDataBuilder.build(CloudPlatform.AZURE, "hash123", map));
+        Assert.assertEquals(expectedScript, userDataBuilder.build(CloudPlatform.AZURE, "hash123", 3, map));
     }
 
     @Test
@@ -50,7 +50,7 @@ public class UserDataBuilderTest {
         Map<String, String> map = new HashMap<>();
         map.put("NODE_PREFIX", "testamb");
         map.put("MYDOMAIN", "test.kom");
-        Assert.assertEquals(expectedScript, userDataBuilder.build(CloudPlatform.GCC, "hash123", map));
+        Assert.assertEquals(expectedScript, userDataBuilder.build(CloudPlatform.GCC, "hash123", 3, map));
     }
 
 }

--- a/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/ProvisionContextTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/ProvisionContextTest.java
@@ -139,7 +139,7 @@ public class ProvisionContextTest {
 
         given(reactor.notify(any(), any(Event.class))).willReturn(null);
 
-        given(userDataBuilder.build(any(CloudPlatform.class), anyString(), anyMap())).willReturn("userdata dummy");
+        given(userDataBuilder.build(any(CloudPlatform.class), anyString(), anyInt(), anyMap())).willReturn(DUMMY_NAME);
         // WHEN
         underTest.buildStack(cloudPlatform, 1L, setupProperties, userDataParams);
         // THEN
@@ -160,7 +160,7 @@ public class ProvisionContextTest {
 
         given(reactor.notify(any(), any(Event.class))).willReturn(null);
 
-        given(userDataBuilder.build(any(CloudPlatform.class), anyString(), anyMap())).willReturn("userdata dummy");
+        given(userDataBuilder.build(any(CloudPlatform.class), anyString(), anyInt(), anyMap())).willReturn(DUMMY_NAME);
         // WHEN
         underTest.buildStack(cloudPlatform, 1L, setupProperties, userDataParams);
         // THEN
@@ -183,7 +183,7 @@ public class ProvisionContextTest {
 
         given(reactor.notify(any(), any(Event.class))).willReturn(null);
 
-        given(userDataBuilder.build(any(CloudPlatform.class), anyString(), anyMap())).willReturn("userdata dummy");
+        given(userDataBuilder.build(any(CloudPlatform.class), anyString(), anyInt(), anyMap())).willReturn(DUMMY_NAME);
         // WHEN
         underTest.buildStack(cloudPlatform, 1L, setupProperties, userDataParams);
         // THEN

--- a/src/test/resources/azure-init-test-expected.sh
+++ b/src/test/resources/azure-init-test-expected.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 METADATA_HASH=hash123
+CONSUL_SERVER_COUNT=3
 MYDOMAIN=test.kom
 METADATA_ADDRESS=http://cloudbreak.sequenceiq.com
 NODE_PREFIX=testamb

--- a/src/test/resources/ec2-init-test-expected.sh
+++ b/src/test/resources/ec2-init-test-expected.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 METADATA_HASH=hash123
+CONSUL_SERVER_COUNT=3
 MYDOMAIN=test.kom
 METADATA_ADDRESS=http://cloudbreak.sequenceiq.com
 NODE_PREFIX=testamb

--- a/src/test/resources/gcc-init-test-expected.sh
+++ b/src/test/resources/gcc-init-test-expected.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 METADATA_HASH=hash123
+CONSUL_SERVER_COUNT=3
 MYDOMAIN=test.kom
 METADATA_ADDRESS=http://cloudbreak.sequenceiq.com
 NODE_PREFIX=testamb

--- a/src/test/resources/openstack-init-test-expected.sh
+++ b/src/test/resources/openstack-init-test-expected.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 METADATA_HASH=hash123
+CONSUL_SERVER_COUNT=3
 MYDOMAIN=test.kom
 METADATA_ADDRESS=http://cloudbreak.sequenceiq.com
 NODE_PREFIX=testamb


### PR DESCRIPTION
@biharitomi @martonsereg 

It is possible now to configure how many consul servers should CB launch. If it's not provided the defaults are used.

DB change required, changeset added to liquibase.