### PR TITLE
CLOUD-470 use ip address instead of dns name when restarting instances

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
@@ -400,14 +400,14 @@ public class AwsConnector implements CloudPlatformConnector {
             for (Instance instance : reservation.getInstances()) {
                 for (InstanceMetaData metaData : instanceMetaData) {
                     if (metaData.getInstanceId().equals(instance.getInstanceId())) {
-                        String publicDnsName = instance.getPublicDnsName();
+                        String publicIp = instance.getPublicIpAddress();
                         if (metaData.getAmbariServer()) {
-                            stack.setAmbariIp(publicDnsName);
+                            stack.setAmbariIp(publicIp);
                             Cluster cluster = clusterRepository.findOneWithLists(stack.getCluster().getId());
                             stack.setCluster(cluster);
                             stackRepository.save(stack);
                         }
-                        metaData.setPublicIp(publicDnsName);
+                        metaData.setPublicIp(publicIp);
                         instanceMetaDataRepository.save(metaData);
                         break;
                     }


### PR DESCRIPTION
@biharitomi 
Public DNS names must be enabled on the VPC on AWS that is not possible when deploying to an existing one, but we can use the ip addresses as well (and we do use them when creating a stack). This PR fixes that we are using them when restarting a cluster as well.