### PR TITLE
CLOUD-491 scaling on Openstack

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/HeatTemplateBuilder.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/HeatTemplateBuilder.java
@@ -1,22 +1,22 @@
 package com.sequenceiq.cloudbreak.service.stack.connector.openstack;
 
-import static java.util.Collections.singletonMap;
 import static org.springframework.ui.freemarker.FreeMarkerTemplateUtils.processTemplateIntoString;
 
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
-import com.google.common.collect.Ordering;
-import com.google.common.primitives.Ints;
 import com.sequenceiq.cloudbreak.controller.InternalServerException;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.OpenStackTemplate;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.service.network.NetworkConfig;
@@ -29,6 +29,8 @@ import freemarker.template.TemplateException;
 public class HeatTemplateBuilder {
 
     public static final String CB_INSTANCE_GROUP_NAME = "cb_instance_group_name";
+    public static final String CB_INSTANCE_PRIVATE_ID = "cb_instance_private_id";
+    private static final int PRIVATE_ID_PART = 2;
     private static final String MOUNT_PREFIX = "/mnt/fs";
     private static final String DEVICE_PREFIX = "/dev/vd";
     private static final char[] DEVICE_CHAR = {'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'};
@@ -36,10 +38,35 @@ public class HeatTemplateBuilder {
     @Autowired
     private Configuration freemarkerConfiguration;
 
-    public String build(Stack stack, String templatePath, List<InstanceGroup> instanceGroups, String userData) {
+    public String build(Stack stack, String templatePath, String userData) {
+        List<OpenStackInstance> agents = generateAgents(stack.getInstanceGroups());
+        return build(stack, templatePath, agents, userData);
+    }
+
+    public String update(Stack stack, String templatePath, String userData, Set<InstanceMetaData> instanceMetadata) {
+        List<OpenStackInstance> agents = regenerateAgents(instanceMetadata);
+        return build(stack, templatePath, agents, userData);
+    }
+
+    public String remove(Stack stack, String templatePath, String userData, Set<InstanceMetaData> instanceMetadata,
+            Set<String> removeInstances, String hostGroup) {
+        Set<Integer> privateIds = new HashSet<>();
+        for (String instanceId : removeInstances) {
+            privateIds.add(getPrivateId(instanceId));
+        }
+        List<OpenStackInstance> agents = generateAgentsWithFilter(instanceMetadata, privateIds, hostGroup);
+        return build(stack, templatePath, agents, userData);
+    }
+
+    public String add(Stack stack, String templatePath, String userData, Set<InstanceMetaData> instanceMetadata, String hostGroup, int adjustment) {
+        List<OpenStackInstance> agents = generateNewAgents(instanceMetadata, hostGroup, adjustment);
+        return build(stack, templatePath, agents, userData);
+    }
+
+    private String build(Stack stack, String templatePath, List<OpenStackInstance> agents, String userData) {
         try {
             Map<String, Object> model = new HashMap<>();
-            model.put("agents", buildInstances(getOrderedCopy(instanceGroups)));
+            model.put("agents", agents);
             model.put("userdata", formatUserData(userData));
             model.put("subnets", stack.getAllowedSubnets());
             model.put("ports", NetworkUtils.getPorts(stack));
@@ -53,16 +80,87 @@ public class HeatTemplateBuilder {
         }
     }
 
-    private List<OpenStackInstance> buildInstances(List<InstanceGroup> instanceGroups) {
+    private List<OpenStackInstance> generateAgents(Set<InstanceGroup> instanceGroups) {
         List<OpenStackInstance> agents = new ArrayList<>();
         for (InstanceGroup group : instanceGroups) {
+            String groupName = group.getGroupName();
             OpenStackTemplate template = (OpenStackTemplate) group.getTemplate();
+            int privateId = 0;
             for (int i = 0; i < group.getNodeCount(); i++) {
                 List<OpenStackVolume> volumes = buildVolumes(template.getVolumeCount(), template.getVolumeSize());
-                agents.add(new OpenStackInstance(template.getInstanceType(), volumes, singletonMap(CB_INSTANCE_GROUP_NAME, group.getGroupName())));
+                Map<String, String> metadata = generateMetadata(groupName, privateId);
+                OpenStackInstance instance = new OpenStackInstance(template.getInstanceType(), volumes, metadata);
+                agents.add(instance);
+                ++privateId;
             }
         }
         return agents;
+    }
+
+    private List<OpenStackInstance> regenerateAgents(Set<InstanceMetaData> instanceMetadata) {
+        return generateAgentsWithFilter(instanceMetadata, new HashSet<Integer>(), null);
+    }
+
+    private List<OpenStackInstance> generateAgentsWithFilter(Set<InstanceMetaData> instanceMetadata, Set<Integer> idFilter, String groupFilter) {
+        List<OpenStackInstance> agents = new ArrayList<>();
+        for (InstanceMetaData data : instanceMetadata) {
+            InstanceGroup group = data.getInstanceGroup();
+            String groupName = group.getGroupName();
+            int privateId = getPrivateId(data.getInstanceId());
+            if (groupName.equals(groupFilter) && idFilter.contains(privateId)) {
+                continue;
+            }
+            OpenStackTemplate template = (OpenStackTemplate) group.getTemplate();
+            List<OpenStackVolume> volumes = buildVolumes(template.getVolumeCount(), template.getVolumeSize());
+            Map<String, String> metadata = generateMetadata(groupName, privateId);
+            OpenStackInstance agent = new OpenStackInstance(template.getInstanceType(), volumes, metadata);
+            agents.add(agent);
+        }
+        return agents;
+    }
+
+    private List<OpenStackInstance> generateNewAgents(Set<InstanceMetaData> instanceMetadata, String hostGroup, int adjustment) {
+        List<OpenStackInstance> agents = regenerateAgents(instanceMetadata);
+        Set<Integer> existingIds = new HashSet<>();
+        for (OpenStackInstance agent : agents) {
+            Map<String, String> metadata = agent.getMetadataAsMap();
+            if (hostGroup.equals(metadata.get(CB_INSTANCE_GROUP_NAME))) {
+                existingIds.add(Integer.valueOf(metadata.get(CB_INSTANCE_PRIVATE_ID)));
+            }
+        }
+        OpenStackTemplate template = getTemplate(instanceMetadata, hostGroup);
+        while (adjustment > 0) {
+            int privateId = 0;
+            while (existingIds.contains(privateId)) {
+                privateId++;
+            }
+            List<OpenStackVolume> volumes = buildVolumes(template.getVolumeCount(), template.getVolumeSize());
+            Map<String, String> metadata = generateMetadata(hostGroup, privateId);
+            OpenStackInstance instance = new OpenStackInstance(template.getInstanceType(), volumes, metadata);
+            agents.add(instance);
+            adjustment--;
+        }
+        return agents;
+    }
+
+    private Map<String, String> generateMetadata(String groupName, int privateId) {
+        Map<String, String> metadata = new HashMap<>();
+        metadata.put(CB_INSTANCE_GROUP_NAME, groupName);
+        metadata.put(CB_INSTANCE_PRIVATE_ID, "" + privateId);
+        return metadata;
+    }
+
+    private int getPrivateId(String instanceId) {
+        return Integer.valueOf(instanceId.split("_")[PRIVATE_ID_PART]);
+    }
+
+    private OpenStackTemplate getTemplate(Set<InstanceMetaData> instanceMetaData, String hostGroup) {
+        for (InstanceMetaData metaData : instanceMetaData) {
+            if (metaData.getInstanceGroup().getGroupName().equals(hostGroup)) {
+                return (OpenStackTemplate) metaData.getInstanceGroup().getTemplate();
+            }
+        }
+        return null;
     }
 
     private List<OpenStackVolume> buildVolumes(int numDisk, int size) {
@@ -81,16 +179,6 @@ public class HeatTemplateBuilder {
             sb.append("            " + lines[i] + "\n");
         }
         return sb.toString();
-    }
-
-    private List<InstanceGroup> getOrderedCopy(List<InstanceGroup> instanceGroupList) {
-        Ordering<InstanceGroup> byLengthOrdering = new Ordering<InstanceGroup>() {
-            public int compare(InstanceGroup left, InstanceGroup right) {
-                int countCompare = Ints.compare(left.getNodeCount(), right.getNodeCount());
-                return countCompare == 0 ? left.getGroupName().compareTo(right.getGroupName()) : countCompare;
-            }
-        };
-        return byLengthOrdering.sortedCopy(instanceGroupList);
     }
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/OpenStackInstance.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/OpenStackInstance.java
@@ -26,6 +26,10 @@ public final class OpenStackInstance {
         return volumes;
     }
 
+    public Map<String, String> getMetadataAsMap() {
+        return metadata;
+    }
+
     public String getMetadata() {
         try {
             return new ObjectMapper().writeValueAsString(metadata);

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/OpenStackMetadataSetup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/OpenStackMetadataSetup.java
@@ -12,14 +12,19 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
 import com.sequenceiq.cloudbreak.conf.ReactorConfig;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.ResourceType;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.stack.connector.MetadataSetup;
 import com.sequenceiq.cloudbreak.service.stack.event.MetadataSetupComplete;
+import com.sequenceiq.cloudbreak.service.stack.event.MetadataUpdateComplete;
 import com.sequenceiq.cloudbreak.service.stack.flow.CoreInstanceMetaData;
 
 import reactor.core.Reactor;
@@ -46,16 +51,11 @@ public class OpenStackMetadataSetup implements MetadataSetup {
         org.openstack4j.model.heat.Stack heatStack = osClient.heat().stacks().getDetails(stack.getName(), heatStackId);
         List<Map<String, Object>> outputs = heatStack.getOutputs();
         for (Map<String, Object> map : outputs) {
-            String instanceId = (String) map.get("output_value");
-            Server server = osClient.compute().servers().get(instanceId);
-            instancesCoreMetadata.add(new CoreInstanceMetaData(
-                    instanceId,
-                    server.getAddresses().getAddresses("app_network").get(0).getAddr(),
-                    server.getAddresses().getAddresses("app_network").get(1).getAddr(),
-                    server.getOsExtendedVolumesAttached().size(),
-                    server.getName(),
-                    stack.getInstanceGroupByInstanceGroupName(server.getMetadata().get(HeatTemplateBuilder.CB_INSTANCE_GROUP_NAME))
-            ));
+            String instanceUUID = (String) map.get("output_value");
+            Server server = osClient.compute().servers().get(instanceUUID);
+            Map<String, String> metadata = server.getMetadata();
+            String instanceGroupName = metadata.get(HeatTemplateBuilder.CB_INSTANCE_GROUP_NAME);
+            instancesCoreMetadata.add(createCoreMetaData(stack, server, instanceGroupName, openStackUtil.getInstanceId(instanceUUID, metadata)));
         }
         LOGGER.info("Publishing {} event [StackId: '{}']", ReactorConfig.METADATA_SETUP_COMPLETE_EVENT, stack.getId());
         reactor.notify(ReactorConfig.METADATA_SETUP_COMPLETE_EVENT,
@@ -63,11 +63,53 @@ public class OpenStackMetadataSetup implements MetadataSetup {
     }
 
     @Override
-    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String hostGroup) {
+    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, final String hostGroup) {
+        MDCBuilder.buildMdcContext(stack);
+        OSClient osClient = openStackUtil.createOSClient(stack);
+        Resource heatResource = stack.getResourceByType(ResourceType.HEAT_STACK);
+        String heatStackId = heatResource.getResourceName();
+        org.openstack4j.model.heat.Stack heatStack = osClient.heat().stacks().getDetails(stack.getName(), heatStackId);
+        List<Map<String, Object>> outputs = heatStack.getOutputs();
+        Set<CoreInstanceMetaData> instancesCoreMetadata = new HashSet<>();
+        for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
+            if (instanceGroup.getGroupName().equals(hostGroup)) {
+                for (Map<String, Object> map : outputs) {
+                    String instanceUUID = (String) map.get("output_value");
+                    Server server = osClient.compute().servers().get(instanceUUID);
+                    Map<String, String> metadata = server.getMetadata();
+                    String instanceGroupName = metadata.get(HeatTemplateBuilder.CB_INSTANCE_GROUP_NAME);
+                    final String instanceId = openStackUtil.getInstanceId(instanceUUID, metadata);
+                    boolean metadataExists = FluentIterable.from(instanceGroup.getInstanceMetaData()).anyMatch(new Predicate<InstanceMetaData>() {
+                        @Override
+                        public boolean apply(InstanceMetaData input) {
+                            return input.getInstanceId().equals(instanceId);
+                        }
+                    });
+                    if (!metadataExists && instanceGroupName.equals(hostGroup)) {
+                        LOGGER.info("New instance added to metadata: [stack: '{}', instanceId: '{}']", stack.getId(), instanceId);
+                        instancesCoreMetadata.add(createCoreMetaData(stack, server, instanceGroupName, instanceId));
+                    }
+                }
+            }
+        }
+        LOGGER.info("Publishing {} event [StackId: '{}']", ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT, stack.getId());
+        reactor.notify(ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT,
+                Event.wrap(new MetadataUpdateComplete(CloudPlatform.OPENSTACK, stack.getId(), instancesCoreMetadata, hostGroup)));
     }
 
     @Override
     public CloudPlatform getCloudPlatform() {
         return CloudPlatform.OPENSTACK;
+    }
+
+    private CoreInstanceMetaData createCoreMetaData(Stack stack, Server server, String instanceGroupName, String instanceId) {
+        return new CoreInstanceMetaData(
+                instanceId,
+                server.getAddresses().getAddresses("app_network").get(0).getAddr(),
+                server.getAddresses().getAddresses("app_network").get(1).getAddr(),
+                server.getOsExtendedVolumesAttached().size(),
+                server.getName(),
+                stack.getInstanceGroupByInstanceGroupName(instanceGroupName)
+        );
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/OpenStackUtil.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/OpenStackUtil.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.service.stack.connector.openstack;
 
 import static org.apache.commons.lang3.StringUtils.deleteWhitespace;
 
+import java.util.Map;
+
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.openstack4j.api.OSClient;
 import org.openstack4j.openstack.OSFactory;
@@ -32,6 +34,15 @@ public class OpenStackUtil {
 
     public String getKeyPairName(OpenStackCredential credential) {
         return CB_KEYPAIR_NAME + deleteWhitespace(credential.getName().toLowerCase());
+    }
+
+    public String getInstanceId(String uuid, Map<String, String> metadata) {
+        return uuid + "_" + getNormalizedGroupName(metadata.get(HeatTemplateBuilder.CB_INSTANCE_GROUP_NAME)) + "_"
+                + metadata.get(HeatTemplateBuilder.CB_INSTANCE_PRIVATE_ID);
+    }
+
+    public String getNormalizedGroupName(String groupName) {
+        return groupName.replaceAll("_", "");
     }
 
 }


### PR DESCRIPTION
@doktoric please review

Scaling without AS group is not that easy. We have to generate the whole template on each update like we would do it for the first time. Previously the resource generation was:
node_1
node_2
node_3
.. The host group didn't matter. With scaling it causes problems so it's changed to:
node_slave1_0
node_slave1_1
node_slave1_2
node_slave2_0
node_slave2_1
node_master_0

Each resource has its own private ID within the host group. In case of downscale now we can say that not to generate the node_slave1_1 when generating the whole template again.

The instance id looks like the following uuid_slave1_1 to be able to identify the host group and private id later.