### PR TITLE
CLOUD-479 removed stack unique name constraint

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
@@ -154,7 +154,7 @@ public class Stack implements ProvisionEntity {
     @SequenceGenerator(name = "stack_generator", sequenceName = "stack_table")
     private Long id;
 
-    @Column(unique = true, nullable = false)
+    @Column(nullable = false)
     private String name;
 
     private String owner;


### PR DESCRIPTION
@doktoric or @martonsereg 
db (cloudbreak) migration is needed