### PR TITLE
CLOUD-470 stacks can be created in an existing VPC on AWS

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/controller/ExceptionControllerAdvice.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/ExceptionControllerAdvice.java
@@ -11,6 +11,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpMediaTypeNotSupportedException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
@@ -57,7 +58,7 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler({ MethodArgumentNotValidException.class })
     public ResponseEntity<ValidationResult> validationFailed(MethodArgumentNotValidException e) {
         MDCBuilder.buildMdcContext();
-        LOGGER.error(e.getMessage(), e);
+        LOGGER.error(e.getMessage());
         ValidationResult result = new ValidationResult();
         for (FieldError err : e.getBindingResult().getFieldErrors()) {
             result.addValidationError(err.getField(), err.getDefaultMessage());
@@ -70,6 +71,13 @@ public class ExceptionControllerAdvice {
         MDCBuilder.buildMdcContext();
         LOGGER.error(e.getMessage(), e);
         return new ResponseEntity<>(new ExceptionResult("The requested http method is not supported on the resource."), HttpStatus.BAD_REQUEST);
+    }
+
+    @ExceptionHandler({ HttpMediaTypeNotSupportedException.class })
+    public ResponseEntity<ExceptionResult> httpMediaTypeNotSupported(Exception e) {
+        MDCBuilder.buildMdcContext();
+        LOGGER.info(e.getMessage());
+        return new ResponseEntity<>(new ExceptionResult(e.getMessage()), HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler({ SubscriptionAlreadyExistException.class })

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackJson.java
@@ -1,19 +1,24 @@
 package com.sequenceiq.cloudbreak.controller.json;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.sequenceiq.cloudbreak.controller.validation.ValidStackRequest;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.OnFailureAction;
 import com.sequenceiq.cloudbreak.domain.Status;
 import com.sequenceiq.cloudbreak.domain.SubnetJson;
 
+@ValidStackRequest
 public class StackJson implements JsonEntity {
 
     private Long id;
@@ -22,6 +27,7 @@ public class StackJson implements JsonEntity {
             message = "The name can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
     @NotNull
     private String name;
+    @NotNull
     private String region;
     private String owner;
     private String account;
@@ -47,9 +53,12 @@ public class StackJson implements JsonEntity {
     private String statusReason;
     private OnFailureAction onFailureAction = OnFailureAction.ROLLBACK;
     private FailurePolicyJson failurePolicy;
+    @Valid
     private List<InstanceGroupJson> instanceGroups = new ArrayList<>();
     private Integer consulServerCount;
     private List<SubnetJson> allowedSubnets = new ArrayList<>();
+
+    private Map<String, String> parameters = new HashMap<>();
 
     public StackJson() {
     }
@@ -240,5 +249,13 @@ public class StackJson implements JsonEntity {
 
     public void setConsulServerCount(Integer consulServerCount) {
         this.consulServerCount = consulServerCount;
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/ParametersRegexValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/ParametersRegexValidator.java
@@ -17,7 +17,7 @@ public class ParametersRegexValidator extends AbstractParameterValidator {
             if (param.getRegex().isPresent()
                     && parameters.containsKey(param.getName())
                     && !String.valueOf(parameters.get(param.getName())).matches(param.getRegex().get())) {
-                addParameterConstraintViolation(context, param.getName(), String.format("%s is not valid for regex: %s.",
+                addParameterConstraintViolation(context, param.getName(), String.format("%s does not match regex: %s.",
                         param.getName(), param.getRegex().get()));
                 valid = false;
             }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/StackJsonValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/StackJsonValidator.java
@@ -1,0 +1,51 @@
+package com.sequenceiq.cloudbreak.controller.validation;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.controller.json.StackJson;
+
+@Component
+public class StackJsonValidator implements ConstraintValidator<ValidStackRequest, StackJson> {
+
+    @Autowired
+    private ParametersRegexValidator regexValidator;
+
+    private List<TemplateParam> stackParams = new ArrayList<>();
+    private List<String> allowedParams = new ArrayList<>();
+
+    @Override
+    public void initialize(ValidStackRequest constraintAnnotation) {
+        for (StackParam param : StackParam.values()) {
+            stackParams.add(param);
+            allowedParams.add(param.getName());
+        }
+    }
+
+    @Override
+    public boolean isValid(StackJson json, ConstraintValidatorContext context) {
+        for (String key : json.getParameters().keySet()) {
+            if (!allowedParams.contains(key)) {
+                context.buildConstraintViolationWithTemplate("Parameter is not allowed. Valid parameters are " + allowedParams)
+                        .addPropertyNode("parameters")
+                        .addBeanNode().inIterable().atKey(key)
+                        .addConstraintViolation();
+                return false;
+            }
+        }
+        Map<String, Object> params = new HashMap<>();
+        params.putAll(json.getParameters());
+        if (!regexValidator.validate(params, context, stackParams)) {
+            return false;
+        }
+        return true;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/StackParam.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/StackParam.java
@@ -1,0 +1,42 @@
+package com.sequenceiq.cloudbreak.controller.validation;
+
+import com.google.common.base.Optional;
+
+public enum StackParam implements TemplateParam {
+
+    VPC_ID("vpcId", false, String.class, Optional.of("vpc-[a-z0-9]{8}")),
+    IGW_ID("internetGatewayId", false, String.class, Optional.of("igw-[a-z0-9]{8}")),
+    SUBNET_CIDR("subnetCIDR", false, String.class, Optional.of("(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"));
+
+    private final String paramName;
+    private final Class clazz;
+    private final boolean required;
+    private final Optional<String> regex;
+
+    private StackParam(String paramName, Boolean required, Class clazz, Optional<String> regex) {
+        this.paramName = paramName;
+        this.required = required;
+        this.clazz = clazz;
+        this.regex = regex;
+    }
+
+    @Override
+    public String getName() {
+        return paramName;
+    }
+
+    @Override
+    public Class getClazz() {
+        return clazz;
+    }
+
+    @Override
+    public Boolean getRequired() {
+        return required;
+    }
+
+    @Override
+    public Optional<String> getRegex() {
+        return regex;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/ValidStackRequest.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/ValidStackRequest.java
@@ -1,0 +1,22 @@
+package com.sequenceiq.cloudbreak.controller.validation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+
+@Target({ ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+@Constraint(validatedBy = StackJsonValidator.class)
+public @interface ValidStackRequest {
+
+    String message() default "Invalid stack request parameters.";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default { };
+
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/converter/StackConverter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/converter/StackConverter.java
@@ -103,6 +103,7 @@ public class StackConverter extends AbstractConverter<StackJson, Stack> {
             stackJson.setFailurePolicy(failurePolicyConverter.convert(entity.getFailurePolicy()));
         }
         stackJson.setImage(entity.getImage());
+        stackJson.setParameters(entity.getParameters());
         return stackJson;
     }
 
@@ -129,7 +130,7 @@ public class StackConverter extends AbstractConverter<StackJson, Stack> {
         int minNodeCount = ConsulUtils.ConsulServers.NODE_COUNT_LOW.getMin();
         int fullNodeCount = stack.getFullNodeCount();
         if (fullNodeCount < minNodeCount) {
-            throw new BadRequestException(String.format("At least %s node is required to launch the stack", minNodeCount));
+            throw new BadRequestException(String.format("At least %s nodes are required to launch the stack", minNodeCount));
         }
         if (json.getImage() != null) {
             stack.setImage(json.getImage());
@@ -153,6 +154,7 @@ public class StackConverter extends AbstractConverter<StackJson, Stack> {
                 throw new BadRequestException(errorMsg);
             }
         }
+        stack.setParameters(json.getParameters());
         return stack;
     }
 

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
@@ -3,16 +3,20 @@ package com.sequenceiq.cloudbreak.domain;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
@@ -180,6 +184,11 @@ public class Stack implements ProvisionEntity {
     private int consulServers;
 
     private boolean metadataReady;
+
+    @ElementCollection(fetch = FetchType.EAGER)
+    @MapKeyColumn(name = "key")
+    @Column(name = "value", columnDefinition = "TEXT", length = 100000)
+    private Map<String, String> parameters;
 
     @OneToOne
     private Credential credential;
@@ -481,5 +490,13 @@ public class Stack implements ProvisionEntity {
 
     public void addAllowedSubnet(Subnet subnet) {
         allowedSubnets.add(subnet);
+    }
+
+    public Map<String, String> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(Map<String, String> parameters) {
+        this.parameters = parameters;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsMetadataSetup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsMetadataSetup.java
@@ -97,7 +97,7 @@ public class AwsMetadataSetup implements MetadataSetup {
                     coreInstanceMetadata.add(new CoreInstanceMetaData(
                             instance.getInstanceId(),
                             instance.getPrivateIpAddress(),
-                            instance.getPublicDnsName(),
+                            instance.getPublicIpAddress(),
                             instance.getBlockDeviceMappings().size() - 1,
                             instance.getPrivateDnsName(),
                             instanceGroup

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationStackStatusChecker.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationStackStatusChecker.java
@@ -43,6 +43,7 @@ public class CloudFormationStackStatusChecker implements StatusCheckerTask<Cloud
             MDCBuilder.buildMdcContext(stack);
             LOGGER.info("Checking if AWS CloudFormation stack '{}' reached status '{}'", cloudFormationStackName, successStatus);
             DescribeStacksResult describeStacksResult = client.describeStacks(describeStacksRequest);
+
             List<com.amazonaws.services.cloudformation.model.Stack> stacks = describeStacksResult.getStacks();
             if (stacks.size() > 0) {
                 StackStatus actualStatus = StackStatus.valueOf(stacks.get(0).getStackStatus());

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationTemplateBuilder.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationTemplateBuilder.java
@@ -26,10 +26,11 @@ public class CloudFormationTemplateBuilder {
     @Autowired
     private Configuration freemarkerConfiguration;
 
-    public String build(Stack stack, String templatePath) {
+    public String build(Stack stack, boolean existingVPC, String templatePath) {
         Map<String, Object> model = new HashMap<>();
         model.put("templates", stack.getInstanceGroupsAsList());
         model.put("useSpot", spotPriceNeeded(stack.getInstanceGroups()));
+        model.put("existingVPC", existingVPC);
         model.put("subnets", stack.getAllowedSubnets());
         model.put("ports", NetworkUtils.getPorts(stack));
         model.put("cbSubnet", NetworkConfig.SUBNET_16);

--- a/src/main/resources/templates/aws-cf-stack.ftl
+++ b/src/main/resources/templates/aws-cf-stack.ftl
@@ -11,7 +11,33 @@
       "MinLength": "1",
       "MaxLength": "50"
     },
-    
+
+    <#if existingVPC>
+    "VPCId" : {
+      "Description" : "Id of the VPC where to deploy the cluster",
+      "Type" : "String",
+      "MinLength": "12",
+      "MaxLength": "12",
+      "AllowedPattern" : "vpc-[a-z0-9]{8}"
+    },
+
+    "SubnetCIDR" : {
+      "Description" : "IP address range in the subnet specified as CIDR notation",
+      "Type" : "String",
+      "MinLength": "9",
+      "MaxLength": "18",
+      "AllowedPattern" : "(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})/(\\d{1,2})"
+    },
+
+    "InternetGatewayId" : {
+      "Description" : "Id of the internet gateway used by the VPC",
+      "Type" : "String",
+      "MinLength": "12",
+      "MaxLength": "12",
+      "AllowedPattern" : "igw-[a-z0-9]{8}"
+    },
+    </#if>
+
     "StackOwner" : {
       "Description" : "The instances will have this parameter as an Owner tag.",
       "Type" : "String",
@@ -53,15 +79,18 @@
 
   },
 
+  <#if !existingVPC>
   "Mappings" : {
     "SubnetConfig" : {
       "VPC"     : { "CIDR" : "${cbSubnet}" },
       "Public"  : { "CIDR" : "${cbSubnet}" }
     }
   },
+  </#if>
 
   "Resources" : {
 
+    <#if !existingVPC>
     "VPC" : {
       "Type" : "AWS::EC2::VPC",
       "Properties" : {
@@ -74,12 +103,18 @@
         ]
       }
     },
+    </#if>
 
     "PublicSubnet" : {
       "Type" : "AWS::EC2::Subnet",
       "Properties" : {
+        <#if existingVPC>
+        "VpcId" : { "Ref" : "VPCId" },
+        "CidrBlock" : { "Ref" : "SubnetCIDR" },
+        <#else>
         "VpcId" : { "Ref" : "VPC" },
         "CidrBlock" : { "Fn::FindInMap" : [ "SubnetConfig", "Public", "CIDR" ]},
+        </#if>
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" }
@@ -87,6 +122,7 @@
       }
     },
 
+    <#if !existingVPC>
     "InternetGateway" : {
       "Type" : "AWS::EC2::InternetGateway",
       "Properties" : {
@@ -104,12 +140,17 @@
          "InternetGatewayId" : { "Ref" : "InternetGateway" }
        }
     },
+    </#if>
 
 	
     "PublicRouteTable" : {
       "Type" : "AWS::EC2::RouteTable",
       "Properties" : {
+        <#if existingVPC>
+        "VpcId" : { "Ref" : "VPCId" },
+        <#else>
         "VpcId" : { "Ref" : "VPC" },
+        </#if>
         "Tags" : [
           { "Key" : "Application", "Value" : { "Ref" : "AWS::StackId" } },
           { "Key" : "Network", "Value" : "Public" }
@@ -119,11 +160,15 @@
 
     "PublicRoute" : {
       "Type" : "AWS::EC2::Route",
-      "DependsOn" : "AttachGateway",
+      "DependsOn" : "PublicRouteTable",
       "Properties" : {
         "RouteTableId" : { "Ref" : "PublicRouteTable" },
         "DestinationCidrBlock" : "0.0.0.0/0",
+        <#if existingVPC>
+        "GatewayId" : { "Ref" : "InternetGatewayId" }
+        <#else>
         "GatewayId" : { "Ref" : "InternetGateway" }
+        </#if>
       }
     },
 
@@ -211,7 +256,11 @@
       "Type" : "AWS::EC2::SecurityGroup",
       "Properties" : {
         "GroupDescription" : "Allow access from web and bastion as well as outbound HTTP and HTTPS traffic",
+        <#if existingVPC>
+        "VpcId" : { "Ref" : "VPCId" },
+        <#else>
         "VpcId" : { "Ref" : "VPC" },
+        </#if>
         "SecurityGroupIngress" : [
           <#list subnets as s>
             <#list ports as p>

--- a/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationTemplateBuilderTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationTemplateBuilderTest.java
@@ -64,7 +64,7 @@ public class CloudFormationTemplateBuilderTest {
         when(stack.getInstanceGroupsAsList()).thenReturn(instanceGroupsList);
         when(stack.getInstanceGroups()).thenReturn(instanceGroupSet);
         // WHEN
-        String result = underTest.build(stack, "templates/aws-cf-stack.ftl");
+        String result = underTest.build(stack, false, "templates/aws-cf-stack.ftl");
         // THEN
         assertTrue(result.contains("\"DeviceName\" : \"/dev/xvdf\""));
         assertTrue(result.contains("\"DeviceName\" : \"/dev/xvdg\""));
@@ -90,7 +90,7 @@ public class CloudFormationTemplateBuilderTest {
         when(stack.getInstanceGroupsAsList()).thenReturn(instanceGroupsList);
         when(stack.getInstanceGroups()).thenReturn(instanceGroupSet);
         // WHEN
-        String result = underTest.build(stack, "templates/aws-cf-stack.ftl");
+        String result = underTest.build(stack, false, "templates/aws-cf-stack.ftl");
         // THEN
         assertTrue(result.contains("\"SpotPrice\""));
     }
@@ -113,7 +113,7 @@ public class CloudFormationTemplateBuilderTest {
         when(stack.getInstanceGroupsAsList()).thenReturn(instanceGroupsList);
         when(stack.getInstanceGroups()).thenReturn(instanceGroupSet);
         // WHEN
-        String result = underTest.build(stack, "templates/aws-cf-stack.ftl");
+        String result = underTest.build(stack, false, "templates/aws-cf-stack.ftl");
         // THEN
         assertFalse(result.contains("\"SpotPrice\""));
     }
@@ -121,6 +121,6 @@ public class CloudFormationTemplateBuilderTest {
     @Test(expected = InternalServerException.class)
     public void testBuildTemplateShouldThrowInternalServerExceptionWhenTemplateDoesNotExist() {
         // WHEN
-        underTest.build(stack, "templates/non-existent.ftl");
+        underTest.build(stack, false, "templates/non-existent.ftl");
     }
 }


### PR DESCRIPTION
@doktoric 
Ability to create stacks in an existing VPC on AWS. VPCId, internetGatewayId and subnetCIDR parameters only make sense on AWS stacks so these are not part of the main Stack domain object, I've rather introduced stack parameters that is an unstructured set of params.
VPC ids and subnet overlappings are not validated before stack creation, so these will only turn out when the CloudFormation stack is creating.
UI and Shell changes are not yet done, this `curl` can be used to test this PR:
```
curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json"  -d '{"name":"almasd","userName":"admin","password":"admin","credentialId":"50","region":"US_WEST_2","instanceGroups":[{"templateId":52, "nodeCount":1, "group":"master"},{"templateId":52, "nodeCount":3, "group":"slave_1"}],"parameters":{"vpcId":"vpc-65f55e00","internetGatewayId":"igw-b8bd6bdd","subnetCIDR":"10.0.128.0/19"}}' http://localhost:9090/user/stacks | jq . 
```