### PR TITLE
CLOUD-269: Blueprint validation improvement

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/controller/StackController.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/StackController.java
@@ -21,10 +21,13 @@ import com.sequenceiq.cloudbreak.controller.json.AmbariAddressJson;
 import com.sequenceiq.cloudbreak.controller.json.IdJson;
 import com.sequenceiq.cloudbreak.controller.json.InstanceMetaDataJson;
 import com.sequenceiq.cloudbreak.controller.json.StackJson;
+import com.sequenceiq.cloudbreak.controller.json.StackValidationRequest;
 import com.sequenceiq.cloudbreak.controller.json.TemplateJson;
 import com.sequenceiq.cloudbreak.controller.json.UpdateStackJson;
+import com.sequenceiq.cloudbreak.domain.StackValidation;
 import com.sequenceiq.cloudbreak.converter.MetaDataConverter;
 import com.sequenceiq.cloudbreak.converter.StackConverter;
+import com.sequenceiq.cloudbreak.converter.StackValidationConverter;
 import com.sequenceiq.cloudbreak.converter.SubnetConverter;
 import com.sequenceiq.cloudbreak.domain.CbUser;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
@@ -46,6 +49,9 @@ public class StackController {
 
     @Autowired
     private MetaDataConverter metaDataConverter;
+
+    @Autowired
+    private StackValidationConverter stackValidationConverter;
 
     @RequestMapping(value = "user/stacks", method = RequestMethod.POST)
     @ResponseBody
@@ -155,6 +161,14 @@ public class StackController {
     public ResponseEntity<StackJson> getStackForAmbari(@RequestBody AmbariAddressJson json) {
         Stack stack = stackService.get(json.getAmbariAddress());
         return new ResponseEntity<>(stackConverter.convert(stack), HttpStatus.OK);
+    }
+
+    @RequestMapping(value = "stacks/validate", method = RequestMethod.POST)
+    @ResponseBody
+    public ResponseEntity<IdJson> validateStack(@RequestBody @Valid StackValidationRequest stackValidationRequest) {
+        StackValidation stackValidation = stackValidationConverter.convert(stackValidationRequest);
+        stackService.validateStack(stackValidation);
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 
     private ResponseEntity<IdJson> createStack(CbUser user, StackJson stackRequest, boolean publicInAccount) {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackValidationRequest.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackValidationRequest.java
@@ -1,0 +1,28 @@
+package com.sequenceiq.cloudbreak.controller.json;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.constraints.NotNull;
+
+public class StackValidationRequest implements JsonEntity {
+    private List<InstanceGroupJson> instanceGroups = new ArrayList<>();
+    @NotNull
+    private Long blueprintId;
+
+    public List<InstanceGroupJson> getInstanceGroups() {
+        return instanceGroups;
+    }
+
+    public void setInstanceGroups(List<InstanceGroupJson> instanceGroups) {
+        this.instanceGroups = instanceGroups;
+    }
+
+    public Long getBlueprintId() {
+        return blueprintId;
+    }
+
+    public void setBlueprintId(Long blueprintId) {
+        this.blueprintId = blueprintId;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintServiceComponent.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintServiceComponent.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.controller.validation.blueprint;
+
+import java.util.List;
+
+import com.google.common.collect.Lists;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+
+class BlueprintServiceComponent {
+    private String name;
+    private int nodeCount;
+    private List<String> hostgroups;
+
+    public BlueprintServiceComponent(String name, String hostgroup, int nodeCount) {
+        this.name = name;
+        this.nodeCount = nodeCount;
+        this.hostgroups = Lists.newArrayList(hostgroup);
+    }
+
+    public void update(InstanceGroup instanceGroup) {
+        nodeCount += instanceGroup.getNodeCount();
+        hostgroups.add(instanceGroup.getGroupName());
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public int getNodeCount() {
+        return nodeCount;
+    }
+
+    public List<String> getHostgroups() {
+        return hostgroups;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidator.java
@@ -1,0 +1,124 @@
+package com.sequenceiq.cloudbreak.controller.validation.blueprint;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+
+@Component
+public class BlueprintValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BlueprintValidator.class);
+
+    private ObjectMapper objectMapper = new ObjectMapper();
+
+    @Autowired
+    private StackServiceComponentDescriptors stackServiceComponentDescs;
+
+    public void validateBlueprintForStack(Blueprint blueprint, Set<InstanceGroup> instanceGroups) {
+        try {
+            JsonNode blueprintJsonTree = createJsonTree(blueprint);
+            Map<String, InstanceGroup> instanceGroupMap = createInstanceGroupMap(instanceGroups);
+            Map<String, BlueprintServiceComponent> blueprintServiceComponentMap = Maps.newHashMap();
+            JsonNode hostGroupsNode = blueprintJsonTree.get("host_groups");
+            int hostGroupCount = 0;
+            for (JsonNode hostGroupNode : hostGroupsNode) {
+                validateHostGroup(hostGroupNode, instanceGroupMap, blueprintServiceComponentMap);
+                hostGroupCount++;
+            }
+            validateHostGroupCount(hostGroupCount, instanceGroupMap.size());
+            validateBlueprintServiceComponents(blueprintServiceComponentMap);
+        } catch (IOException iox) {
+            LOGGER.error("Cannot parse blueprint json", iox);
+            throw new BadRequestException(String.format("Blueprint [%s] can not convert to json tree.", blueprint.getId()));
+        }
+    }
+
+    private JsonNode createJsonTree(Blueprint blueprint) throws IOException {
+        return objectMapper.readTree(blueprint.getBlueprintText());
+    }
+
+    private Map<String, InstanceGroup> createInstanceGroupMap(Set<InstanceGroup> instanceGroups) {
+        Map<String, InstanceGroup> groupMap = Maps.newHashMap();
+        for (InstanceGroup instanceGroup : instanceGroups) {
+            groupMap.put(instanceGroup.getGroupName(), instanceGroup);
+        }
+        return groupMap;
+    }
+
+    private void validateHostGroup(JsonNode hostGroupNode, Map<String, InstanceGroup> instanceGroupMap,
+            Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
+        String hostGroupName = hostGroupNode.get("name").asText();
+        validateHostGroupName(hostGroupName, instanceGroupMap.keySet());
+        InstanceGroup instanceGroup = instanceGroupMap.get(hostGroupName);
+        JsonNode componentsNode = hostGroupNode.get("components");
+        for (JsonNode componentNode : componentsNode) {
+            validateComponent(componentNode, instanceGroup, blueprintServiceComponentMap);
+        }
+    }
+
+    private void validateComponent(JsonNode componentNode, InstanceGroup instanceGroup, Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
+        String componentName = componentNode.get("name").asText();
+        StackServiceComponentDescriptor componentDescriptor = stackServiceComponentDescs.get(componentName);
+        if (componentDescriptor != null) {
+            validateComponentCardinality(componentDescriptor, instanceGroup);
+            updateBlueprintServiceComponentMap(componentDescriptor, instanceGroup, blueprintServiceComponentMap);
+        }
+    }
+
+    private void validateComponentCardinality(StackServiceComponentDescriptor componentDescriptor, InstanceGroup instanceGroup) {
+        int nodeCount = instanceGroup.getNodeCount();
+        int maxCardinality = componentDescriptor.getMaxCardinality();
+        if (componentDescriptor.isMaster() && nodeCount > maxCardinality) {
+            throw new BadRequestException(String.format("The nodecount '%d' for hostgroup '%s' cannot be more than '%d' because of '%s' component",
+                    nodeCount, instanceGroup.getGroupName(), maxCardinality, componentDescriptor.getName()));
+        }
+    }
+
+    private void validateHostGroupName(String groupName, Set<String> instanceGroupNames) {
+        if (!instanceGroupNames.contains(groupName)) {
+            throw new BadRequestException(String.format("The name of host group '%s' doesn't match any of the defined instance groups.", groupName));
+        }
+    }
+
+    private void validateHostGroupCount(int hostGroupCount, int instanceGroupCount) {
+        if (hostGroupCount != instanceGroupCount) {
+            throw new BadRequestException(String.format("The number of instancegroups and hostgroups must be equals."));
+        }
+    }
+
+    private void validateBlueprintServiceComponents(Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
+        for (BlueprintServiceComponent blueprintServiceComponent : blueprintServiceComponentMap.values()) {
+            String componentName = blueprintServiceComponent.getName();
+            int nodeCount = blueprintServiceComponent.getNodeCount();
+            StackServiceComponentDescriptor stackServiceComponentDescriptor = stackServiceComponentDescs.get(componentName);
+            int maxCardinality = stackServiceComponentDescriptor.getMaxCardinality();
+            if (stackServiceComponentDescriptor != null && nodeCount > maxCardinality) {
+                throw new BadRequestException(String.format("Too much '%s' components are in '%s' hostgroups: count: %d, max: %d",
+                        componentName, blueprintServiceComponent.getHostgroups().toString(), nodeCount, maxCardinality));
+            }
+        }
+    }
+
+    private void updateBlueprintServiceComponentMap(StackServiceComponentDescriptor componentDescriptor, InstanceGroup instanceGroup,
+            Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
+        String componentName = componentDescriptor.getName();
+        BlueprintServiceComponent blueprintServiceComponent = blueprintServiceComponentMap.get(componentName);
+        if (blueprintServiceComponent == null) {
+            blueprintServiceComponent = new BlueprintServiceComponent(componentName, instanceGroup.getGroupName(), instanceGroup.getNodeCount());
+            blueprintServiceComponentMap.put(componentName, blueprintServiceComponent);
+        } else {
+            blueprintServiceComponent.update(instanceGroup);
+        }
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/StackServiceComponentDescriptor.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/StackServiceComponentDescriptor.java
@@ -1,0 +1,31 @@
+package com.sequenceiq.cloudbreak.controller.validation.blueprint;
+
+public class StackServiceComponentDescriptor {
+    private static final String MASTER = "MASTER";
+
+    private String name;
+    private String category;
+    private int maxCardinality;
+
+    public StackServiceComponentDescriptor(String name, String category, int maxCardinality) {
+        this.name = name;
+        this.category = category;
+        this.maxCardinality = maxCardinality;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getCategory() {
+        return category;
+    }
+
+    public int getMaxCardinality() {
+        return maxCardinality;
+    }
+
+    public boolean isMaster() {
+        return MASTER.equals(category);
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/StackServiceComponentDescriptorMapFactory.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/StackServiceComponentDescriptorMapFactory.java
@@ -1,0 +1,60 @@
+package com.sequenceiq.cloudbreak.controller.validation.blueprint;
+
+import java.util.Map;
+
+import org.springframework.beans.factory.FactoryBean;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.api.client.util.Maps;
+
+public class StackServiceComponentDescriptorMapFactory implements FactoryBean<StackServiceComponentDescriptors> {
+    private String stackServiceComponentsJson;
+    private Map<String, Integer> maxCardinalityReps;
+    private ObjectMapper objectMapper;
+
+    public StackServiceComponentDescriptorMapFactory(String stackServiceComponentsJson, Map<String, Integer> maxCardinalityReps, ObjectMapper objectMapper) {
+        this.stackServiceComponentsJson = stackServiceComponentsJson;
+        this.maxCardinalityReps = maxCardinalityReps;
+        this.objectMapper = objectMapper;
+    }
+
+    @Override
+    public StackServiceComponentDescriptors getObject() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        Map<String, StackServiceComponentDescriptor> stackServiceComponentDescriptorMap = Maps.newHashMap();
+        JsonNode rootNode = objectMapper.readTree(stackServiceComponentsJson);
+        JsonNode itemsNode = rootNode.get("items");
+        for (JsonNode itemNode : itemsNode) {
+            JsonNode componentsNode = itemNode.get("components");
+            for (JsonNode componentNode : componentsNode) {
+                JsonNode stackServiceComponentsNode = componentNode.get("StackServiceComponents");
+                StackServiceComponentDescriptor componentDesc = createComponentDesc(stackServiceComponentsNode);
+                stackServiceComponentDescriptorMap.put(componentDesc.getName(), componentDesc);
+            }
+        }
+        return new StackServiceComponentDescriptors(stackServiceComponentDescriptorMap);
+    }
+
+    @Override
+    public Class<?> getObjectType() {
+        return Map.class;
+    }
+
+    @Override
+    public boolean isSingleton() {
+        return true;
+    }
+
+    private StackServiceComponentDescriptor createComponentDesc(JsonNode stackServiceComponentNode) {
+        String componentName = stackServiceComponentNode.get("component_name").asText();
+        String componentCategory = stackServiceComponentNode.get("component_category").asText();
+        int maxCardinality = parseMaxCardinality(stackServiceComponentNode.get("cardinality").asText());
+        return new StackServiceComponentDescriptor(componentName, componentCategory, maxCardinality);
+    }
+
+    private int parseMaxCardinality(String cardinalityString) {
+        Integer maxCardinality = maxCardinalityReps.get(cardinalityString);
+        return maxCardinality == null ? Integer.MAX_VALUE : maxCardinality;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/StackServiceComponentDescriptors.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/StackServiceComponentDescriptors.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.controller.validation.blueprint;
+
+import java.util.Map;
+
+public class StackServiceComponentDescriptors {
+    private Map<String, StackServiceComponentDescriptor> stackServiceComponentDescriptorMap;
+
+    public StackServiceComponentDescriptors(Map<String, StackServiceComponentDescriptor> stackServiceComponentDescriptorMap) {
+        this.stackServiceComponentDescriptorMap = stackServiceComponentDescriptorMap;
+    }
+
+    public StackServiceComponentDescriptor get(String name) {
+        return stackServiceComponentDescriptorMap.get(name);
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/converter/InstanceGroupConverter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/converter/InstanceGroupConverter.java
@@ -7,10 +7,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.json.InstanceGroupJson;
-import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.repository.TemplateRepository;
 
 @Component
@@ -37,9 +36,6 @@ public class InstanceGroupConverter extends AbstractConverter<InstanceGroupJson,
         InstanceGroup instanceGroup = new InstanceGroup();
         instanceGroup.setGroupName(json.getGroup());
         instanceGroup.setNodeCount(json.getNodeCount());
-        if (!json.getGroup().contains("slave") && json.getNodeCount() != 1) {
-            throw new BadRequestException("If you have a master hostgroup than the count of the nodes has to be 1 on master group.");
-        }
         try {
             instanceGroup.setTemplate(templateRepository.findOne(json.getTemplateId()));
         } catch (AccessDeniedException e) {

--- a/src/main/java/com/sequenceiq/cloudbreak/converter/StackValidationConverter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/converter/StackValidationConverter.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.controller.json.StackValidationRequest;
+import com.sequenceiq.cloudbreak.domain.StackValidation;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.repository.BlueprintRepository;
+
+@Component
+public class StackValidationConverter {
+    @Autowired
+    private InstanceGroupConverter instanceGroupConverter;
+
+    @Autowired
+    private BlueprintRepository blueprintRepository;
+
+    public StackValidation convert(StackValidationRequest stackValidationRequest) {
+        StackValidation stackValidation = new StackValidation();
+        stackValidation.setInstanceGroups(instanceGroupConverter.convertAllJsonToEntity(stackValidationRequest.getInstanceGroups()));
+        try {
+            Blueprint blueprint = blueprintRepository.findOne(stackValidationRequest.getBlueprintId());
+            stackValidation.setBlueprint(blueprint);
+        } catch (AccessDeniedException e) {
+            throw new AccessDeniedException(
+                    String.format("Access to blueprint '%s' is denied or blueprint doesn't exist.", stackValidationRequest.getBlueprintId()), e);
+        }
+        return stackValidation;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/StackValidation.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/StackValidation.java
@@ -1,0 +1,24 @@
+package com.sequenceiq.cloudbreak.domain;
+
+import java.util.Set;
+
+public class StackValidation implements ProvisionEntity {
+    private Set<InstanceGroup> instanceGroups;
+    private Blueprint blueprint;
+
+    public Set<InstanceGroup> getInstanceGroups() {
+        return instanceGroups;
+    }
+
+    public void setInstanceGroups(Set<InstanceGroup> instanceGroups) {
+        this.instanceGroups = instanceGroups;
+    }
+
+    public Blueprint getBlueprint() {
+        return blueprint;
+    }
+
+    public void setBlueprint(Blueprint blueprint) {
+        this.blueprint = blueprint;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackService.java
@@ -20,6 +20,8 @@ import com.sequenceiq.cloudbreak.conf.ReactorConfig;
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.NotFoundException;
 import com.sequenceiq.cloudbreak.controller.json.HostGroupAdjustmentJson;
+import com.sequenceiq.cloudbreak.controller.validation.blueprint.BlueprintValidator;
+import com.sequenceiq.cloudbreak.domain.StackValidation;
 import com.sequenceiq.cloudbreak.domain.APIResourceType;
 import com.sequenceiq.cloudbreak.domain.CbUser;
 import com.sequenceiq.cloudbreak.domain.CbUserRole;
@@ -73,6 +75,9 @@ public class DefaultStackService implements StackService {
 
     @Resource
     private Map<CloudPlatform, ProvisionSetup> provisionSetups;
+
+    @Autowired
+    private BlueprintValidator blueprintValidator;
 
     @Override
     public Set<Stack> retrievePrivateStacks(CbUser user) {
@@ -268,6 +273,11 @@ public class DefaultStackService implements StackService {
             }
         }
         throw new NotFoundException("Metadata not found on stack.");
+    }
+
+    @Override
+    public void validateStack(StackValidation stackValidation) {
+        blueprintValidator.validateBlueprintForStack(stackValidation.getBlueprint(), stackValidation.getInstanceGroups());
     }
 
     private void delete(Stack stack, CbUser user) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.controller.json.HostGroupAdjustmentJson;
+import com.sequenceiq.cloudbreak.domain.StackValidation;
 import com.sequenceiq.cloudbreak.domain.CbUser;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.Stack;
@@ -37,4 +38,6 @@ public interface StackService {
     void updateNodeCount(Long stackId, HostGroupAdjustmentJson hostGroupAdjustmentJson);
 
     void updateAllowedSubnets(Long stackId, List<Subnet> subnetList);
+
+    void validateStack(StackValidation stackValidation);
 }

--- a/src/main/resources/hdp/hdp-services.json
+++ b/src/main/resources/hdp/hdp-services.json
@@ -1,0 +1,811 @@
+{
+  "href" : "/api/v1/stacks/HDP/versions/2.2/services?fields=serviceComponents/StackServiceComponents",
+  "items" : [
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/FALCON",
+      "StackServices" : {
+        "service_name" : "FALCON",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/FALCON/components/FALCON_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "FALCON_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "Falcon Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "FALCON",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/FALCON/components/FALCON_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "FALCON_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "Falcon Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "FALCON",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/FLUME",
+      "StackServices" : {
+        "service_name" : "FLUME",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/FLUME/components/FLUME_HANDLER",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "SLAVE",
+            "component_name" : "FLUME_HANDLER",
+            "custom_commands" : [ ],
+            "display_name" : "Flume",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "FLUME",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/GANGLIA",
+      "StackServices" : {
+        "service_name" : "GANGLIA",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/GANGLIA/components/GANGLIA_MONITOR",
+          "StackServiceComponents" : {
+            "cardinality" : "ALL",
+            "component_category" : "SLAVE",
+            "component_name" : "GANGLIA_MONITOR",
+            "custom_commands" : [ ],
+            "display_name" : "Ganglia Monitor",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "GANGLIA",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/GANGLIA/components/GANGLIA_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "GANGLIA_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "Ganglia Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "GANGLIA",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/HBASE",
+      "StackServices" : {
+        "service_name" : "HBASE",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HBASE/components/HBASE_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "HBASE_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "HBase Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "HBASE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HBASE/components/HBASE_MASTER",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "MASTER",
+            "component_name" : "HBASE_MASTER",
+            "custom_commands" : [
+              "DECOMMISSION"
+            ],
+            "display_name" : "HBase Master",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HBASE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HBASE/components/HBASE_REGIONSERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "SLAVE",
+            "component_name" : "HBASE_REGIONSERVER",
+            "custom_commands" : [ ],
+            "display_name" : "RegionServer",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "HBASE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS",
+      "StackServices" : {
+        "service_name" : "HDFS",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS/components/DATANODE",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "SLAVE",
+            "component_name" : "DATANODE",
+            "custom_commands" : [ ],
+            "display_name" : "DataNode",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "HDFS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS/components/HDFS_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "HDFS_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "HDFS Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "HDFS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS/components/JOURNALNODE",
+          "StackServiceComponents" : {
+            "cardinality" : "0+",
+            "component_category" : "SLAVE",
+            "component_name" : "JOURNALNODE",
+            "custom_commands" : [ ],
+            "display_name" : "JournalNode",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "HDFS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS/components/NAMENODE",
+          "StackServiceComponents" : {
+            "cardinality" : "1-2",
+            "component_category" : "MASTER",
+            "component_name" : "NAMENODE",
+            "custom_commands" : [
+              "DECOMMISSION",
+              "REBALANCEHDFS"
+            ],
+            "display_name" : "NameNode",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HDFS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS/components/SECONDARY_NAMENODE",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "SECONDARY_NAMENODE",
+            "custom_commands" : [ ],
+            "display_name" : "SNameNode",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HDFS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HDFS/components/ZKFC",
+          "StackServiceComponents" : {
+            "cardinality" : "0+",
+            "component_category" : "SLAVE",
+            "component_name" : "ZKFC",
+            "custom_commands" : [ ],
+            "display_name" : "ZKFailoverController",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "HDFS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE",
+      "StackServices" : {
+        "service_name" : "HIVE",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE/components/HCAT",
+          "StackServiceComponents" : {
+            "cardinality" : null,
+            "component_category" : "CLIENT",
+            "component_name" : "HCAT",
+            "custom_commands" : [ ],
+            "display_name" : "HCat Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "HIVE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE/components/HIVE_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "HIVE_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "Hive Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "HIVE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE/components/HIVE_METASTORE",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "HIVE_METASTORE",
+            "custom_commands" : [ ],
+            "display_name" : "Hive Metastore",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HIVE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE/components/HIVE_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "HIVE_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "HiveServer2",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HIVE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE/components/MYSQL_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "0-1",
+            "component_category" : "MASTER",
+            "component_name" : "MYSQL_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "MySQL Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HIVE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/HIVE/components/WEBHCAT_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "WEBHCAT_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "WebHCat Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "HIVE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/KAFKA",
+      "StackServices" : {
+        "service_name" : "KAFKA",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/KAFKA/components/KAFKA_BROKER",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "MASTER",
+            "component_name" : "KAFKA_BROKER",
+            "custom_commands" : [ ],
+            "display_name" : "Kafka Broker",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "KAFKA",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/KNOX",
+      "StackServices" : {
+        "service_name" : "KNOX",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/KNOX/components/KNOX_GATEWAY",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "MASTER",
+            "component_name" : "KNOX_GATEWAY",
+            "custom_commands" : [
+              "STARTDEMOLDAP",
+              "STOPDEMOLDAP"
+            ],
+            "display_name" : "Knox Gateway",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "KNOX",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/MAPREDUCE2",
+      "StackServices" : {
+        "service_name" : "MAPREDUCE2",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/MAPREDUCE2/components/HISTORYSERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "HISTORYSERVER",
+            "custom_commands" : [ ],
+            "display_name" : "History Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "MAPREDUCE2",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/MAPREDUCE2/components/MAPREDUCE2_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "0+",
+            "component_category" : "CLIENT",
+            "component_name" : "MAPREDUCE2_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "MapReduce2 Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "MAPREDUCE2",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/NAGIOS",
+      "StackServices" : {
+        "service_name" : "NAGIOS",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/NAGIOS/components/NAGIOS_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "NAGIOS_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "Nagios Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "NAGIOS",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/OOZIE",
+      "StackServices" : {
+        "service_name" : "OOZIE",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/OOZIE/components/OOZIE_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "OOZIE_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "Oozie Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "OOZIE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/OOZIE/components/OOZIE_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "OOZIE_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "Oozie Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "OOZIE",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/PIG",
+      "StackServices" : {
+        "service_name" : "PIG",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/PIG/components/PIG",
+          "StackServiceComponents" : {
+            "cardinality" : "0+",
+            "component_category" : "CLIENT",
+            "component_name" : "PIG",
+            "custom_commands" : [ ],
+            "display_name" : "Pig",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "PIG",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/SLIDER",
+      "StackServices" : {
+        "service_name" : "SLIDER",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/SLIDER/components/SLIDER",
+          "StackServiceComponents" : {
+            "cardinality" : "0+",
+            "component_category" : "CLIENT",
+            "component_name" : "SLIDER",
+            "custom_commands" : [ ],
+            "display_name" : "Slider",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "SLIDER",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/SQOOP",
+      "StackServices" : {
+        "service_name" : "SQOOP",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/SQOOP/components/SQOOP",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "SQOOP",
+            "custom_commands" : [ ],
+            "display_name" : "Sqoop",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "SQOOP",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/STORM",
+      "StackServices" : {
+        "service_name" : "STORM",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/STORM/components/DRPC_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "DRPC_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "DRPC Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "STORM",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/STORM/components/NIMBUS",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "NIMBUS",
+            "custom_commands" : [ ],
+            "display_name" : "Nimbus",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "STORM",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/STORM/components/STORM_UI_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "STORM_UI_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "Storm UI Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "STORM",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/STORM/components/SUPERVISOR",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "SLAVE",
+            "component_name" : "SUPERVISOR",
+            "custom_commands" : [ ],
+            "display_name" : "Supervisor",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "STORM",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/TEZ",
+      "StackServices" : {
+        "service_name" : "TEZ",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/TEZ/components/TEZ_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "TEZ_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "Tez Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "TEZ",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/YARN",
+      "StackServices" : {
+        "service_name" : "YARN",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/YARN/components/APP_TIMELINE_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1",
+            "component_category" : "MASTER",
+            "component_name" : "APP_TIMELINE_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "App Timeline Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "YARN",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/YARN/components/NODEMANAGER",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "SLAVE",
+            "component_name" : "NODEMANAGER",
+            "custom_commands" : [ ],
+            "display_name" : "NodeManager",
+            "is_client" : false,
+            "is_master" : false,
+            "service_name" : "YARN",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/YARN/components/RESOURCEMANAGER",
+          "StackServiceComponents" : {
+            "cardinality" : "1-2",
+            "component_category" : "MASTER",
+            "component_name" : "RESOURCEMANAGER",
+            "custom_commands" : [
+              "DECOMMISSION",
+              "REFRESHQUEUES"
+            ],
+            "display_name" : "ResourceManager",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "YARN",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/YARN/components/YARN_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "YARN_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "YARN Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "YARN",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    },
+    {
+      "href" : "/api/v1/stacks/HDP/versions/2.2/services/ZOOKEEPER",
+      "StackServices" : {
+        "service_name" : "ZOOKEEPER",
+        "stack_name" : "HDP",
+        "stack_version" : "2.2"
+      },
+      "components" : [
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/ZOOKEEPER/components/ZOOKEEPER_CLIENT",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "CLIENT",
+            "component_name" : "ZOOKEEPER_CLIENT",
+            "custom_commands" : [ ],
+            "display_name" : "ZooKeeper Client",
+            "is_client" : true,
+            "is_master" : false,
+            "service_name" : "ZOOKEEPER",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        },
+        {
+          "href" : "/api/v1/stacks/HDP/versions/2.2/services/ZOOKEEPER/components/ZOOKEEPER_SERVER",
+          "StackServiceComponents" : {
+            "cardinality" : "1+",
+            "component_category" : "MASTER",
+            "component_name" : "ZOOKEEPER_SERVER",
+            "custom_commands" : [ ],
+            "display_name" : "ZooKeeper Server",
+            "is_client" : false,
+            "is_master" : true,
+            "service_name" : "ZOOKEEPER",
+            "stack_name" : "HDP",
+            "stack_version" : "2.2"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/src/test/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidatorTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidatorTest.java
@@ -1,0 +1,249 @@
+package com.sequenceiq.cloudbreak.controller.validation.blueprint;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BlueprintValidatorTest {
+    private static final String BLUEPRINT_STRING = "blueprint";
+    private static final String GROUP1 = "group1";
+    private static final String GROUP2 = "group2";
+    private static final String GROUP3 = "group3";
+    private static final String COMPONENT1 = "comp1";
+    private static final String COMPONENT2 = "comp2";
+    private static final String COMPONENT3 = "comp3";
+    private static final String SLAVE_COMPONENT = "slavecomp";
+    private static final String UNKNOWN = "unknown";
+
+    @Mock
+    private StackServiceComponentDescriptors stackServiceComponentDescriptors;
+    @Mock
+    private ObjectMapper objectMapper;
+    @InjectMocks
+    private BlueprintValidator underTest;
+
+    @Before
+    public void setUp() {
+        setupStackServiceComponentDescriptors();
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testValidateBlueprintForStackShouldThrowBadRequestExceptionWhenJsonTreeCreationIsFailed() throws Exception {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        BDDMockito.given(objectMapper.readTree(BDDMockito.anyString())).willThrow(new IOException());
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN throw exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testValidateBlueprintForStackShouldThrowBadRequestExceptionWhenNoInstanceGroupForAHostGroup() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTreeWithUnknownHostGroup();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN throw exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testValidateBlueprintForStackShouldThrowBadRequestExceptionWhenNodeCountForAHostGroupIsMoreThanMax() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTreeWithIllegalGroup();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN throw exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testValidateBlueprintForStackShouldThrowBadRequestExceptionWhenGroupCountsAreDifferent() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTreeWithTooMuchGroup();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN throw exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testValidateBlueprintForStackShouldThrowBadRequestExceptionWhenNotEnoughGroupDefinedInBlueprint() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTreeWithNotEnoughGroup();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN throw exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testValidateBlueprintForStackShouldThrowBadRequestExceptionWhenComponentIsInMoreGroupsAndNodeCountIsMoreThanMax() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTreeWithComponentInMoreGroups();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN throw exception
+    }
+
+    @Test
+    public void testValidateBlueprintForStackShouldNotThrowAnyExceptionWhenBlueprintIsValid() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTree();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN doesn't throw exception
+    }
+
+    @Test
+    public void testValidateBlueprintForStackShouldNotThrowAnyExceptionWhenBlueprintContainsUnknownComponent() throws IOException {
+        // GIVEN
+        Blueprint blueprint = createBlueprint();
+        Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        JsonNode blueprintJsonTree = createJsonTreeWithUnknownComponent();
+        BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
+        // WHEN
+        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        // THEN doesn't throw exception
+    }
+
+    private void setupStackServiceComponentDescriptors() {
+        BDDMockito.given(stackServiceComponentDescriptors.get(COMPONENT1)).willReturn(new StackServiceComponentDescriptor(COMPONENT1, "MASTER", 5));
+        BDDMockito.given(stackServiceComponentDescriptors.get(COMPONENT2)).willReturn(new StackServiceComponentDescriptor(COMPONENT2, "MASTER", 1));
+        BDDMockito.given(stackServiceComponentDescriptors.get(COMPONENT3)).willReturn(new StackServiceComponentDescriptor(COMPONENT3, "MASTER", 3));
+        BDDMockito.given(stackServiceComponentDescriptors.get(SLAVE_COMPONENT)).willReturn(new StackServiceComponentDescriptor(SLAVE_COMPONENT, "SLAVE", 3));
+    }
+
+    private Blueprint createBlueprint() {
+        Blueprint blueprint = new Blueprint();
+        blueprint.setBlueprintText(BLUEPRINT_STRING);
+        return blueprint;
+    }
+
+    private Set<InstanceGroup> createInstanceGroups() {
+        Set<InstanceGroup> groups = Sets.newHashSet();
+        groups.add(createInstanceGroup(GROUP1, 1));
+        groups.add(createInstanceGroup(GROUP2, 2));
+        groups.add(createInstanceGroup(GROUP3, 3));
+        return groups;
+    }
+
+    private InstanceGroup createInstanceGroup(String groupName, int nodeCount) {
+        InstanceGroup group = new InstanceGroup();
+        group.setGroupName(groupName);
+        group.setNodeCount(nodeCount);
+        return group;
+    }
+
+    private JsonNode createJsonTreeWithUnknownHostGroup() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, SLAVE_COMPONENT);
+        addHostGroup(hostGroupsNode, UNKNOWN);
+        return rootNode;
+    }
+
+    private JsonNode createJsonTreeWithIllegalGroup() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, SLAVE_COMPONENT);
+        addHostGroup(hostGroupsNode, GROUP2, COMPONENT1, COMPONENT2);
+        addHostGroup(hostGroupsNode, GROUP3, COMPONENT3);
+        return rootNode;
+    }
+
+    private JsonNode createJsonTreeWithTooMuchGroup() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, COMPONENT2);
+        addHostGroup(hostGroupsNode, GROUP2, COMPONENT1);
+        addHostGroup(hostGroupsNode, GROUP3, COMPONENT3);
+        addHostGroup(hostGroupsNode, GROUP3, SLAVE_COMPONENT);
+        return rootNode;
+    }
+
+    private JsonNode createJsonTreeWithNotEnoughGroup() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, COMPONENT2);
+        addHostGroup(hostGroupsNode, GROUP2, COMPONENT1);
+        return rootNode;
+    }
+
+    private JsonNode createJsonTreeWithUnknownComponent() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, COMPONENT2);
+        addHostGroup(hostGroupsNode, GROUP2, COMPONENT1);
+        addHostGroup(hostGroupsNode, GROUP3, UNKNOWN);
+        return rootNode;
+    }
+
+    private JsonNode createJsonTreeWithComponentInMoreGroups() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, COMPONENT2, COMPONENT3);
+        addHostGroup(hostGroupsNode, GROUP2, COMPONENT1);
+        addHostGroup(hostGroupsNode, GROUP3, COMPONENT3);
+        return rootNode;
+    }
+
+    private JsonNode createJsonTree() {
+        JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+        ObjectNode rootNode = jsonNodeFactory.objectNode();
+        ArrayNode hostGroupsNode = rootNode.putArray("host_groups");
+        addHostGroup(hostGroupsNode, GROUP1, SLAVE_COMPONENT, COMPONENT2);
+        addHostGroup(hostGroupsNode, GROUP2, COMPONENT1);
+        addHostGroup(hostGroupsNode, GROUP3, COMPONENT3);
+        return rootNode;
+    }
+
+    private void addHostGroup(ArrayNode hostGroupsNode, String name, String... components) {
+        ObjectNode hostGroupNode = hostGroupsNode.addObject();
+        hostGroupNode.put("name", name);
+        ArrayNode componentsNode = hostGroupNode.putArray("components");
+        for (String comp : components) {
+            ObjectNode compNode = componentsNode.addObject();
+            compNode.put("name", comp);
+        }
+    }
+}

--- a/src/test/java/com/sequenceiq/cloudbreak/converter/BlueprintConverterTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/converter/BlueprintConverterTest.java
@@ -26,6 +26,22 @@ public class BlueprintConverterTest {
     public static final String DUMMY_DESCRIPTION = "dummyDescription";
 
     public static final String DUMMY_BLUEPRINT_TEXT =
+            "{\"Blueprints\":{\"blueprint_name\":\"asd\"},\"host_groups\":[{\"name\":\"asd\", \"components\":[{\"name\":\"comp\"}]},"
+                    + "{\"name\":\"slave_a\", \"components\":[{\"name\":\"comp\"}]}]}";
+
+    public static final String DUMMY_BLUEPRINT_TEXT_WITH_EMPTY_COMPONENT_ARRAY =
+            "{\"Blueprints\":{\"blueprint_name\":\"asd\"},\"host_groups\":[{\"name\":\"asd\", \"components\":[]},"
+                    + "{\"name\":\"slave_a\", \"components\":[{\"name\":\"comp\"}]}]}";
+
+    public static final String DUMMY_BLUEPRINT_TEXT_WO_COMPONENT_ARRAY =
+            "{\"Blueprints\":{\"blueprint_name\":\"asd\"},\"host_groups\":[{\"name\":\"asd\", \"components\":[{\"name\":\"comp\"}]},"
+                    + "{\"name\":\"slave_a\", \"components\":{\"name\":\"comp\"}}]}";
+
+    public static final String DUMMY_BLUEPRINT_TEXT_WO_COMPONENT_NAME =
+            "{\"Blueprints\":{\"blueprint_name\":\"asd\"},\"host_groups\":[{\"name\":\"asd\", \"components\":[{\"name\":\"comp\"}]},"
+                    + "{\"name\":\"slave_a\", \"components\":[{\"names\":\"comp\"}]}]}";
+
+    public static final String DUMMY_BLUEPRINT_TEXT_WO_COMPONENTS =
             "{\"Blueprints\":{\"blueprint_name\":\"asd\"},\"host_groups\":[{\"name\":\"asd\"},{\"name\":\"slave_a\"}]}";
 
     public static final String DUMMY_BLUEPRINT_TEXT_WO_BLUEPRINTS =
@@ -192,7 +208,7 @@ public class BlueprintConverterTest {
         assertEquals(result.getBlueprintText(), blueprintJson.getAmbariBlueprint());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test(expected = BadRequestException.class)
     public void testConvertBlueprintJsonToEntityShouldThrowBadRequestWhenHostGroupDoNotHaveName() {
         // GIVEN
         given(jsonNode.toString()).willReturn(DUMMY_BLUEPRINT_TEXT_HOSTGROUPS_DONT_HAVE_NAME);
@@ -202,6 +218,50 @@ public class BlueprintConverterTest {
         Blueprint result = underTest.convert(blueprintJson);
         // THEN
         assertEquals(result.getBlueprintText(), blueprintJson.getAmbariBlueprint());
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testConvertBlueprintJsonToEntityShouldThrowBadRequestWhenHostGroupDoNotHaveComponents() {
+        // GIVEN
+        given(jsonNode.toString()).willReturn(DUMMY_BLUEPRINT_TEXT_WO_COMPONENTS);
+        blueprintJson.setAmbariBlueprint(jsonNode);
+        blueprintJson.setUrl(null);
+        // WHEN
+        Blueprint result = underTest.convert(blueprintJson);
+        // THEN throws Exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testConvertBlueprintJsonToEntityShouldThrowBadRequestWhenHostGroupContainsComponentWithoutName() {
+        // GIVEN
+        given(jsonNode.toString()).willReturn(DUMMY_BLUEPRINT_TEXT_WO_COMPONENT_NAME);
+        blueprintJson.setAmbariBlueprint(jsonNode);
+        blueprintJson.setUrl(null);
+        // WHEN
+        Blueprint result = underTest.convert(blueprintJson);
+        // THEN throws Exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testConvertBlueprintJsonToEntityShouldThrowBadRequestWhenHostGroupHasNoComponentArray() {
+        // GIVEN
+        given(jsonNode.toString()).willReturn(DUMMY_BLUEPRINT_TEXT_WO_COMPONENT_ARRAY);
+        blueprintJson.setAmbariBlueprint(jsonNode);
+        blueprintJson.setUrl(null);
+        // WHEN
+        Blueprint result = underTest.convert(blueprintJson);
+        // THEN throws Exception
+    }
+
+    @Test(expected = BadRequestException.class)
+    public void testConvertBlueprintJsonToEntityShouldThrowBadRequestWhenHostGroupHasEmptyComponentArray() {
+        // GIVEN
+        given(jsonNode.toString()).willReturn(DUMMY_BLUEPRINT_TEXT_WITH_EMPTY_COMPONENT_ARRAY);
+        blueprintJson.setAmbariBlueprint(jsonNode);
+        blueprintJson.setUrl(null);
+        // WHEN
+        Blueprint result = underTest.convert(blueprintJson);
+        // THEN throws Exception
     }
 
     private BlueprintJson createBlueprintJson() {


### PR DESCRIPTION
@keyki pls review

**Notes**

* validate hostgroup and instancegroup name matching
* validate hostgroup and instancegroup count matching
* validate hostgroup cardinality based on it’s master components’ max cardinality
* validate master components’ max cardinality in more than one host groups 
* if validation fails cluster creation request will throw BadRequestException
* introducing new stack validation request: stacks/validate

**Tested with**
* hdp-multinode-default
* lambda-architecture: starts only if master and slave_1 node count was 1, slave_1 with more than one nodes start will fail because of snamenode. with new validation slave_1 nodecount can be only 1 because it contains master components with 1 cardinality: example snamenode, storm_ui_server
* multi-node-hdfs-yarn
* multi-node-hdfs-yarn with multi resourcemanager and namenode throws bad request ex
* multi-node with single rm and nn but with more zookeeper server can be requested and started successfully

**Outstanding questions:**
* What else should be validated in blueprints?
* Should we validate from cli as well? When and how?
* cloudbreak rest client should be updated?
