### PR TITLE
Separated instance groups and host groups

### DIFF
--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakITContextConstants.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakITContextConstants.java
@@ -6,6 +6,7 @@ public class CloudbreakITContextConstants {
     public static final String TEMPLATE_ID = "TEMPLATE_ID";
     public static final String CREDENTIAL_ID = "CREDENTIAL_ID";
     public static final String STACK_ID = "STACK_ID";
+    public static final String HOSTGROUP_ID = "HOSTGROUP_ID";
 
     private CloudbreakITContextConstants() {
     }

--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTestSuiteInitializer.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTestSuiteInitializer.java
@@ -42,17 +42,21 @@ public class CloudbreakTestSuiteInitializer extends AbstractTestNGSpringContextT
     }
 
     @BeforeSuite(dependsOnMethods = "initContext")
-    @Parameters({ "cloudbreakServer", "credentialName", "instanceGroups", "blueprintName", "stackName" })
+    @Parameters({ "cloudbreakServer", "credentialName", "instanceGroups", "hostGroups", "blueprintName", "stackName" })
     public void initCloudbreakSuite(@Optional("") String cloudbreakServer, @Optional("") String credentialName,
-            @Optional("") String instanceGroups, @Optional("") String blueprintName, @Optional("") String stackName) {
+            @Optional("") String instanceGroups, @Optional("") String hostGroups, @Optional("") String blueprintName, @Optional("") String stackName) {
         cloudbreakServer = StringUtils.hasLength(cloudbreakServer) ? cloudbreakServer : defaultCloudbreakServer;
         itContext.putContextParam(CloudbreakITContextConstants.CLOUDBREAK_SERVER, cloudbreakServer);
         putResourceToContextIfExist(CloudbreakITContextConstants.BLUEPRINT_ID, "/account/blueprints/{name}", blueprintName);
         putResourceToContextIfExist(CloudbreakITContextConstants.CREDENTIAL_ID, "/account/credentials/{name}", credentialName);
         putResourceToContextIfExist(CloudbreakITContextConstants.STACK_ID, "/account/stacks/{name}", stackName);
         if (StringUtils.hasLength(instanceGroups)) {
-            List<String[]> instanceGroupStrings = templateAdditionParser.parseInstanceGroups(instanceGroups);
+            List<String[]> instanceGroupStrings = templateAdditionParser.parseCommaSeparatedRows(instanceGroups);
             itContext.putContextParam(CloudbreakITContextConstants.TEMPLATE_ID, createInstanceGroups(instanceGroupStrings));
+        }
+        if (StringUtils.hasLength(hostGroups)) {
+            List<String[]> hostGroupStrings = templateAdditionParser.parseCommaSeparatedRows(hostGroups);
+            itContext.putContextParam(CloudbreakITContextConstants.HOSTGROUP_ID, createHostGroups(hostGroupStrings));
         }
     }
 
@@ -63,6 +67,14 @@ public class CloudbreakTestSuiteInitializer extends AbstractTestNGSpringContextT
                     Integer.parseInt(instanceGroupStr[2])));
         }
         return instanceGroups;
+    }
+
+    private List<HostGroup> createHostGroups(List<String[]> hostGroupStrings) {
+        List<HostGroup> hostGroups = new ArrayList<>();
+        for (String[] hostGroupStr : hostGroupStrings) {
+            hostGroups.add(new HostGroup(hostGroupStr[0], hostGroupStr[1]));
+        }
+        return hostGroups;
     }
 
     private void putResourceToContextIfExist(String contextId, String resourcePath, String resourceName) {

--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/ClusterCreationTest.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/ClusterCreationTest.java
@@ -48,6 +48,7 @@ public class ClusterCreationTest extends AbstractCloudbreakIntegrationTest {
         templateModel.put("clusterName", clusterName);
         templateModel.put("emailNeeded", String.valueOf(emailNeeded));
         templateModel.put("blueprintId", itContext.getContextParam(CloudbreakITContextConstants.BLUEPRINT_ID));
+        templateModel.put("hostGroups", itContext.getContextParam(CloudbreakITContextConstants.HOSTGROUP_ID, List.class));
         // WHEN
         Response resourceCreationResponse = RestUtil.entityPathRequest(itContext.getContextParam(CloudbreakITContextConstants.CLOUDBREAK_SERVER),
                 itContext.getContextParam(IntegrationTestContext.AUTH_TOKEN), "stackId", itContext.getContextParam(CloudbreakITContextConstants.STACK_ID))

--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/HostGroup.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/HostGroup.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.it.cloudbreak;
+
+public class HostGroup {
+    private String name;
+    private String instanceGroupName;
+
+    public HostGroup(String name, String instanceGroupName) {
+        this.name = name;
+        this.instanceGroupName = instanceGroupName;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getInstanceGroupName() {
+        return instanceGroupName;
+    }
+}

--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/StackCreationTest.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/StackCreationTest.java
@@ -37,7 +37,7 @@ public class StackCreationTest extends AbstractCloudbreakIntegrationTest {
     @Test
     @Parameters({ "stackName", "region", "ambariUser", "ambariPassword", "onFailureAction", "threshold", "adjustmentType" })
     public void testStackCreation(@Optional("testing1") String stackName, @Optional("EUROPE_WEST1_B") String region, @Optional("admin") String ambariUser,
-            @Optional("admin") String ambariPassword, @Optional("DO_NOTHING") String onFailureAction, @Optional("1") Long threshold,
+            @Optional("admin") String ambariPassword, @Optional("DO_NOTHING") String onFailureAction, @Optional("4") Long threshold,
             @Optional("EXACT") String adjustmentType) {
         // GIVEN
         IntegrationTestContext itContext = getItContext();

--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/TemplateAdditionParser.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/TemplateAdditionParser.java
@@ -14,12 +14,12 @@ public class TemplateAdditionParser {
         return additions;
     }
 
-    public List<String[]> parseInstanceGroups(String instanceGroupsString) {
-        List<String[]> instanceGroups = new ArrayList<>();
-        String[] instanceGroupStrings = instanceGroupsString.split(";");
-        for (String instanceGroupString : instanceGroupStrings) {
-            instanceGroups.add(instanceGroupString.split(","));
+    public List<String[]> parseCommaSeparatedRows(String source) {
+        List<String[]> result = new ArrayList<>();
+        String[] rows = source.split(";");
+        for (String row : rows) {
+            result.add(row.split(","));
         }
-        return instanceGroups;
+        return result;
     }
 }

--- a/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/config/FreeMarkerConfig.java
+++ b/integrationtest/src/main/java/com/sequenceiq/it/cloudbreak/config/FreeMarkerConfig.java
@@ -61,6 +61,11 @@ public class FreeMarkerConfig {
     }
 
     @Bean
+    public Template instancegroupAdjustmentTemplate() throws IOException {
+        return freeConfig.getTemplate("requests/instancegroup.adjustment.json.fm", "UTF-8");
+    }
+
+    @Bean
     public Template statusUpdateTemplate() throws IOException {
         return freeConfig.getTemplate("requests/status.update.json.fm", "UTF-8");
     }

--- a/integrationtest/src/main/resources/requests/cluster.json.fm
+++ b/integrationtest/src/main/resources/requests/cluster.json.fm
@@ -1,5 +1,13 @@
 {
    "name":"${clusterName}",
    "blueprintId":"${blueprintId}",
-   "emailNeeded":${emailNeeded}
+   "emailNeeded":${emailNeeded},
+   "hostGroups" : [
+   <#list hostGroups as hostGroup>
+        {
+             "name":"${hostGroup.name}",
+             "instanceGroupName":"${hostGroup.instanceGroupName}"
+        }<#if hostGroup_has_next>,</#if>
+   </#list>
+   ]
 }

--- a/integrationtest/src/main/resources/requests/instancegroup.adjustment.json.fm
+++ b/integrationtest/src/main/resources/requests/instancegroup.adjustment.json.fm
@@ -1,0 +1,6 @@
+{
+   "instanceGroupAdjustment":{
+      "instanceGroup":"${instanceGroup}",
+      "scalingAdjustment":"${scalingAdjustment}"
+   }
+}

--- a/integrationtest/src/main/resources/testng-aws-full.xml
+++ b/integrationtest/src/main/resources/testng-aws-full.xml
@@ -7,6 +7,7 @@
     <parameter name="uaaPassword" value="COULD BE SPECIFIED" />
     <parameter name="cloudbreakServer" value="COULD BE SPECIFIED" />
     -->
+    <parameter name="hostGroups" value="master,master;slave_1,slave_1" />
     <test name="init">
         <classes>
             <class name="com.sequenceiq.it.TestSuiteInitializer" />

--- a/integrationtest/src/main/resources/testng-aws-full.xml
+++ b/integrationtest/src/main/resources/testng-aws-full.xml
@@ -71,14 +71,14 @@
         </classes>
     </test>
     <test name="upscale">
-        <parameter name="hostGroup" value="slave_1" />
+        <parameter name="instanceGroup" value="slave_1" />
         <parameter name="scalingAdjustment" value="3" />
         <classes>
             <class name="com.sequenceiq.it.cloudbreak.ScalingTest" />
         </classes>
     </test>
     <test name="downscale">
-        <parameter name="hostGroup" value="slave_1" />
+        <parameter name="instanceGroup" value="slave_1" />
         <parameter name="scalingAdjustment" value="-2" />
         <classes>
             <class name="com.sequenceiq.it.cloudbreak.ScalingTest" />

--- a/integrationtest/src/main/resources/testng-aws-pre.xml
+++ b/integrationtest/src/main/resources/testng-aws-pre.xml
@@ -13,6 +13,7 @@
     <!-- with existing cloud provider templates
     <parameter name="instanceGroups" value="it-aws-master,master,1;it-aws-slave,slave_1,3" />
     -->
+    <parameter name="hostGroups" value="master,master;slave_1,slave_1" />
     <test name="init">
         <classes>
             <class name="com.sequenceiq.it.TestSuiteInitializer" />

--- a/integrationtest/src/main/resources/testng-gcp-full.xml
+++ b/integrationtest/src/main/resources/testng-gcp-full.xml
@@ -74,14 +74,14 @@
     </test>
     -->
     <test name="upscale">
-        <parameter name="hostGroup" value="slave_1" />
+        <parameter name="instanceGroup" value="slave_1" />
         <parameter name="scalingAdjustment" value="3" />
         <classes>
             <class name="com.sequenceiq.it.cloudbreak.ScalingTest" />
         </classes>
     </test>
     <test name="downscale">
-        <parameter name="hostGroup" value="slave_1" />
+        <parameter name="instanceGroup" value="slave_1" />
         <parameter name="scalingAdjustment" value="-2" />
         <classes>
             <class name="com.sequenceiq.it.cloudbreak.ScalingTest" />

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/ClusterController.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/ClusterController.java
@@ -83,13 +83,15 @@ public class ClusterController {
         if (updateJson.getStatus() != null) {
             clusterService.updateStatus(stackId, updateJson.getStatus());
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else if (updateJson.getHostGroupAdjustment() != null) {
+            if (!stackStatus.equals(Status.AVAILABLE)) {
+                throw new BadRequestException(String.format(
+                        "Stack '%s' is currently in '%s' state. PUT requests to a cluster can only be made if the underlying stack is 'AVAILABLE'.", stackId,
+                        stackStatus));
+            }
+            clusterService.updateHosts(stackId, updateJson.getHostGroupAdjustment());
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         }
-        if (!stackStatus.equals(Status.AVAILABLE)) {
-            throw new BadRequestException(String.format(
-                    "Stack '%s' is currently in '%s' state. PUT requests to a cluster can only be made if the underlying stack is 'AVAILABLE'.", stackId,
-                    stackStatus));
-        }
-        clusterService.updateHosts(stackId, updateJson.getHostGroupAdjustment());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/StackController.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/StackController.java
@@ -136,8 +136,8 @@ public class StackController {
         if (updateRequest.getStatus() != null) {
             stackService.updateStatus(id, updateRequest.getStatus());
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
-        } else if (updateRequest.getHostGroupAdjustment() != null) {
-            stackService.updateNodeCount(id, updateRequest.getHostGroupAdjustment());
+        } else if (updateRequest.getInstanceGroupAdjustment() != null) {
+            stackService.updateNodeCount(id, updateRequest.getInstanceGroupAdjustment());
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         } else {
             stackService.updateAllowedSubnets(id, new ArrayList<>(subnetConverter.convertAllJsonToEntity(updateRequest.getAllowedSubnets())));

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/CloudbreakUsageJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/CloudbreakUsageJson.java
@@ -23,7 +23,7 @@ public class CloudbreakUsageJson implements JsonEntity {
 
     private String instanceType;
 
-    private String hostGroup;
+    private String instanceGroup;
 
     public String getOwner() {
         return owner;
@@ -113,11 +113,11 @@ public class CloudbreakUsageJson implements JsonEntity {
         this.instanceType = instanceType;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public String getInstanceGroup() {
+        return instanceGroup;
     }
 
-    public void setHostGroup(String hostGroup) {
-        this.hostGroup = hostGroup;
+    public void setInstanceGroup(String instanceGroup) {
+        this.instanceGroup = instanceGroup;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterRequest.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterRequest.java
@@ -1,5 +1,8 @@
 package com.sequenceiq.cloudbreak.controller.json;
 
+import java.util.Set;
+
+import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
@@ -9,7 +12,7 @@ public class ClusterRequest {
 
     @Size(max = 40, min = 5, message = "The length of the cluster's name has to be in range of 5 to 40")
     @Pattern(regexp = "([a-z][-a-z0-9]*[a-z0-9])",
-            message = "The name of the cluster can only contain lowercase alphanumeric characters and hyphens and has start with an alphanumeric character")
+            message = "The name of the cluster can only contain lowercase alphanumeric characters and hyphens and has to start with an alphanumeric character")
     @NotNull
     private String name;
     @NotNull
@@ -17,6 +20,9 @@ public class ClusterRequest {
     private Long recipeId;
     @Size(max = 1000)
     private String description;
+    @Valid
+    @NotNull
+    private Set<HostGroupJson> hostGroups;
     private Boolean emailNeeded = Boolean.FALSE;
 
     public String getDescription() {
@@ -49,6 +55,14 @@ public class ClusterRequest {
 
     public void setRecipeId(Long recipeId) {
         this.recipeId = recipeId;
+    }
+
+    public Set<HostGroupJson> getHostGroups() {
+        return hostGroups;
+    }
+
+    public void setHostGroups(Set<HostGroupJson> hostGroups) {
+        this.hostGroups = hostGroups;
     }
 
     public Boolean getEmailNeeded() {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterResponse.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterResponse.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.controller.json;
 
+import java.util.Set;
+
 import com.fasterxml.jackson.annotation.JsonRawValue;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -14,6 +16,7 @@ public class ClusterResponse {
     private Long recipeId;
     private String description;
     private String statusReason;
+    private Set<HostGroupJson> hostGroups;
 
     public String getDescription() {
         return description;
@@ -86,5 +89,13 @@ public class ClusterResponse {
 
     public void setRecipeId(Long recipeId) {
         this.recipeId = recipeId;
+    }
+
+    public Set<HostGroupJson> getHostGroups() {
+        return hostGroups;
+    }
+
+    public void setHostGroups(Set<HostGroupJson> hostGroups) {
+        this.hostGroups = hostGroups;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/HostGroupJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/HostGroupJson.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.controller.json;
+
+import javax.validation.constraints.NotNull;
+
+public class HostGroupJson {
+
+    @NotNull
+    private String name;
+    @NotNull
+    private String instanceGroupName;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getInstanceGroupName() {
+        return instanceGroupName;
+    }
+
+    public void setInstanceGroupName(String instanceGroupName) {
+        this.instanceGroupName = instanceGroupName;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/InstanceGroupAdjustmentJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/InstanceGroupAdjustmentJson.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.controller.json;
+
+public class InstanceGroupAdjustmentJson {
+
+    private String instanceGroup;
+    private Integer scalingAdjustment;
+
+    public InstanceGroupAdjustmentJson() {
+
+    }
+
+    public String getInstanceGroup() {
+        return instanceGroup;
+    }
+
+    public void setInstanceGroup(String instanceGroup) {
+        this.instanceGroup = instanceGroup;
+    }
+
+    public Integer getScalingAdjustment() {
+        return scalingAdjustment;
+    }
+
+    public void setScalingAdjustment(Integer scalingAdjustment) {
+        this.scalingAdjustment = scalingAdjustment;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackValidationRequest.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/StackValidationRequest.java
@@ -1,20 +1,29 @@
 package com.sequenceiq.cloudbreak.controller.json;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 
 public class StackValidationRequest implements JsonEntity {
-    private List<InstanceGroupJson> instanceGroups = new ArrayList<>();
+    private Set<HostGroupJson> hostGroups = new HashSet<>();
+    private Set<InstanceGroupJson> instanceGroups = new HashSet<>();
     @NotNull
     private Long blueprintId;
 
-    public List<InstanceGroupJson> getInstanceGroups() {
+    public Set<HostGroupJson> getHostGroups() {
+        return hostGroups;
+    }
+
+    public void setHostGroups(Set<HostGroupJson> hostGroups) {
+        this.hostGroups = hostGroups;
+    }
+
+    public Set<InstanceGroupJson> getInstanceGroups() {
         return instanceGroups;
     }
 
-    public void setInstanceGroups(List<InstanceGroupJson> instanceGroups) {
+    public void setInstanceGroups(Set<InstanceGroupJson> instanceGroups) {
         this.instanceGroups = instanceGroups;
     }
 

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/UpdateStackJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/UpdateStackJson.java
@@ -13,7 +13,7 @@ public class UpdateStackJson implements JsonEntity {
 
     private StatusRequest status;
 
-    private HostGroupAdjustmentJson hostGroupAdjustment;
+    private InstanceGroupAdjustmentJson instanceGroupAdjustment;
 
     private List<SubnetJson> allowedSubnets;
 
@@ -29,12 +29,12 @@ public class UpdateStackJson implements JsonEntity {
         this.status = status;
     }
 
-    public HostGroupAdjustmentJson getHostGroupAdjustment() {
-        return hostGroupAdjustment;
+    public InstanceGroupAdjustmentJson getInstanceGroupAdjustment() {
+        return instanceGroupAdjustment;
     }
 
-    public void setHostGroupAdjustment(HostGroupAdjustmentJson hostGroupAdjustment) {
-        this.hostGroupAdjustment = hostGroupAdjustment;
+    public void setInstanceGroupAdjustment(InstanceGroupAdjustmentJson instanceGroupAdjustment) {
+        this.instanceGroupAdjustment = instanceGroupAdjustment;
     }
 
     public List<SubnetJson> getAllowedSubnets() {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/UpdateStackRequestValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/UpdateStackRequestValidator.java
@@ -18,7 +18,7 @@ public class UpdateStackRequestValidator implements ConstraintValidator<ValidUpd
         if (value.getStatus() != null) {
             updateResources++;
         }
-        if (value.getHostGroupAdjustment() != null) {
+        if (value.getInstanceGroupAdjustment() != null) {
             updateResources++;
         }
         if (value.getAllowedSubnets() != null) {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintServiceComponent.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintServiceComponent.java
@@ -3,7 +3,7 @@ package com.sequenceiq.cloudbreak.controller.validation.blueprint;
 import java.util.List;
 
 import com.google.common.collect.Lists;
-import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.HostGroup;
 
 class BlueprintServiceComponent {
     private String name;
@@ -16,9 +16,9 @@ class BlueprintServiceComponent {
         this.hostgroups = Lists.newArrayList(hostgroup);
     }
 
-    public void update(InstanceGroup instanceGroup) {
-        nodeCount += instanceGroup.getNodeCount();
-        hostgroups.add(instanceGroup.getGroupName());
+    public void update(HostGroup hostGroup) {
+        nodeCount += hostGroup.getInstanceGroup().getNodeCount();
+        hostgroups.add(hostGroup.getName());
     }
 
     public String getName() {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidator.java
@@ -1,8 +1,12 @@
 package com.sequenceiq.cloudbreak.controller.validation.blueprint;
 
 import java.io.IOException;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+
+import javax.annotation.Nullable;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -11,9 +15,12 @@ import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Maps;
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.HostGroup;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
 
 @Component
@@ -25,22 +32,19 @@ public class BlueprintValidator {
     @Autowired
     private StackServiceComponentDescriptors stackServiceComponentDescs;
 
-    public void validateBlueprintForStack(Blueprint blueprint, Set<InstanceGroup> instanceGroups) {
+    public void validateBlueprintForStack(Blueprint blueprint, Set<HostGroup> hostGroups, Set<InstanceGroup> instanceGroups) {
         try {
             JsonNode blueprintJsonTree = createJsonTree(blueprint);
-            Map<String, InstanceGroup> instanceGroupMap = createInstanceGroupMap(instanceGroups);
-            Map<String, BlueprintServiceComponent> blueprintServiceComponentMap = Maps.newHashMap();
             JsonNode hostGroupsNode = blueprintJsonTree.get("host_groups");
-            int hostGroupCount = 0;
+            validateHostGroups(hostGroupsNode, hostGroups, instanceGroups);
+            Map<String, HostGroup> hostGroupMap = createHostGroupMap(hostGroups);
+            Map<String, BlueprintServiceComponent> blueprintServiceComponentMap = Maps.newHashMap();
             for (JsonNode hostGroupNode : hostGroupsNode) {
-                validateHostGroup(hostGroupNode, instanceGroupMap, blueprintServiceComponentMap);
-                hostGroupCount++;
+                validateHostGroup(hostGroupNode, hostGroupMap, blueprintServiceComponentMap);
             }
-            validateHostGroupCount(hostGroupCount, instanceGroupMap.size());
             validateBlueprintServiceComponents(blueprintServiceComponentMap);
-        } catch (IOException iox) {
-            LOGGER.error("Cannot parse blueprint json", iox);
-            throw new BadRequestException(String.format("Blueprint [%s] can not convert to json tree.", blueprint.getId()));
+        }  catch (IOException e) {
+            throw new BadRequestException(String.format("Blueprint [%s] can not be parsed from JSON.", blueprint.getId()));
         }
     }
 
@@ -48,52 +52,80 @@ public class BlueprintValidator {
         return objectMapper.readTree(blueprint.getBlueprintText());
     }
 
-    private Map<String, InstanceGroup> createInstanceGroupMap(Set<InstanceGroup> instanceGroups) {
-        Map<String, InstanceGroup> groupMap = Maps.newHashMap();
-        for (InstanceGroup instanceGroup : instanceGroups) {
-            groupMap.put(instanceGroup.getGroupName(), instanceGroup);
+    private void validateHostGroups(JsonNode hostGroupsNode, Set<HostGroup> hostGroups, Set<InstanceGroup> instanceGroups) {
+        Set<String> hostGroupsInRequest = getHostGroupsFromRequest(hostGroups);
+        Set<String> hostGroupsInBlueprint = getHostGroupsFromBlueprint(hostGroupsNode);
+
+        if (!hostGroupsInRequest.containsAll(hostGroupsInBlueprint) || !hostGroupsInBlueprint.containsAll(hostGroupsInRequest)) {
+            throw new BadRequestException(String.format("The host groups in the blueprint must match the hostgroups in the request."));
+        }
+
+        Set<Long> instanceGroupNames = new HashSet<>();
+        for (HostGroup hostGroup : hostGroups) {
+            if (instanceGroupNames.contains(hostGroup.getInstanceGroup().getGroupName())) {
+                throw new BadRequestException(String.format(
+                        "Instance group '%s' is assigned to more than one hostgroup.", hostGroup.getInstanceGroup().getGroupName()));
+            }
+            instanceGroupNames.add(hostGroup.getInstanceGroup().getId());
+        }
+
+        if (instanceGroups.size() != hostGroupsInRequest.size()) {
+            throw new BadRequestException("The number of hostgroups must match the number of instance groups on the stack");
+        }
+    }
+
+    private Set<String> getHostGroupsFromRequest(Set<HostGroup> hostGroup) {
+        return FluentIterable.from(hostGroup).transform(new Function<HostGroup, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable HostGroup hostGroup) {
+                return hostGroup.getName();
+            }
+        }).toSet();
+    }
+
+    private Set<String> getHostGroupsFromBlueprint(JsonNode hostGroupsNode) {
+        Set<String> hostGroupsInBlueprint = new HashSet<>();
+        Iterator<JsonNode> hostGroups = hostGroupsNode.elements();
+        while (hostGroups.hasNext()) {
+            hostGroupsInBlueprint.add(hostGroups.next().get("name").asText());
+        }
+        return hostGroupsInBlueprint;
+    }
+
+    private Map<String, HostGroup> createHostGroupMap(Set<HostGroup> hostGroups) {
+        Map<String, HostGroup> groupMap = Maps.newHashMap();
+        for (HostGroup hostGroup : hostGroups) {
+            groupMap.put(hostGroup.getName(), hostGroup);
         }
         return groupMap;
     }
 
-    private void validateHostGroup(JsonNode hostGroupNode, Map<String, InstanceGroup> instanceGroupMap,
+    private void validateHostGroup(JsonNode hostGroupNode, Map<String, HostGroup> hostGroupMap,
             Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
         String hostGroupName = hostGroupNode.get("name").asText();
-        validateHostGroupName(hostGroupName, instanceGroupMap.keySet());
-        InstanceGroup instanceGroup = instanceGroupMap.get(hostGroupName);
+        HostGroup hostGroup = hostGroupMap.get(hostGroupName);
         JsonNode componentsNode = hostGroupNode.get("components");
         for (JsonNode componentNode : componentsNode) {
-            validateComponent(componentNode, instanceGroup, blueprintServiceComponentMap);
+            validateComponent(componentNode, hostGroup, blueprintServiceComponentMap);
         }
     }
 
-    private void validateComponent(JsonNode componentNode, InstanceGroup instanceGroup, Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
+    private void validateComponent(JsonNode componentNode, HostGroup hostGroup, Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
         String componentName = componentNode.get("name").asText();
         StackServiceComponentDescriptor componentDescriptor = stackServiceComponentDescs.get(componentName);
         if (componentDescriptor != null) {
-            validateComponentCardinality(componentDescriptor, instanceGroup);
-            updateBlueprintServiceComponentMap(componentDescriptor, instanceGroup, blueprintServiceComponentMap);
+            validateComponentCardinality(componentDescriptor, hostGroup);
+            updateBlueprintServiceComponentMap(componentDescriptor, hostGroup, blueprintServiceComponentMap);
         }
     }
 
-    private void validateComponentCardinality(StackServiceComponentDescriptor componentDescriptor, InstanceGroup instanceGroup) {
-        int nodeCount = instanceGroup.getNodeCount();
+    private void validateComponentCardinality(StackServiceComponentDescriptor componentDescriptor, HostGroup hostGroup) {
+        int nodeCount = hostGroup.getInstanceGroup().getNodeCount();
         int maxCardinality = componentDescriptor.getMaxCardinality();
         if (componentDescriptor.isMaster() && nodeCount > maxCardinality) {
             throw new BadRequestException(String.format("The nodecount '%d' for hostgroup '%s' cannot be more than '%d' because of '%s' component",
-                    nodeCount, instanceGroup.getGroupName(), maxCardinality, componentDescriptor.getName()));
-        }
-    }
-
-    private void validateHostGroupName(String groupName, Set<String> instanceGroupNames) {
-        if (!instanceGroupNames.contains(groupName)) {
-            throw new BadRequestException(String.format("The name of host group '%s' doesn't match any of the defined instance groups.", groupName));
-        }
-    }
-
-    private void validateHostGroupCount(int hostGroupCount, int instanceGroupCount) {
-        if (hostGroupCount != instanceGroupCount) {
-            throw new BadRequestException(String.format("The number of instancegroups and hostgroups must be equals."));
+                    nodeCount, hostGroup.getName(), maxCardinality, componentDescriptor.getName()));
         }
     }
 
@@ -110,15 +142,15 @@ public class BlueprintValidator {
         }
     }
 
-    private void updateBlueprintServiceComponentMap(StackServiceComponentDescriptor componentDescriptor, InstanceGroup instanceGroup,
+    private void updateBlueprintServiceComponentMap(StackServiceComponentDescriptor componentDescriptor, HostGroup hostGroup,
             Map<String, BlueprintServiceComponent> blueprintServiceComponentMap) {
         String componentName = componentDescriptor.getName();
         BlueprintServiceComponent blueprintServiceComponent = blueprintServiceComponentMap.get(componentName);
         if (blueprintServiceComponent == null) {
-            blueprintServiceComponent = new BlueprintServiceComponent(componentName, instanceGroup.getGroupName(), instanceGroup.getNodeCount());
+            blueprintServiceComponent = new BlueprintServiceComponent(componentName, hostGroup.getName(), hostGroup.getInstanceGroup().getNodeCount());
             blueprintServiceComponentMap.put(componentName, blueprintServiceComponent);
         } else {
-            blueprintServiceComponent.update(instanceGroup);
+            blueprintServiceComponent.update(hostGroup);
         }
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/converter/CloudbreakUsageConverter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/converter/CloudbreakUsageConverter.java
@@ -40,7 +40,7 @@ public class CloudbreakUsageConverter extends AbstractConverter<CloudbreakUsageJ
         json.setUsername(cbUser.getUsername());
         json.setCosts(entity.getCosts());
         json.setInstanceType(entity.getInstanceType());
-        json.setHostGroup(entity.getHostGroup());
+        json.setInstanceGroup(entity.getInstanceGroup());
         return json;
     }
 
@@ -55,7 +55,7 @@ public class CloudbreakUsageConverter extends AbstractConverter<CloudbreakUsageJ
         entity.setStackId(json.getStackId());
         entity.setStackName(json.getStackName());
         entity.setInstanceType(json.getInstanceType());
-        entity.setHostGroup(json.getHostGroup());
+        entity.setInstanceGroup(json.getInstanceGroup());
         return entity;
     }
 

--- a/src/main/java/com/sequenceiq/cloudbreak/converter/StackValidationConverter.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/converter/StackValidationConverter.java
@@ -1,12 +1,23 @@
 package com.sequenceiq.cloudbreak.converter;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.annotation.Nullable;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 
+import com.google.common.base.Predicate;
+import com.google.common.collect.FluentIterable;
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+import com.sequenceiq.cloudbreak.controller.json.HostGroupJson;
 import com.sequenceiq.cloudbreak.controller.json.StackValidationRequest;
-import com.sequenceiq.cloudbreak.domain.StackValidation;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.HostGroup;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.StackValidation;
 import com.sequenceiq.cloudbreak.repository.BlueprintRepository;
 
 @Component
@@ -19,7 +30,9 @@ public class StackValidationConverter {
 
     public StackValidation convert(StackValidationRequest stackValidationRequest) {
         StackValidation stackValidation = new StackValidation();
-        stackValidation.setInstanceGroups(instanceGroupConverter.convertAllJsonToEntity(stackValidationRequest.getInstanceGroups()));
+        Set<InstanceGroup> instanceGroups = instanceGroupConverter.convertAllJsonToEntity(stackValidationRequest.getInstanceGroups());
+        stackValidation.setInstanceGroups(instanceGroups);
+        stackValidation.setHostGroups(convertHostGroupsFromJson(instanceGroups, stackValidationRequest.getHostGroups()));
         try {
             Blueprint blueprint = blueprintRepository.findOne(stackValidationRequest.getBlueprintId());
             stackValidation.setBlueprint(blueprint);
@@ -28,5 +41,25 @@ public class StackValidationConverter {
                     String.format("Access to blueprint '%s' is denied or blueprint doesn't exist.", stackValidationRequest.getBlueprintId()), e);
         }
         return stackValidation;
+    }
+
+    private Set<HostGroup> convertHostGroupsFromJson(Set<InstanceGroup> instanceGroups, final Set<HostGroupJson> hostGroupsJsons) {
+        Set<HostGroup> hostGroups = new HashSet<>();
+        for (final HostGroupJson json : hostGroupsJsons) {
+            HostGroup hostGroup = new HostGroup();
+            hostGroup.setName(json.getName());
+            InstanceGroup instanceGroup = FluentIterable.from(instanceGroups).firstMatch(new Predicate<InstanceGroup>() {
+                @Override
+                public boolean apply(@Nullable InstanceGroup instanceGroup) {
+                    return instanceGroup.getGroupName().equals(json.getInstanceGroupName());
+                }
+            }).get();
+            if (instanceGroup == null) {
+                throw new BadRequestException(String.format("Cannot find instance group named '%s' in instance group list", json.getInstanceGroupName()));
+            }
+            hostGroup.setInstanceGroup(instanceGroup);
+            hostGroups.add(hostGroup);
+        }
+        return hostGroups;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/CloudbreakUsage.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/CloudbreakUsage.java
@@ -32,7 +32,7 @@ public class CloudbreakUsage implements ProvisionEntity {
 
     private String instanceType;
 
-    private String hostGroup;
+    private String instanceGroup;
 
     public Long getId() {
         return id;
@@ -114,12 +114,12 @@ public class CloudbreakUsage implements ProvisionEntity {
         this.instanceType = instanceType;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public String getInstanceGroup() {
+        return instanceGroup;
     }
 
-    public void setHostGroup(String hostGroup) {
-        this.hostGroup = hostGroup;
+    public void setInstanceGroup(String instanceGroup) {
+        this.instanceGroup = instanceGroup;
     }
 
     @Override
@@ -135,7 +135,7 @@ public class CloudbreakUsage implements ProvisionEntity {
         sb.append(", stackId='").append(stackId).append('\'');
         sb.append(", stackName='").append(stackName).append('\'');
         sb.append(", instanceType='").append(instanceType).append('\'');
-        sb.append(", hostGroup='").append(hostGroup).append('\'');
+        sb.append(", instanceGroup='").append(instanceGroup).append('\'');
         sb.append(", costs='").append(costs).append('\'');
         sb.append('}');
         return sb.toString();

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Cluster.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Cluster.java
@@ -33,7 +33,7 @@ import javax.persistence.UniqueConstraint;
         @NamedQuery(
                 name = "Cluster.findOneWithLists",
                 query = "SELECT c FROM Cluster c "
-                        + "LEFT JOIN FETCH c.hostMetadata "
+                        + "LEFT JOIN FETCH c.hostGroups "
                         + "WHERE c.id= :id")
 })
 public class Cluster implements ProvisionEntity {
@@ -71,7 +71,7 @@ public class Cluster implements ProvisionEntity {
     private Boolean emailNeeded;
 
     @OneToMany(mappedBy = "cluster", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<HostMetadata> hostMetadata = new HashSet<>();
+    private Set<HostGroup> hostGroups = new HashSet<>();
 
     public String getDescription() {
         return description;
@@ -177,11 +177,11 @@ public class Cluster implements ProvisionEntity {
         this.emailNeeded = emailNeeded;
     }
 
-    public Set<HostMetadata> getHostMetadata() {
-        return hostMetadata;
+    public Set<HostGroup> getHostGroups() {
+        return hostGroups;
     }
 
-    public void setHostMetadata(Set<HostMetadata> hostMetadata) {
-        this.hostMetadata = hostMetadata;
+    public void setHostGroups(Set<HostGroup> hostGroups) {
+        this.hostGroups = hostGroups;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/HostGroup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/HostGroup.java
@@ -1,0 +1,86 @@
+package com.sequenceiq.cloudbreak.domain;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.OneToMany;
+
+@Entity
+@NamedQueries({
+        @NamedQuery(
+                name = "HostGroup.findHostGroupsInCluster",
+                query = "SELECT h FROM HostGroup h "
+                        + "LEFT JOIN FETCH h.hostMetadata "
+                        + "WHERE h.cluster.id= :clusterId"),
+        @NamedQuery(
+                name = "HostGroup.findHostGroupInClusterByName",
+                query = "SELECT h FROM HostGroup h "
+                        + "LEFT JOIN FETCH h.hostMetadata "
+                        + "WHERE h.cluster.id= :clusterId "
+                        + "AND h.name= :hostGroupName")
+})
+public class HostGroup {
+
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    private String name;
+
+    @ManyToOne
+    private Cluster cluster;
+
+    @ManyToOne
+    private InstanceGroup instanceGroup;
+
+    @OneToMany(mappedBy = "hostGroup", cascade = CascadeType.ALL, orphanRemoval = true)
+    private Set<HostMetadata> hostMetadata = new HashSet<>();
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Cluster getCluster() {
+        return cluster;
+    }
+
+    public void setCluster(Cluster cluster) {
+        this.cluster = cluster;
+    }
+
+    public InstanceGroup getInstanceGroup() {
+        return instanceGroup;
+    }
+
+    public void setInstanceGroup(InstanceGroup instanceGroup) {
+        this.instanceGroup = instanceGroup;
+    }
+
+    public Set<HostMetadata> getHostMetadata() {
+        return hostMetadata;
+    }
+
+    public void setHostMetadata(Set<HostMetadata> hostMetadata) {
+        this.hostMetadata = hostMetadata;
+    }
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
@@ -13,8 +13,7 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 @NamedQuery(
         name = "HostMetadata.findHostsInHostgroup",
         query = "SELECT h FROM HostMetadata h "
-                + "WHERE h.hostGroup= :hostGroup "
-                + "AND h.cluster.id= :clusterId")
+                + "WHERE h.hostGroup.id= :hostGroupId ")
 public class HostMetadata {
 
     @Id
@@ -23,10 +22,8 @@ public class HostMetadata {
 
     private String hostName;
 
-    private String hostGroup;
-
     @ManyToOne
-    private Cluster cluster;
+    private HostGroup hostGroup;
 
     public HostMetadata() {
 
@@ -40,30 +37,22 @@ public class HostMetadata {
         this.hostName = hostName;
     }
 
-    public String getHostGroup() {
+    public HostGroup getHostGroup() {
         return hostGroup;
     }
 
-    public void setHostGroup(String hostGroup) {
+    public void setHostGroup(HostGroup hostGroup) {
         this.hostGroup = hostGroup;
-    }
-
-    public Cluster getCluster() {
-        return cluster;
-    }
-
-    public void setCluster(Cluster cluster) {
-        this.cluster = cluster;
     }
 
     @Override
     public int hashCode() {
-        return HashCodeBuilder.reflectionHashCode(this, "cluster");
+        return HashCodeBuilder.reflectionHashCode(this, "hostGroup");
     }
 
     @Override
     public boolean equals(Object obj) {
-        return EqualsBuilder.reflectionEquals(this, obj, "cluster");
+        return EqualsBuilder.reflectionEquals(this, obj, "hostGroup");
     }
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/InstanceGroup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/InstanceGroup.java
@@ -8,10 +8,18 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
 
 @Entity
+@NamedQueries({
+        @NamedQuery(name = "InstanceGroup.findOneByGroupNameInStack",
+                query = "SELECT i from InstanceGroup i "
+                        + "WHERE i.stack.id = :stackId "
+                        + "AND i.groupName = :groupName")
+})
 public class InstanceGroup implements ProvisionEntity, Comparable {
     @Id
     @GeneratedValue

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/InstanceMetaData.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/InstanceMetaData.java
@@ -22,6 +22,12 @@ import javax.persistence.NamedQuery;
                         + "AND i.terminated = false "
                         + "AND i.removable= true"),
         @NamedQuery(
+                name = "InstanceMetaData.findUnregisteredHostsInInstanceGroup",
+                query = "SELECT i FROM InstanceMetaData i "
+                        + "WHERE i.instanceGroup.id= :instanceGroupId "
+                        + "AND i.terminated = false "
+                        + "AND i.removable = true"),
+        @NamedQuery(
                 name = "InstanceMetaData.findAllInStack",
                 query = "SELECT i FROM InstanceMetaData i "
                         + "WHERE i.instanceGroup.stack.id= :stackId "
@@ -29,7 +35,11 @@ import javax.persistence.NamedQuery;
         @NamedQuery(
                 name = "InstanceMetaData.findByInstanceId",
                 query = "SELECT i FROM InstanceMetaData i "
-                        + "WHERE i.instanceId= :instanceId")
+                        + "WHERE i.instanceId= :instanceId"),
+        @NamedQuery(
+                name = "InstanceMetaData.findHostNamesInInstanceGroup",
+                query = "SELECT i.longName FROM InstanceMetaData i "
+                        + "WHERE i.instanceGroup.id= :instanceGroupId")
 })
 public class InstanceMetaData implements ProvisionEntity {
 

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/StackValidation.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/StackValidation.java
@@ -3,8 +3,17 @@ package com.sequenceiq.cloudbreak.domain;
 import java.util.Set;
 
 public class StackValidation implements ProvisionEntity {
+    private Set<HostGroup> hostGroups;
     private Set<InstanceGroup> instanceGroups;
     private Blueprint blueprint;
+
+    public Set<HostGroup> getHostGroups() {
+        return hostGroups;
+    }
+
+    public void setHostGroups(Set<HostGroup> hostGroups) {
+        this.hostGroups = hostGroups;
+    }
 
     public Set<InstanceGroup> getInstanceGroups() {
         return instanceGroups;

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/HostGroupRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/HostGroupRepository.java
@@ -1,0 +1,15 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import java.util.Set;
+
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+import com.sequenceiq.cloudbreak.domain.HostGroup;
+
+public interface HostGroupRepository extends CrudRepository<HostGroup, Long> {
+
+    Set<HostGroup> findHostGroupsInCluster(@Param("clusterId") Long clusterId);
+
+    HostGroup findHostGroupInClusterByName(@Param("clusterId") Long clusterId, @Param("hostGroupName") String hostGroupName);
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
@@ -9,6 +9,6 @@ import com.sequenceiq.cloudbreak.domain.HostMetadata;
 
 public interface HostMetadataRepository extends CrudRepository<HostMetadata, Long> {
 
-    Set<HostMetadata> findHostsInHostgroup(@Param("hostGroup") String hostGroup, @Param("clusterId") Long clusterId);
+    Set<HostMetadata> findHostsInHostgroup(@Param("hostGroupId") Long hostGroupId);
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceGroupRepository.java
@@ -9,6 +9,6 @@ public interface InstanceGroupRepository extends CrudRepository<InstanceGroup, L
 
     InstanceGroup findOne(@Param("id") Long id);
 
-    InstanceGroup findOneByGroupName(@Param("groupName") String groupName);
+    InstanceGroup findOneByGroupNameInStack(@Param("stackId") Long stackId, @Param("groupName") String groupName);
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.repository;
 
+import java.util.List;
 import java.util.Set;
 
 import org.springframework.data.repository.CrudRepository;
@@ -15,6 +16,10 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
 
     InstanceMetaData findHostInStack(@Param("stackId") Long stackId, @Param("hostName") String hostName);
 
-    Set<InstanceMetaData> findUnregisteredHostsInStack(@Param("stackId") Long stackId);
+//    Set<InstanceMetaData> findUnregisteredHostsInStack(@Param("stackId") Long stackId);
+
+    Set<InstanceMetaData> findUnregisteredHostsInInstanceGroup(@Param("instanceGroupId") Long instanceGroupId);
+
+    List<String> findHostNamesInInstanceGroup(@Param("instanceGroupId") Long instanceGroupId);
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/InstanceMetaDataRepository.java
@@ -16,8 +16,6 @@ public interface InstanceMetaDataRepository extends CrudRepository<InstanceMetaD
 
     InstanceMetaData findHostInStack(@Param("stackId") Long stackId, @Param("hostName") String hostName);
 
-//    Set<InstanceMetaData> findUnregisteredHostsInStack(@Param("stackId") Long stackId);
-
     Set<InstanceMetaData> findUnregisteredHostsInInstanceGroup(@Param("instanceGroupId") Long instanceGroupId);
 
     List<String> findHostNamesInInstanceGroup(@Param("instanceGroupId") Long instanceGroupId);

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/RecipeRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/RecipeRepository.java
@@ -4,10 +4,14 @@ import java.util.Set;
 
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.data.repository.query.Param;
+import org.springframework.security.access.prepost.PostAuthorize;
 
 import com.sequenceiq.cloudbreak.domain.Recipe;
 
 public interface RecipeRepository extends CrudRepository<Recipe, Long> {
+
+    @PostAuthorize("hasPermission(returnObject,'read')")
+    Recipe findOne(@Param("id") Long id);
 
     Recipe findByNameInAccount(@Param("name") String name, @Param("account") String account);
 

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/RetryingStackUpdater.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/RetryingStackUpdater.java
@@ -200,12 +200,12 @@ public class RetryingStackUpdater {
         }
     }
 
-    public Stack updateNodeCount(Long stackId, Integer nodeCount, String hostGroup) {
+    public Stack updateNodeCount(Long stackId, Integer nodeCount, String instanceGroup) {
         Stack stack = stackRepository.findById(stackId);
         MDCBuilder.buildMdcContext(stack);
         int attempt = 1;
         try {
-            return doUpdateNodeCount(stackId, nodeCount, hostGroup);
+            return doUpdateNodeCount(stackId, nodeCount, instanceGroup);
         } catch (OptimisticLockException | OptimisticLockingFailureException e) {
             if (attempt <= MAX_RETRIES) {
                 LOGGER.info("Failed to update stack while trying to set 'nodecount'. [attempt: '{}', Cause: {}]. Trying to save it again.",
@@ -281,10 +281,10 @@ public class RetryingStackUpdater {
         return stack;
     }
 
-    private Stack doUpdateNodeCount(Long stackId, Integer nodeCount, String hostGroup) {
+    private Stack doUpdateNodeCount(Long stackId, Integer nodeCount, String instanceGroup) {
         Stack stack = stackRepository.findById(stackId);
         MDCBuilder.buildMdcContext(stack);
-        stack.getInstanceGroupByInstanceGroupName(hostGroup).setNodeCount(nodeCount);
+        stack.getInstanceGroupByInstanceGroupName(instanceGroup).setNodeCount(nodeCount);
         stack = stackRepository.save(stack);
         LOGGER.info("Updated stack: [nodeCount: '{}'].", nodeCount);
         return stack;

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterService.java
@@ -164,6 +164,9 @@ public class AmbariClusterService implements ClusterService {
     public void updateStatus(Long stackId, StatusRequest statusRequest) {
         Stack stack = stackRepository.findOne(stackId);
         Cluster cluster = stack.getCluster();
+        if (cluster == null) {
+            throw new BadRequestException(String.format("There is no cluster installed on stack '%s'.", stackId));
+        }
         MDCBuilder.buildMdcContext(stack.getCluster());
         long clusterId = cluster.getId();
         Status clusterStatus = cluster.getStatus();

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -3,8 +3,8 @@ package com.sequenceiq.cloudbreak.service.stack;
 import java.util.List;
 import java.util.Set;
 
-import com.sequenceiq.cloudbreak.controller.json.HostGroupAdjustmentJson;
 import com.sequenceiq.cloudbreak.domain.StackValidation;
+import com.sequenceiq.cloudbreak.controller.json.InstanceGroupAdjustmentJson;
 import com.sequenceiq.cloudbreak.domain.CbUser;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.Stack;
@@ -35,7 +35,7 @@ public interface StackService {
 
     void delete(String name, CbUser cbUser);
 
-    void updateNodeCount(Long stackId, HostGroupAdjustmentJson hostGroupAdjustmentJson);
+    void updateNodeCount(Long stackId, InstanceGroupAdjustmentJson instanceGroupAdjustmentJson);
 
     void updateAllowedSubnets(Long stackId, List<Subnet> subnetList);
 

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/CloudPlatformConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/CloudPlatformConnector.java
@@ -12,9 +12,9 @@ public interface CloudPlatformConnector {
 
     void buildStack(Stack stack, String userData, Map<String, Object> setupProperties);
 
-    boolean addInstances(Stack stack, String userData, Integer instanceCount, String hostGroup);
+    boolean addInstances(Stack stack, String userData, Integer instanceCount, String instanceGroup);
 
-    boolean removeInstances(Stack stack, Set<String> instanceIds, String hostGroup);
+    boolean removeInstances(Stack stack, Set<String> instanceIds, String instanceGroup);
 
     void deleteStack(Stack stack, Credential credential);
 

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/MetadataSetup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/MetadataSetup.java
@@ -10,7 +10,7 @@ public interface MetadataSetup {
 
     void setupMetadata(Stack stack);
 
-    void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String hostGroup);
+    void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String instanceGroup);
 
     CloudPlatform getCloudPlatform();
 

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsMetadataSetup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsMetadataSetup.java
@@ -112,7 +112,7 @@ public class AwsMetadataSetup implements MetadataSetup {
     }
 
     @Override
-    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String hostGroup) {
+    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String instanceGroupName) {
         MDCBuilder.buildMdcContext(stack);
         Set<CoreInstanceMetaData> coreInstanceMetadata = new HashSet<>();
         LOGGER.info("Adding new instances to metadata: [stack: '{}']", stack.getId());
@@ -136,7 +136,7 @@ public class AwsMetadataSetup implements MetadataSetup {
                         coreInstanceMetadata.add(new CoreInstanceMetaData(
                                 instance.getInstanceId(),
                                 instance.getPrivateIpAddress(),
-                                instance.getPublicDnsName(),
+                                instance.getPublicIpAddress(),
                                 instance.getBlockDeviceMappings().size() - 1,
                                 instance.getPrivateDnsName(),
                                 instanceGroup
@@ -148,7 +148,7 @@ public class AwsMetadataSetup implements MetadataSetup {
         }
         LOGGER.info("Publishing {} event [StackId: '{}']", ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT, stack.getId());
         reactor.notify(ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT,
-                Event.wrap(new MetadataUpdateComplete(CloudPlatform.AWS, stack.getId(), coreInstanceMetadata, hostGroup)));
+                Event.wrap(new MetadataUpdateComplete(CloudPlatform.AWS, stack.getId(), coreInstanceMetadata, instanceGroupName)));
     }
 
     @Override

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationStackUtil.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationStackUtil.java
@@ -24,16 +24,16 @@ public class CloudFormationStackUtil {
     @Autowired
     private AwsStackUtil awsStackUtil;
 
-    public String getAutoscalingGroupName(Stack stack, String hostGroup) {
+    public String getAutoscalingGroupName(Stack stack, String instanceGroup) {
         AwsCredential awsCredential = (AwsCredential) stack.getCredential();
         AmazonCloudFormationClient amazonCfClient = awsStackUtil.createCloudFormationClient(Regions.valueOf(stack.getRegion()), awsCredential);
-        return getAutoscalingGroupName(stack, amazonCfClient, hostGroup);
+        return getAutoscalingGroupName(stack, amazonCfClient, instanceGroup);
     }
 
-    public String getAutoscalingGroupName(Stack stack, AmazonCloudFormationClient amazonCFClient, String hostGroup) {
+    public String getAutoscalingGroupName(Stack stack, AmazonCloudFormationClient amazonCFClient, String instanceGroup) {
         DescribeStackResourceResult asGroupResource = amazonCFClient.describeStackResource(new DescribeStackResourceRequest()
                 .withStackName(stack.getResourcesByType(ResourceType.CLOUDFORMATION_STACK).get(0).getResourceName())
-                .withLogicalResourceId(String.format("AmbariNodes%s", hostGroup.replaceAll("_", ""))));
+                .withLogicalResourceId(String.format("AmbariNodes%s", instanceGroup.replaceAll("_", ""))));
         return asGroupResource.getStackResourceDetail().getPhysicalResourceId();
     }
 
@@ -41,17 +41,17 @@ public class CloudFormationStackUtil {
         return String.format("%s-%s", stack.getName(), stack.getId());
     }
 
-    public List<String> getInstanceIds(Stack stack, String hostGroup) {
+    public List<String> getInstanceIds(Stack stack, String instanceGroup) {
         AwsCredential awsCredential = (AwsCredential) stack.getCredential();
         AmazonAutoScalingClient amazonASClient = awsStackUtil.createAutoScalingClient(Regions.valueOf(stack.getRegion()), awsCredential);
         AmazonCloudFormationClient amazonCFClient = awsStackUtil.createCloudFormationClient(Regions.valueOf(stack.getRegion()), awsCredential);
-        return getInstanceIds(stack, amazonASClient, amazonCFClient, hostGroup);
+        return getInstanceIds(stack, amazonASClient, amazonCFClient, instanceGroup);
     }
 
-    public List<String> getInstanceIds(Stack stack, AmazonAutoScalingClient amazonASClient, AmazonCloudFormationClient amazonCFClient, String hostGroup) {
+    public List<String> getInstanceIds(Stack stack, AmazonAutoScalingClient amazonASClient, AmazonCloudFormationClient amazonCFClient, String instanceGroup) {
         DescribeAutoScalingGroupsResult describeAutoScalingGroupsResult = amazonASClient
                 .describeAutoScalingGroups(new DescribeAutoScalingGroupsRequest()
-                        .withAutoScalingGroupNames(getAutoscalingGroupName(stack, amazonCFClient, hostGroup)));
+                        .withAutoScalingGroupNames(getAutoscalingGroupName(stack, amazonCFClient, instanceGroup)));
         List<String> instanceIds = new ArrayList<>();
         if (describeAutoScalingGroupsResult.getAutoScalingGroups().get(0).getInstances() != null) {
             for (Instance instance : describeAutoScalingGroupsResult.getAutoScalingGroups().get(0).getInstances()) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureMetadataSetup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureMetadataSetup.java
@@ -67,7 +67,7 @@ public class AzureMetadataSetup implements MetadataSetup {
     }
 
     @Override
-    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String hostGroup) {
+    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String instanceGroup) {
         MDCBuilder.buildMdcContext(stack);
         AzureCredential azureCredential = (AzureCredential) stack.getCredential();
         AzureClient azureClient = azureStackUtil.createAzureClient(azureCredential);
@@ -80,7 +80,7 @@ public class AzureMetadataSetup implements MetadataSetup {
         Set<CoreInstanceMetaData> instanceMetaDatas = collectMetaData(stack, azureClient, resources);
         LOGGER.info("Publishing {} event [StackId: '{}']", ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT, stack.getId());
         reactor.notify(ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT,
-                Event.wrap(new MetadataUpdateComplete(CloudPlatform.AZURE, stack.getId(), instanceMetaDatas, hostGroup)));
+                Event.wrap(new MetadataUpdateComplete(CloudPlatform.AZURE, stack.getId(), instanceMetaDatas, instanceGroup)));
     }
 
     private Set<CoreInstanceMetaData> collectMetaData(Stack stack, AzureClient azureClient, List<Resource> resources) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/gcc/GccMetadataSetup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/gcc/GccMetadataSetup.java
@@ -56,7 +56,7 @@ public class GccMetadataSetup implements MetadataSetup {
     }
 
     @Override
-    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String hostGroup) {
+    public void addNewNodesToMetadata(Stack stack, Set<Resource> resourceList, String instanceGroup) {
         MDCBuilder.buildMdcContext(stack);
         List<Resource> resources = new ArrayList<>();
         for (Resource resource : resourceList) {
@@ -67,7 +67,7 @@ public class GccMetadataSetup implements MetadataSetup {
         Set<CoreInstanceMetaData> instanceMetaDatas = collectMetaData(stack, resources);
         LOGGER.info("Publishing {} event [StackId: '{}']", ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT, stack.getId());
         reactor.notify(ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT,
-                Event.wrap(new MetadataUpdateComplete(CloudPlatform.GCC, stack.getId(), instanceMetaDatas, hostGroup)));
+                Event.wrap(new MetadataUpdateComplete(CloudPlatform.GCC, stack.getId(), instanceMetaDatas, instanceGroup)));
     }
 
     private CoreInstanceMetaData getMetadata(Stack stack, Compute compute, Resource resource) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/AddInstancesComplete.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/AddInstancesComplete.java
@@ -8,12 +8,12 @@ import com.sequenceiq.cloudbreak.domain.Resource;
 public class AddInstancesComplete extends ProvisionEvent {
 
     private Set<Resource> resources;
-    private String hostGroup;
+    private String instanceGroup;
 
-    public AddInstancesComplete(CloudPlatform cloudPlatform, Long stackId, Set<Resource> resources, String hostGroup) {
+    public AddInstancesComplete(CloudPlatform cloudPlatform, Long stackId, Set<Resource> resources, String instanceGroup) {
         super(cloudPlatform, stackId);
         this.resources = resources;
-        this.hostGroup = hostGroup;
+        this.instanceGroup = instanceGroup;
     }
 
     public Set<Resource> getResources() {
@@ -24,11 +24,11 @@ public class AddInstancesComplete extends ProvisionEvent {
         this.resources = resources;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public String getInstanceGroup() {
+        return instanceGroup;
     }
 
-    public void setHostGroup(String hostGroup) {
-        this.hostGroup = hostGroup;
+    public void setInstanceGroup(String instanceGroup) {
+        this.instanceGroup = instanceGroup;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/MetadataUpdateComplete.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/MetadataUpdateComplete.java
@@ -8,12 +8,12 @@ import com.sequenceiq.cloudbreak.service.stack.flow.CoreInstanceMetaData;
 
 public class MetadataUpdateComplete extends ProvisionEvent {
     private Set<CoreInstanceMetaData> coreInstanceMetaData = new HashSet<>();
-    private String hostGroup;
+    private String instanceGroup;
 
-    public MetadataUpdateComplete(CloudPlatform cloudPlatform, Long stackId, Set<CoreInstanceMetaData> coreInstanceMetaData, String hostGroup) {
+    public MetadataUpdateComplete(CloudPlatform cloudPlatform, Long stackId, Set<CoreInstanceMetaData> coreInstanceMetaData, String instanceGroup) {
         super(cloudPlatform, stackId);
         this.coreInstanceMetaData = coreInstanceMetaData;
-        this.hostGroup = hostGroup;
+        this.instanceGroup = instanceGroup;
     }
 
     public Set<CoreInstanceMetaData> getCoreInstanceMetaData() {
@@ -24,11 +24,11 @@ public class MetadataUpdateComplete extends ProvisionEvent {
         this.coreInstanceMetaData = coreInstanceMetaData;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public String getInstanceGroup() {
+        return instanceGroup;
     }
 
-    public void setHostGroup(String hostGroup) {
-        this.hostGroup = hostGroup;
+    public void setInstanceGroup(String instanceGroup) {
+        this.instanceGroup = instanceGroup;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/StackUpdateSuccess.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/StackUpdateSuccess.java
@@ -7,13 +7,13 @@ public class StackUpdateSuccess {
     private Long stackId;
     private boolean removeInstances;
     private Set<String> instanceIds;
-    private String hostGroup;
+    private String instanceGroup;
 
-    public StackUpdateSuccess(Long stackId, boolean removeInstances, Set<String> instanceIds, String hostGroup) {
+    public StackUpdateSuccess(Long stackId, boolean removeInstances, Set<String> instanceIds, String instanceGroup) {
         this.stackId = stackId;
         this.removeInstances = removeInstances;
         this.instanceIds = instanceIds;
-        this.hostGroup = hostGroup;
+        this.instanceGroup = instanceGroup;
     }
 
     public Long getStackId() {
@@ -28,7 +28,7 @@ public class StackUpdateSuccess {
         return instanceIds;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public String getInstanceGroup() {
+        return instanceGroup;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/UpdateInstancesRequest.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/event/UpdateInstancesRequest.java
@@ -5,12 +5,12 @@ import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 public class UpdateInstancesRequest extends ProvisionEvent {
 
     private Integer scalingAdjustment;
-    private String hostGroup;
+    private String instanceGroup;
 
-    public UpdateInstancesRequest(CloudPlatform cloudPlatform, Long stackId, Integer scalingAdjustment, String hostGroup) {
+    public UpdateInstancesRequest(CloudPlatform cloudPlatform, Long stackId, Integer scalingAdjustment, String instanceGroup) {
         super(cloudPlatform, stackId);
         this.scalingAdjustment = scalingAdjustment;
-        this.hostGroup = hostGroup;
+        this.instanceGroup = instanceGroup;
     }
 
     public Integer getScalingAdjustment() {
@@ -21,11 +21,11 @@ public class UpdateInstancesRequest extends ProvisionEvent {
         this.scalingAdjustment = scalingAdjustment;
     }
 
-    public String getHostGroup() {
-        return hostGroup;
+    public String getInstanceGroup() {
+        return instanceGroup;
     }
 
-    public void setHostGroup(String hostGroup) {
-        this.hostGroup = hostGroup;
+    public void setInstanceGroup(String instanceGroup) {
+        this.instanceGroup = instanceGroup;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupContext.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/MetadataSetupContext.java
@@ -48,11 +48,11 @@ public class MetadataSetupContext {
         }
     }
 
-    public void updateMetadata(CloudPlatform cloudPlatform, Long stackId, Set<Resource> resourceSet, String hostGroup) {
+    public void updateMetadata(CloudPlatform cloudPlatform, Long stackId, Set<Resource> resourceSet, String instanceGroup) {
         Stack stack = stackRepository.findOneWithLists(stackId);
         MDCBuilder.buildMdcContext(stack);
         try {
-            metadataSetups.get(cloudPlatform).addNewNodesToMetadata(stack, resourceSet, hostGroup);
+            metadataSetups.get(cloudPlatform).addNewNodesToMetadata(stack, resourceSet, instanceGroup);
         } catch (Exception e) {
             String errMessage = "Unhandled exception occurred while updating stack metadata.";
             LOGGER.error(errMessage, e);

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/AddInstancesCompleteHandler.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/AddInstancesCompleteHandler.java
@@ -24,6 +24,6 @@ public class AddInstancesCompleteHandler implements Consumer<Event<AddInstancesC
     public void accept(Event<AddInstancesComplete> event) {
         AddInstancesComplete data = event.getData();
         LOGGER.info("Accepted {} event.", ReactorConfig.ADD_INSTANCES_COMPLETE_EVENT);
-        metadataSetupContext.updateMetadata(data.getCloudPlatform(), data.getStackId(), event.getData().getResources(), data.getHostGroup());
+        metadataSetupContext.updateMetadata(data.getCloudPlatform(), data.getStackId(), event.getData().getResources(), data.getInstanceGroup());
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/MetadataUpdateCompleteHandler.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/MetadataUpdateCompleteHandler.java
@@ -37,6 +37,6 @@ public class MetadataUpdateCompleteHandler implements Consumer<Event<MetadataUpd
         Stack stack = stackRepository.findById(stackId);
         MDCBuilder.buildMdcContext(stack);
         LOGGER.info("Accepted {} event.", ReactorConfig.METADATA_UPDATE_COMPLETE_EVENT, stackId);
-        ambariRoleAllocator.updateInstanceMetadata(stackId, coreInstanceMetaData, data.getHostGroup());
+        ambariRoleAllocator.updateInstanceMetadata(stackId, coreInstanceMetaData, data.getInstanceGroup());
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/StackStatusUpdateHandler.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/StackStatusUpdateHandler.java
@@ -246,7 +246,7 @@ public class StackStatusUpdateHandler implements Consumer<Event<StackStatusUpdat
     }
 
     private void triggerConsulEvent(Stack stack, ConsulPluginEvent event) {
-        Set<String> eventIds = pluginManager.triggerPlugins(stack.getAllInstanceMetaData(), event);
-        pluginManager.waitForEventFinish(stack, stack.getAllInstanceMetaData(), eventIds);
+        Set<String> eventIds = pluginManager.triggerPlugins(stack.getRunningInstanceMetaData(), event);
+        pluginManager.waitForEventFinish(stack, stack.getRunningInstanceMetaData(), eventIds);
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/UpdateInstancesRequestHandler.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/UpdateInstancesRequestHandler.java
@@ -116,7 +116,7 @@ public class UpdateInstancesRequestHandler implements Consumer<Event<UpdateInsta
             }
         }
         if (stack.isCloudPlatformUsedWithTemplate()) {
-            cloudPlatformConnectors.get(stack.cloudPlatform()).removeInstances(stack, instanceIds, request.getHostGroup());
+            cloudPlatformConnectors.get(stack.cloudPlatform()).removeInstances(stack, instanceIds, request.getInstanceGroup());
         } else {
             ResourceBuilderInit resourceBuilderInit = resourceBuilderInits.get(stack.cloudPlatform());
             final DeleteContextObject deleteContextObject = resourceBuilderInit.decommissionInit(stack, instanceIds);
@@ -148,7 +148,7 @@ public class UpdateInstancesRequestHandler implements Consumer<Event<UpdateInsta
                 LOGGER.info("Terminated instances in stack: '{}'", instanceIds);
                 LOGGER.info("Publishing {} event.", ReactorConfig.REMOVE_INSTANCES_COMPLETE_EVENT);
                 reactor.notify(ReactorConfig.REMOVE_INSTANCES_COMPLETE_EVENT, Event.wrap(new StackUpdateSuccess(stack.getId(), true,
-                        instanceIds, request.getHostGroup())));
+                        instanceIds, request.getInstanceGroup())));
             }
         }
     }
@@ -156,7 +156,7 @@ public class UpdateInstancesRequestHandler implements Consumer<Event<UpdateInsta
     private void upScaleStack(UpdateInstancesRequest request, Stack stack) throws Exception {
         String userDataScript = userDataBuilder.build(stack.cloudPlatform(), stack.getHash(), stack.getConsulServers(), new HashMap<String, String>());
         if (stack.isCloudPlatformUsedWithTemplate()) {
-            cloudPlatformConnectors.get(stack.cloudPlatform()).addInstances(stack, userDataScript, request.getScalingAdjustment(), request.getHostGroup());
+            cloudPlatformConnectors.get(stack.cloudPlatform()).addInstances(stack, userDataScript, request.getScalingAdjustment(), request.getInstanceGroup());
         } else {
             ResourceBuilderInit resourceBuilderInit = resourceBuilderInits.get(stack.cloudPlatform());
             final ProvisionContextObject provisionContextObject = resourceBuilderInit.provisionInit(stack, userDataScript);
@@ -174,7 +174,7 @@ public class UpdateInstancesRequestHandler implements Consumer<Event<UpdateInsta
                                 .withIndex(index)
                                 .withProvisionContextObject(provisionContextObject)
                                 .withInstanceResourceBuilders(instanceResourceBuilders)
-                                .withHostGroup(request.getHostGroup())
+                                .withInstanceGroup(request.getInstanceGroup())
                                 .build()
                 );
                 futures.add(submit);
@@ -192,7 +192,7 @@ public class UpdateInstancesRequestHandler implements Consumer<Event<UpdateInsta
                 LOGGER.info("Publishing {} event.", ReactorConfig.ADD_INSTANCES_COMPLETE_EVENT);
                 reactor.notify(ReactorConfig.ADD_INSTANCES_COMPLETE_EVENT,
                         Event.wrap(new AddInstancesComplete(stack.cloudPlatform(), stack.getId(),
-                                        collectResources(resourceRequestResults), request.getHostGroup())
+                                        collectResources(resourceRequestResults), request.getInstanceGroup())
                         )
                 );
             }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/callable/UpScaleCallable.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/handler/callable/UpScaleCallable.java
@@ -29,14 +29,14 @@ public class UpScaleCallable implements Callable<ResourceRequestResult> {
     private final Stack stack;
     private final ProvisionContextObject provisionContextObject;
     private final RetryingStackUpdater stackUpdater;
-    private final String hostGroup;
+    private final String instanceGroup;
 
-    private UpScaleCallable(Map<CloudPlatform, List<ResourceBuilder>> instanceResourceBuilders, int index, Stack stack, String hostGroup,
+    private UpScaleCallable(Map<CloudPlatform, List<ResourceBuilder>> instanceResourceBuilders, int index, Stack stack, String instanceGroup,
             ProvisionContextObject provisionContextObject, RetryingStackUpdater stackUpdater) {
         this.instanceResourceBuilders = instanceResourceBuilders;
         this.index = index;
         this.stack = stack;
-        this.hostGroup = hostGroup;
+        this.instanceGroup = instanceGroup;
         this.provisionContextObject = provisionContextObject;
         this.stackUpdater = stackUpdater;
     }
@@ -50,9 +50,9 @@ public class UpScaleCallable implements Callable<ResourceRequestResult> {
                         resourceBuilder.buildCreateRequest(provisionContextObject,
                                 resources,
                                 resourceBuilder.buildResources(provisionContextObject, index, resources,
-                                        Optional.of(stack.getInstanceGroupByInstanceGroupName(hostGroup))),
+                                        Optional.of(stack.getInstanceGroupByInstanceGroupName(instanceGroup))),
                                 index,
-                                Optional.of(stack.getInstanceGroupByInstanceGroupName(hostGroup)));
+                                Optional.of(stack.getInstanceGroupByInstanceGroupName(instanceGroup)));
                 stackUpdater.addStackResources(stack.getId(), createResourceRequest.getBuildableResources());
                 resources.addAll(createResourceRequest.getBuildableResources());
                 resourceBuilder.create(createResourceRequest, stack.getRegion());
@@ -61,13 +61,13 @@ public class UpScaleCallable implements Callable<ResourceRequestResult> {
             return ResourceRequestResult.ResourceRequestResultBuilder.builder()
                     .withException(ex)
                     .withFutureResult(FutureResult.FAILED)
-                    .withInstanceGroup(stack.getInstanceGroupByInstanceGroupName(hostGroup))
+                    .withInstanceGroup(stack.getInstanceGroupByInstanceGroupName(instanceGroup))
                     .build();
         }
         return ResourceRequestResult.ResourceRequestResultBuilder.builder()
                 .withFutureResult(FutureResult.SUCCESS)
                 .withBuildedResources(resources)
-                .withInstanceGroup(stack.getInstanceGroupByInstanceGroupName(hostGroup))
+                .withInstanceGroup(stack.getInstanceGroupByInstanceGroupName(instanceGroup))
                 .build();
     }
 
@@ -76,7 +76,7 @@ public class UpScaleCallable implements Callable<ResourceRequestResult> {
         private Map<CloudPlatform, List<ResourceBuilder>> instanceResourceBuilders = new HashMap<>();
         private int index;
         private Stack stack;
-        private String hostGroup;
+        private String instanceGroup;
         private ProvisionContextObject provisionContextObject;
         private RetryingStackUpdater stackUpdater;
 
@@ -99,8 +99,8 @@ public class UpScaleCallable implements Callable<ResourceRequestResult> {
             return this;
         }
 
-        public UpScaleCallableBuilder withHostGroup(String hostGroup) {
-            this.hostGroup = hostGroup;
+        public UpScaleCallableBuilder withInstanceGroup(String instanceGroup) {
+            this.instanceGroup = instanceGroup;
             return this;
         }
 
@@ -115,7 +115,7 @@ public class UpScaleCallable implements Callable<ResourceRequestResult> {
         }
 
         public UpScaleCallable build() {
-            return new UpScaleCallable(instanceResourceBuilders, index, stack, hostGroup, provisionContextObject, stackUpdater);
+            return new UpScaleCallable(instanceResourceBuilders, index, stack, instanceGroup, provisionContextObject, stackUpdater);
         }
 
     }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/usages/IntervalStackUsageGenerator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/usages/IntervalStackUsageGenerator.java
@@ -42,7 +42,7 @@ public class IntervalStackUsageGenerator {
     private List<PriceGenerator> priceGenerators;
 
     public List<CloudbreakUsage> generateUsages(Date startTime, Date stopTime, CloudbreakEvent startEvent) throws ParseException {
-        List<CloudbreakUsage> dailyUsagesByHostGroup = new ArrayList<>();
+        List<CloudbreakUsage> dailyUsagesByInstanceGroup = new ArrayList<>();
         Stack stack = stackRepository.findById(startEvent.getStackId());
 
         if (stack != null) {
@@ -59,10 +59,10 @@ public class IntervalStackUsageGenerator {
                 }
 
                 addCalculatedPrice(instanceGroupDailyUsages, priceGenerator, template);
-                dailyUsagesByHostGroup.addAll(instanceGroupDailyUsages.values());
+                dailyUsagesByInstanceGroup.addAll(instanceGroupDailyUsages.values());
             }
         }
-        return dailyUsagesByHostGroup;
+        return dailyUsagesByInstanceGroup;
     }
 
     private String getInstanceType(Template template) {
@@ -127,7 +127,7 @@ public class IntervalStackUsageGenerator {
         usage.setStackId(event.getStackId());
         usage.setStackName(event.getStackName());
         usage.setInstanceType(instanceType);
-        usage.setHostGroup(groupName);
+        usage.setInstanceGroup(groupName);
         return usage;
     }
 

--- a/src/main/resources/templates/aws-cf-stack.ftl
+++ b/src/main/resources/templates/aws-cf-stack.ftl
@@ -192,7 +192,7 @@
         "DesiredCapacity" : ${tgroup.nodeCount},
         "Tags" : [ { "Key" : "Name", "Value" : { "Ref" : "StackName" }, "PropagateAtLaunch" : "true" },
         		   { "Key" : "owner", "Value" : { "Ref" : "StackOwner" }, "PropagateAtLaunch" : "true" },
-        		   { "Key" : "hostGroup", "Value" : "${tgroup.groupName}", "PropagateAtLaunch" : "true" }]
+        		   { "Key" : "instanceGroup", "Value" : "${tgroup.groupName}", "PropagateAtLaunch" : "true" }]
       }
     },
 

--- a/src/test/java/com/sequenceiq/cloudbreak/controller/validation/UpdateStackRequestValidatorTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/controller/validation/UpdateStackRequestValidatorTest.java
@@ -23,7 +23,7 @@ import org.hibernate.validator.internal.engine.path.PathImpl;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.sequenceiq.cloudbreak.controller.json.HostGroupAdjustmentJson;
+import com.sequenceiq.cloudbreak.controller.json.InstanceGroupAdjustmentJson;
 import com.sequenceiq.cloudbreak.controller.json.UpdateStackJson;
 import com.sequenceiq.cloudbreak.domain.StatusRequest;
 
@@ -46,7 +46,7 @@ public class UpdateStackRequestValidatorTest {
     @Test
     public void testIsValidShouldReturnTrueWhenStatusIsUpdated() {
         UpdateStackJson updateStackJson = new UpdateStackJson();
-        updateStackJson.setHostGroupAdjustment(null);
+        updateStackJson.setInstanceGroupAdjustment(null);
         updateStackJson.setStatus(StatusRequest.STARTED);
         boolean valid = underTest.isValid(updateStackJson, constraintValidatorContext);
         assertTrue(valid);
@@ -55,10 +55,10 @@ public class UpdateStackRequestValidatorTest {
     @Test
     public void testIsValidShouldReturnTrueWhenNodeCountIsUpdated() {
         UpdateStackJson updateStackJson = new UpdateStackJson();
-        HostGroupAdjustmentJson hostGroupAdjustmentJson = new HostGroupAdjustmentJson();
-        hostGroupAdjustmentJson.setScalingAdjustment(12);
-        hostGroupAdjustmentJson.setHostGroup("slave_1");
-        updateStackJson.setHostGroupAdjustment(hostGroupAdjustmentJson);
+        InstanceGroupAdjustmentJson instanceGroupAdjustmentJson = new InstanceGroupAdjustmentJson();
+        instanceGroupAdjustmentJson.setScalingAdjustment(12);
+        instanceGroupAdjustmentJson.setInstanceGroup("slave_1");
+        updateStackJson.setInstanceGroupAdjustment(instanceGroupAdjustmentJson);
         updateStackJson.setStatus(null);
         boolean valid = underTest.isValid(updateStackJson, constraintValidatorContext);
         assertTrue(valid);
@@ -67,19 +67,20 @@ public class UpdateStackRequestValidatorTest {
     @Test
     public void testIsValidShouldReturnFalseWhenRequestContainsNodeCountAndStatus() {
         UpdateStackJson updateStackJson = new UpdateStackJson();
-        HostGroupAdjustmentJson hostGroupAdjustmentJson = new HostGroupAdjustmentJson();
-        hostGroupAdjustmentJson.setScalingAdjustment(4);
-        hostGroupAdjustmentJson.setHostGroup("slave_1");
+        InstanceGroupAdjustmentJson instanceGroupAdjustmentJson = new InstanceGroupAdjustmentJson();
+        instanceGroupAdjustmentJson.setScalingAdjustment(4);
+        instanceGroupAdjustmentJson.setInstanceGroup("slave_1");
         updateStackJson.setStatus(StatusRequest.STARTED);
+        updateStackJson.setInstanceGroupAdjustment(instanceGroupAdjustmentJson);
         boolean valid = underTest.isValid(updateStackJson, constraintValidatorContext);
-        assertTrue(valid);
+        assertFalse(valid);
     }
 
     @Test
     public void testIsValidShouldReturnFalseWhenRequestContainsOnlyNulls() {
 
         UpdateStackJson updateStackJson = new UpdateStackJson();
-        updateStackJson.setHostGroupAdjustment(null);
+        updateStackJson.setInstanceGroupAdjustment(null);
         updateStackJson.setStatus(null);
         updateStackJson.setAllowedSubnets(null);
         boolean valid = underTest.isValid(updateStackJson, constraintValidatorContext);

--- a/src/test/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidatorTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/controller/validation/blueprint/BlueprintValidatorTest.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.controller.validation.blueprint;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Set;
 
 import org.junit.Before;
@@ -19,6 +20,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
+import com.sequenceiq.cloudbreak.domain.HostGroup;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -27,6 +29,7 @@ public class BlueprintValidatorTest {
     private static final String GROUP1 = "group1";
     private static final String GROUP2 = "group2";
     private static final String GROUP3 = "group3";
+    private static final String GROUP4 = "group4";
     private static final String COMPONENT1 = "comp1";
     private static final String COMPONENT2 = "comp2";
     private static final String COMPONENT3 = "comp3";
@@ -50,9 +53,10 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         BDDMockito.given(objectMapper.readTree(BDDMockito.anyString())).willThrow(new IOException());
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
     }
 
@@ -61,10 +65,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTreeWithUnknownHostGroup();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
     }
 
@@ -73,10 +78,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTreeWithIllegalGroup();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
     }
 
@@ -85,10 +91,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTreeWithTooMuchGroup();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
     }
 
@@ -97,10 +104,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTreeWithNotEnoughGroup();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
     }
 
@@ -109,10 +117,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTreeWithComponentInMoreGroups();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN throw exception
     }
 
@@ -121,10 +130,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTree();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN doesn't throw exception
     }
 
@@ -133,10 +143,11 @@ public class BlueprintValidatorTest {
         // GIVEN
         Blueprint blueprint = createBlueprint();
         Set<InstanceGroup> instanceGroups = createInstanceGroups();
+        Set<HostGroup> hostGroups = createHostGroups(instanceGroups);
         JsonNode blueprintJsonTree = createJsonTreeWithUnknownComponent();
         BDDMockito.given(objectMapper.readTree(BLUEPRINT_STRING)).willReturn(blueprintJsonTree);
         // WHEN
-        underTest.validateBlueprintForStack(blueprint, instanceGroups);
+        underTest.validateBlueprintForStack(blueprint, hostGroups, instanceGroups);
         // THEN doesn't throw exception
     }
 
@@ -168,6 +179,21 @@ public class BlueprintValidatorTest {
         return group;
     }
 
+    private Set<HostGroup> createHostGroups(Set<InstanceGroup> instanceGroups) {
+        Set<HostGroup> groups = Sets.newHashSet();
+        for (InstanceGroup instanceGroup : new ArrayList<InstanceGroup>(instanceGroups)) {
+            groups.add(createHostGroup(instanceGroup.getGroupName(), instanceGroup));
+        }
+        return groups;
+    }
+
+    private HostGroup createHostGroup(String groupName, InstanceGroup instanceGroup) {
+        HostGroup group = new HostGroup();
+        group.setName(groupName);
+        group.setInstanceGroup(instanceGroup);
+        return group;
+    }
+
     private JsonNode createJsonTreeWithUnknownHostGroup() {
         JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
         ObjectNode rootNode = jsonNodeFactory.objectNode();
@@ -194,7 +220,7 @@ public class BlueprintValidatorTest {
         addHostGroup(hostGroupsNode, GROUP1, COMPONENT2);
         addHostGroup(hostGroupsNode, GROUP2, COMPONENT1);
         addHostGroup(hostGroupsNode, GROUP3, COMPONENT3);
-        addHostGroup(hostGroupsNode, GROUP3, SLAVE_COMPONENT);
+        addHostGroup(hostGroupsNode, GROUP4, SLAVE_COMPONENT);
         return rootNode;
     }
 

--- a/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterServiceTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterServiceTest.java
@@ -38,11 +38,12 @@ import com.sequenceiq.cloudbreak.controller.json.HostGroupAdjustmentJson;
 import com.sequenceiq.cloudbreak.converter.ClusterConverter;
 import com.sequenceiq.cloudbreak.domain.Blueprint;
 import com.sequenceiq.cloudbreak.domain.Cluster;
+import com.sequenceiq.cloudbreak.domain.HostGroup;
 import com.sequenceiq.cloudbreak.domain.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.repository.ClusterRepository;
-import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
+import com.sequenceiq.cloudbreak.repository.HostGroupRepository;
 import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
 import com.sequenceiq.cloudbreak.repository.RetryingStackUpdater;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
@@ -87,7 +88,7 @@ public class AmbariClusterServiceTest {
     private HostFilterService hostFilterService;
 
     @Mock
-    private HostMetadataRepository hostMetadataRepository;
+    private HostGroupRepository hostGroupRepository;
 
     @Mock
     private AmbariConfigurationService configurationService;
@@ -171,7 +172,10 @@ public class AmbariClusterServiceTest {
         HostMetadata metadata3 = mock(HostMetadata.class);
         Set<HostMetadata> hostsMetaData = new HashSet<>();
         hostsMetaData.addAll(asList(metadata1, metadata2, metadata3));
-        when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setHostMetadata(hostsMetaData);
+        hostGroup.setName("slave_1");
+        when(hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), "slave_1")).thenReturn(hostGroup);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
         when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "2"));
@@ -199,7 +203,10 @@ public class AmbariClusterServiceTest {
         Set<HostMetadata> hostsMetaData = new HashSet<>();
         List<HostMetadata> hostsMetadataList = asList(metadata1, metadata2, metadata3);
         hostsMetaData.addAll(hostsMetadataList);
-        when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setHostMetadata(hostsMetaData);
+        hostGroup.setName("slave_1");
+        when(hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), "slave_1")).thenReturn(hostGroup);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
         when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "2"));
@@ -231,6 +238,9 @@ public class AmbariClusterServiceTest {
         InstanceMetaData instanceMetaData4 = mock(InstanceMetaData.class);
         Set<HostMetadata> hostsMetaData = new HashSet<>(asList(metadata1, metadata2, metadata3, metadata4));
         List<HostMetadata> hostsMetadataList = asList(metadata2, metadata3, metadata4);
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setHostMetadata(hostsMetaData);
+        hostGroup.setName("slave_1");
         Map<String, Map<Long, Long>> dfsSpace = new HashMap<>();
         dfsSpace.put("node2", singletonMap(85_000L, 15_000L));
         dfsSpace.put("node1", singletonMap(90_000L, 10_000L));
@@ -244,7 +254,7 @@ public class AmbariClusterServiceTest {
         when(instanceMetaData2.getAmbariServer()).thenReturn(false);
         when(instanceMetaData3.getAmbariServer()).thenReturn(false);
         when(instanceMetaData4.getAmbariServer()).thenReturn(false);
-        when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
+        when(hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), "slave_1")).thenReturn(hostGroup);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
         when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "1"));
@@ -279,6 +289,9 @@ public class AmbariClusterServiceTest {
         Set<HostMetadata> hostsMetaData = new HashSet<>();
         List<HostMetadata> hostsMetadataList = asList(metadata1, metadata2, metadata3);
         hostsMetaData.addAll(hostsMetadataList);
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setHostMetadata(hostsMetaData);
+        hostGroup.setName("slave_1");
         Map<String, Map<Long, Long>> dfsSpace = new HashMap<>();
         dfsSpace.put("node2", singletonMap(85_000L, 15_000L));
         dfsSpace.put("node1", singletonMap(90_000L, 10_000L));
@@ -289,7 +302,7 @@ public class AmbariClusterServiceTest {
         when(instanceMetaData1.getAmbariServer()).thenReturn(false);
         when(instanceMetaData2.getAmbariServer()).thenReturn(false);
         when(instanceMetaData3.getAmbariServer()).thenReturn(false);
-        when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
+        when(hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), "slave_1")).thenReturn(hostGroup);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
         when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "1"));
@@ -325,6 +338,9 @@ public class AmbariClusterServiceTest {
         Set<HostMetadata> hostsMetaData = new HashSet<>();
         List<HostMetadata> hostsMetadataList = asList(metadata1, metadata2, metadata3, metadata4);
         hostsMetaData.addAll(hostsMetadataList);
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setHostMetadata(hostsMetaData);
+        hostGroup.setName("slave_1");
         Map<String, Map<Long, Long>> dfsSpace = new HashMap<>();
         dfsSpace.put("node2", singletonMap(85_000L, 15_000L));
         dfsSpace.put("node1", singletonMap(90_000L, 10_000L));
@@ -338,7 +354,7 @@ public class AmbariClusterServiceTest {
         when(instanceMetaData2.getAmbariServer()).thenReturn(false);
         when(instanceMetaData3.getAmbariServer()).thenReturn(false);
         when(instanceMetaData4.getAmbariServer()).thenReturn(false);
-        when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
+        when(hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), "slave_1")).thenReturn(hostGroup);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
         when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "1"));
@@ -374,6 +390,9 @@ public class AmbariClusterServiceTest {
         Set<HostMetadata> hostsMetaData = new HashSet<>();
         List<HostMetadata> hostsMetadataList = asList(metadata1, metadata2, metadata3);
         hostsMetaData.addAll(hostsMetadataList);
+        HostGroup hostGroup = new HostGroup();
+        hostGroup.setHostMetadata(hostsMetaData);
+        hostGroup.setName("slave_1");
         Map<String, Map<Long, Long>> dfsSpace = new HashMap<>();
         dfsSpace.put("node2", singletonMap(5_000L, 15_000L));
         dfsSpace.put("node1", singletonMap(10_000L, 10_000L));
@@ -384,7 +403,7 @@ public class AmbariClusterServiceTest {
         when(instanceMetaData1.getAmbariServer()).thenReturn(false);
         when(instanceMetaData2.getAmbariServer()).thenReturn(false);
         when(instanceMetaData3.getAmbariServer()).thenReturn(false);
-        when(hostMetadataRepository.findHostsInHostgroup("slave_1", cluster.getId())).thenReturn(hostsMetaData);
+        when(hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), "slave_1")).thenReturn(hostGroup);
         when(clientService.create(stack)).thenReturn(ambariClient);
         when(ambariClient.getComponentsCategory("multi-node-yarn", "slave_1")).thenReturn(singletonMap("DATANODE", "SLAVE"));
         when(configurationService.getConfiguration(ambariClient, "slave_1")).thenReturn(singletonMap(ConfigParam.DFS_REPLICATION.key(), "1"));


### PR DESCRIPTION
@doktoric 
There was some confusion in the code regarding host groups and instance groups
This PR separates the two concepts - *instance groups belong to the stack layer, host groups belong to the cluster layer*. Every host group belongs to an instance group, but they can have different names. This association must be provided when posting the cluster.
A new domain was introduced to hold the host groups - it has a name, and it contains a reference to the corresponding instance group. This domain object can be used later to hold some additional things, like recipe associations, or installed services if needed. HostMetadata entries now belong to HostGroups instead of directly to the cluster.
There are some major database changes, so the PR in the liquibase-changesets must be merged first:
- https://github.com/sequenceiq/liquibase-changesets/pull/14

This PR changes the API so changes in Uluwatu, the rest-client and the Shell are also needed, these PRs contain the necessary changes:
- https://github.com/sequenceiq/uluwatu/pull/187
- https://github.com/sequenceiq/cloudbreak-rest-client/pull/43
- https://github.com/sequenceiq/cloudbreak-shell/pull/59
- Periscope must use the new cloudbreak-rest-client version if it is built by Jenkins