### PR TITLE
Recipe improvements

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/controller/ExceptionControllerAdvice.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/ExceptionControllerAdvice.java
@@ -76,8 +76,8 @@ public class ExceptionControllerAdvice {
     @ExceptionHandler({ HttpMediaTypeNotSupportedException.class })
     public ResponseEntity<ExceptionResult> httpMediaTypeNotSupported(Exception e) {
         MDCBuilder.buildMdcContext();
-        LOGGER.info(e.getMessage());
-        return new ResponseEntity<>(new ExceptionResult(e.getMessage()), HttpStatus.BAD_REQUEST);
+        LOGGER.error(e.getMessage());
+        return new ResponseEntity<>(new ExceptionResult(e.getMessage()), HttpStatus.NOT_ACCEPTABLE);
     }
 
     @ExceptionHandler({ SubscriptionAlreadyExistException.class })

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/ExceptionControllerAdvice.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/ExceptionControllerAdvice.java
@@ -6,6 +6,7 @@ import javax.persistence.EntityNotFoundException;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.TypeMismatchException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -35,7 +36,7 @@ public class ExceptionControllerAdvice {
         return new ResponseEntity<>(new ExceptionResult(e.getMessage()), HttpStatus.UNAUTHORIZED);
     }
 
-    @ExceptionHandler({ HttpMessageNotReadableException.class, BadRequestException.class })
+    @ExceptionHandler({ TypeMismatchException.class, HttpMessageNotReadableException.class, BadRequestException.class })
     public ResponseEntity<ExceptionResult> badRequest(Exception e) {
         MDCBuilder.buildMdcContext();
         LOGGER.error(e.getMessage(), e);

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterRequest.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterRequest.java
@@ -17,7 +17,6 @@ public class ClusterRequest {
     private String name;
     @NotNull
     private Long blueprintId;
-    private Long recipeId;
     @Size(max = 1000)
     private String description;
     @Valid
@@ -47,14 +46,6 @@ public class ClusterRequest {
 
     public void setBlueprintId(Long blueprintId) {
         this.blueprintId = blueprintId;
-    }
-
-    public Long getRecipeId() {
-        return recipeId;
-    }
-
-    public void setRecipeId(Long recipeId) {
-        this.recipeId = recipeId;
     }
 
     public Set<HostGroupJson> getHostGroups() {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterResponse.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterResponse.java
@@ -13,7 +13,6 @@ public class ClusterResponse {
     private int minutesUp;
     private String cluster;
     private Long blueprintId;
-    private Long recipeId;
     private String description;
     private String statusReason;
     private Set<HostGroupJson> hostGroups;
@@ -81,14 +80,6 @@ public class ClusterResponse {
 
     public void setBlueprintId(Long blueprintId) {
         this.blueprintId = blueprintId;
-    }
-
-    public Long getRecipeId() {
-        return recipeId;
-    }
-
-    public void setRecipeId(Long recipeId) {
-        this.recipeId = recipeId;
     }
 
     public Set<HostGroupJson> getHostGroups() {

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/HostGroupJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/HostGroupJson.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.controller.json;
 
+import java.util.Set;
+
 import javax.validation.constraints.NotNull;
 
 public class HostGroupJson {
@@ -8,6 +10,7 @@ public class HostGroupJson {
     private String name;
     @NotNull
     private String instanceGroupName;
+    private Set<Long> recipeIds;
 
     public String getName() {
         return name;
@@ -23,5 +26,13 @@ public class HostGroupJson {
 
     public void setInstanceGroupName(String instanceGroupName) {
         this.instanceGroupName = instanceGroupName;
+    }
+
+    public Set<Long> getRecipeIds() {
+        return recipeIds;
+    }
+
+    public void setRecipeIds(Set<Long> recipeIds) {
+        this.recipeIds = recipeIds;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/json/RecipeJson.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/json/RecipeJson.java
@@ -1,7 +1,6 @@
 package com.sequenceiq.cloudbreak.controller.json;
 
 import java.util.Map;
-import java.util.Set;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
@@ -11,6 +10,7 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.codehaus.jackson.annotate.JsonProperty;
 
 import com.sequenceiq.cloudbreak.controller.validation.TrustedPlugin;
+import com.sequenceiq.cloudbreak.domain.PluginExecutionType;
 
 
 public class RecipeJson implements JsonEntity {
@@ -25,7 +25,7 @@ public class RecipeJson implements JsonEntity {
     private String description;
 
     @TrustedPlugin
-    private Set<String> plugins;
+    private Map<String, PluginExecutionType> plugins;
 
     @JsonProperty("properties")
     private Map<String, String> properties;
@@ -64,11 +64,11 @@ public class RecipeJson implements JsonEntity {
         this.properties = properties;
     }
 
-    public Set<String> getPlugins() {
+    public Map<String, PluginExecutionType> getPlugins() {
         return plugins;
     }
 
-    public void setPlugins(Set<String> plugins) {
+    public void setPlugins(Map<String, PluginExecutionType> plugins) {
         this.plugins = plugins;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/TrustedPluginValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/TrustedPluginValidator.java
@@ -3,6 +3,7 @@ package com.sequenceiq.cloudbreak.controller.validation;
 
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 import javax.validation.ConstraintValidator;
@@ -10,7 +11,9 @@ import javax.validation.ConstraintValidatorContext;
 
 import org.springframework.beans.factory.annotation.Value;
 
-public class TrustedPluginValidator implements ConstraintValidator<TrustedPlugin, Set<String>> {
+import com.sequenceiq.cloudbreak.domain.PluginExecutionType;
+
+public class TrustedPluginValidator implements ConstraintValidator<TrustedPlugin, Map<String, PluginExecutionType>> {
 
     private static final String PLUGIN_URL_PATTERN = "https://github.com/.*/(consul-plugins-)[a-z0-9-._]*.git";
 
@@ -24,8 +27,11 @@ public class TrustedPluginValidator implements ConstraintValidator<TrustedPlugin
     }
 
     @Override
-    public boolean isValid(Set<String> urls, ConstraintValidatorContext cxt) {
-        for (String url : urls) {
+    public boolean isValid(Map<String, PluginExecutionType> plugins, ConstraintValidatorContext cxt) {
+        if (plugins == null) {
+            return false;
+        }
+        for (String url : plugins.keySet()) {
             if (!url.matches(PLUGIN_URL_PATTERN)) {
                 return false;
             } else {

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Cluster.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Cluster.java
@@ -27,10 +27,6 @@ import javax.persistence.UniqueConstraint;
                 query = "SELECT c FROM Cluster c "
                         + "WHERE c.blueprint.id= :id"),
         @NamedQuery(
-                name = "Cluster.findAllClustersByRecipe",
-                query = "SELECT c FROM Cluster c "
-                        + "WHERE c.recipe.id= :id"),
-        @NamedQuery(
                 name = "Cluster.findOneWithLists",
                 query = "SELECT c FROM Cluster c "
                         + "LEFT JOIN FETCH c.hostGroups "
@@ -44,9 +40,6 @@ public class Cluster implements ProvisionEntity {
 
     @ManyToOne
     private Blueprint blueprint;
-
-    @ManyToOne
-    private Recipe recipe;
 
     @Column(nullable = false)
     private String name;
@@ -95,14 +88,6 @@ public class Cluster implements ProvisionEntity {
 
     public void setBlueprint(Blueprint blueprint) {
         this.blueprint = blueprint;
-    }
-
-    public Recipe getRecipe() {
-        return recipe;
-    }
-
-    public void setRecipe(Recipe recipe) {
-        this.recipe = recipe;
     }
 
     public String getName() {

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/HostGroup.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/HostGroup.java
@@ -7,6 +7,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.ManyToMany;
 import javax.persistence.ManyToOne;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
@@ -18,13 +19,20 @@ import javax.persistence.OneToMany;
                 name = "HostGroup.findHostGroupsInCluster",
                 query = "SELECT h FROM HostGroup h "
                         + "LEFT JOIN FETCH h.hostMetadata "
+                        + "LEFT JOIN FETCH h.recipes "
                         + "WHERE h.cluster.id= :clusterId"),
         @NamedQuery(
                 name = "HostGroup.findHostGroupInClusterByName",
                 query = "SELECT h FROM HostGroup h "
                         + "LEFT JOIN FETCH h.hostMetadata "
+                        + "LEFT JOIN FETCH h.recipes "
                         + "WHERE h.cluster.id= :clusterId "
-                        + "AND h.name= :hostGroupName")
+                        + "AND h.name= :hostGroupName"),
+        @NamedQuery(
+                name = "HostGroup.findAllHostGroupsByRecipe",
+                query = "SELECT h FROM HostGroup h "
+                        + "JOIN h.recipes r "
+                        + "WHERE r.id= :recipeId")
 })
 public class HostGroup {
 
@@ -43,6 +51,9 @@ public class HostGroup {
 
     @OneToMany(mappedBy = "hostGroup", cascade = CascadeType.ALL, orphanRemoval = true)
     private Set<HostMetadata> hostMetadata = new HashSet<>();
+
+    @ManyToMany
+    private Set<Recipe> recipes = new HashSet<>();
 
     public Long getId() {
         return id;
@@ -82,5 +93,13 @@ public class HostGroup {
 
     public void setHostMetadata(Set<HostMetadata> hostMetadata) {
         this.hostMetadata = hostMetadata;
+    }
+
+    public Set<Recipe> getRecipes() {
+        return recipes;
+    }
+
+    public void setRecipes(Set<Recipe> recipes) {
+        this.recipes = recipes;
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
@@ -4,16 +4,23 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 
 @Entity
-@NamedQuery(
-        name = "HostMetadata.findHostsInHostgroup",
-        query = "SELECT h FROM HostMetadata h "
-                + "WHERE h.hostGroup.id= :hostGroupId ")
+@NamedQueries({
+        @NamedQuery(
+                name = "HostMetadata.findHostsInHostgroup",
+                query = "SELECT h FROM HostMetadata h "
+                        + "WHERE h.hostGroup.id= :hostGroupId "),
+        @NamedQuery(
+                name = "HostMetadata.findHostsInCluster",
+                query = "SELECT h FROM HostMetadata h "
+                        + "WHERE h.hostGroup.cluster.id= :clusterId")
+})
 public class HostMetadata {
 
     @Id

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
@@ -13,10 +13,6 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 @Entity
 @NamedQueries({
         @NamedQuery(
-                name = "HostMetadata.findHostsInHostgroup",
-                query = "SELECT h FROM HostMetadata h "
-                        + "WHERE h.hostGroup.id= :hostGroupId "),
-        @NamedQuery(
                 name = "HostMetadata.findHostsInCluster",
                 query = "SELECT h FROM HostMetadata h "
                         + "WHERE h.hostGroup.cluster.id= :clusterId")

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/PluginExecutionType.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/PluginExecutionType.java
@@ -1,0 +1,6 @@
+package com.sequenceiq.cloudbreak.domain;
+
+public enum PluginExecutionType {
+    ONE_NODE,
+    ALL_NODES
+}

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Recipe.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Recipe.java
@@ -10,6 +10,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
+import javax.persistence.MapKeyColumn;
 import javax.persistence.NamedQueries;
 import javax.persistence.NamedQuery;
 import javax.persistence.Table;
@@ -52,11 +53,14 @@ public class Recipe implements ProvisionEntity {
     private String description;
 
     @ElementCollection(fetch = FetchType.EAGER)
+    @MapKeyColumn(name = "plugin")
+    @Column(name = "execution_type")
     @Enumerated(EnumType.STRING)
     private Map<String, PluginExecutionType> plugins;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    @Column(columnDefinition = "TEXT", length = 100000)
+    @MapKeyColumn(name = "key")
+    @Column(name = "value", columnDefinition = "TEXT", length = 100000)
     private Map<String, String> keyValues;
 
     private String account;

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Recipe.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Recipe.java
@@ -1,11 +1,12 @@
 package com.sequenceiq.cloudbreak.domain;
 
 import java.util.Map;
-import java.util.Set;
 
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -51,7 +52,8 @@ public class Recipe implements ProvisionEntity {
     private String description;
 
     @ElementCollection(fetch = FetchType.EAGER)
-    private Set<String> plugins;
+    @Enumerated(EnumType.STRING)
+    private Map<String, PluginExecutionType> plugins;
 
     @ElementCollection(fetch = FetchType.EAGER)
     @Column(columnDefinition = "TEXT", length = 100000)
@@ -95,11 +97,11 @@ public class Recipe implements ProvisionEntity {
         this.keyValues = keyValues;
     }
 
-    public Set<String> getPlugins() {
+    public Map<String, PluginExecutionType> getPlugins() {
         return plugins;
     }
 
-    public void setPlugins(Set<String> plugins) {
+    public void setPlugins(Map<String, PluginExecutionType> plugins) {
         this.plugins = plugins;
     }
 

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/ClusterRepository.java
@@ -13,8 +13,6 @@ public interface ClusterRepository extends CrudRepository<Cluster, Long> {
 
     Set<Cluster> findAllClustersByBlueprint(@Param("id") Long id);
 
-    Set<Cluster> findAllClustersByRecipe(@Param("id") Long id);
-
     Cluster findOneWithLists(@Param("id") Long id);
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/HostGroupRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/HostGroupRepository.java
@@ -12,4 +12,7 @@ public interface HostGroupRepository extends CrudRepository<HostGroup, Long> {
     Set<HostGroup> findHostGroupsInCluster(@Param("clusterId") Long clusterId);
 
     HostGroup findHostGroupInClusterByName(@Param("clusterId") Long clusterId, @Param("hostGroupName") String hostGroupName);
+
+    Set<HostGroup> findAllHostGroupsByRecipe(@Param("recipeId") Long recipeId);
+
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
@@ -9,8 +9,6 @@ import com.sequenceiq.cloudbreak.domain.HostMetadata;
 
 public interface HostMetadataRepository extends CrudRepository<HostMetadata, Long> {
 
-    Set<HostMetadata> findHostsInHostgroup(@Param("hostGroupId") Long hostGroupId);
-
     Set<HostMetadata> findHostsInCluster(@Param("clusterId") Long clusterId);
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/HostMetadataRepository.java
@@ -11,4 +11,6 @@ public interface HostMetadataRepository extends CrudRepository<HostMetadata, Lon
 
     Set<HostMetadata> findHostsInHostgroup(@Param("hostGroupId") Long hostGroupId);
 
+    Set<HostMetadata> findHostsInCluster(@Param("clusterId") Long clusterId);
+
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -140,15 +140,15 @@ public class AmbariClusterConnector {
             Blueprint blueprint = cluster.getBlueprint();
 
             AmbariClient ambariClient = clientService.create(stack);
-            if (cluster.getRecipe() != null) {
-                recipeEngine.setupRecipe(stack);
-                recipeEngine.executePreInstall(stack);
-            }
             addBlueprint(stack, ambariClient, blueprint);
             PollingResult waitForHostsResult = waitForHosts(stack, ambariClient);
             if (isSuccess(waitForHostsResult)) {
                 Map<String, List<String>> hostGroupMappings = recommend(cluster);
                 saveHostMetadata(cluster, hostGroupMappings);
+                if (cluster.getRecipe() != null) {
+                    recipeEngine.setupRecipe(stack);
+                    recipeEngine.executePreInstall(stack);
+                }
                 ambariClient.createCluster(cluster.getName(), blueprint.getBlueprintName(), hostGroupMappings);
                 PollingResult pollingResult = waitForClusterInstall(stack, ambariClient);
                 if (isSuccess(pollingResult)) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -25,6 +25,7 @@ import org.springframework.stereotype.Service;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
+import com.google.common.collect.Sets;
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.ambari.client.InvalidHostGroupHostAssociation;
 import com.sequenceiq.cloudbreak.conf.ReactorConfig;
@@ -41,7 +42,6 @@ import com.sequenceiq.cloudbreak.domain.Status;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.repository.ClusterRepository;
 import com.sequenceiq.cloudbreak.repository.HostGroupRepository;
-import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
 import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
 import com.sequenceiq.cloudbreak.repository.RetryingStackUpdater;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
@@ -57,8 +57,6 @@ import com.sequenceiq.cloudbreak.service.cluster.event.ClusterCreationFailure;
 import com.sequenceiq.cloudbreak.service.cluster.event.ClusterCreationSuccess;
 import com.sequenceiq.cloudbreak.service.cluster.event.UpdateAmbariHostsFailure;
 import com.sequenceiq.cloudbreak.service.cluster.event.UpdateAmbariHostsSuccess;
-import com.sequenceiq.cloudbreak.service.cluster.filter.HostFilterService;
-import com.sequenceiq.cloudbreak.service.cluster.flow.status.AmbariClusterStatusUpdater;
 import com.sequenceiq.cloudbreak.service.events.CloudbreakEventService;
 
 import groovyx.net.http.HttpResponseException;
@@ -80,9 +78,6 @@ public class AmbariClusterConnector {
 
     @Autowired
     private ClusterRepository clusterRepository;
-
-    @Autowired
-    private HostMetadataRepository hostMetadataRepository;
 
     @Autowired
     private InstanceMetaDataRepository instanceMetadataRepository;
@@ -109,13 +104,7 @@ public class AmbariClusterConnector {
     private AmbariClientService clientService;
 
     @Autowired
-    private HostFilterService hostFilterService;
-
-    @Autowired
     private CloudbreakEventService eventService;
-
-    @Autowired
-    private AmbariClusterStatusUpdater clusterStatusUpdater;
 
     @Autowired
     private RecipeEngine recipeEngine;
@@ -143,10 +132,12 @@ public class AmbariClusterConnector {
             addBlueprint(stack, ambariClient, blueprint);
             PollingResult waitForHostsResult = waitForHosts(stack, ambariClient);
             if (isSuccess(waitForHostsResult)) {
-                Map<String, List<String>> hostGroupMappings = recommend(cluster);
-                saveHostMetadata(cluster, hostGroupMappings);
-                if (cluster.getRecipe() != null) {
-                    recipeEngine.setupRecipe(stack);
+                Set<HostGroup> hostGroups = hostGroupRepository.findHostGroupsInCluster(cluster.getId());
+                Map<String, List<String>> hostGroupMappings = buildHostGroupAssociations(hostGroups);
+                hostGroups = saveHostMetadata(cluster, hostGroupMappings);
+                boolean recipesFound = recipesFound(hostGroups);
+                if (recipesFound) {
+                    recipeEngine.setupRecipes(stack, hostGroups);
                     recipeEngine.executePreInstall(stack);
                 }
                 ambariClient.createCluster(cluster.getName(), blueprint.getBlueprintName(), hostGroupMappings);
@@ -154,7 +145,7 @@ public class AmbariClusterConnector {
                 if (isSuccess(pollingResult)) {
                     pollingResult = runSmokeTest(stack, ambariClient);
                     if (!isExited(pollingResult)) {
-                        if (cluster.getRecipe() != null) {
+                        if (recipesFound) {
                             recipeEngine.executePostInstall(stack);
                         }
                     }
@@ -182,10 +173,11 @@ public class AmbariClusterConnector {
             if (PollingResult.SUCCESS.equals(waitForHosts(stack, ambariClient))) {
                 HostGroup hostGroup = hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), hostGroupAdjustment.getHostGroup());
                 List<String> hosts = findFreeHosts(stack.getId(), hostGroup, hostGroupAdjustment.getScalingAdjustment());
-                if (cluster.getRecipe() != null) {
-                    recipeEngine.setupRecipe(stack);
+                Set<HostGroup> hostGroupAsSet = Sets.newHashSet(hostGroup);
+                Set<HostMetadata> hostMetadata = addHostMetadata(cluster, hosts, hostGroupAdjustment);
+                if (recipesFound(hostGroupAsSet)) {
+                    recipeEngine.setupRecipesOnHosts(stack, hostGroup.getRecipes(), hostMetadata);
                 }
-                addHostMetadata(cluster, hosts, hostGroupAdjustment);
                 PollingResult pollingResult = waitForAmbariOperations(stack, ambariClient, installServices(hosts, stack, ambariClient, hostGroupAdjustment));
                 if (isSuccess(pollingResult)) {
                     pollingResult = waitForAmbariOperations(stack, ambariClient, singletonMap("START_SERVICES", ambariClient.startAllServices()));
@@ -264,6 +256,15 @@ public class AmbariClusterConnector {
 
     public boolean startCluster(Stack stack) {
         return setClusterState(stack, false);
+    }
+
+    private boolean recipesFound(Set<HostGroup> hostGroups) {
+        for (HostGroup hostGroup : hostGroups) {
+            if (!hostGroup.getRecipes().isEmpty()) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private Map<String, HostMetadata> selectHostsToRemove(List<HostMetadata> decommissionCandidates, Stack stack, int adjustment) {
@@ -384,7 +385,8 @@ public class AmbariClusterConnector {
         return stopped;
     }
 
-    private void saveHostMetadata(Cluster cluster, Map<String, List<String>> hostGroupMappings) {
+    private Set<HostGroup> saveHostMetadata(Cluster cluster, Map<String, List<String>> hostGroupMappings) {
+        Set<HostGroup> hostGroups = new HashSet<>();
         for (Entry<String, List<String>> hostGroupMapping : hostGroupMappings.entrySet()) {
             Set<HostMetadata> hostMetadata = new HashSet<>();
             HostGroup hostGroup = hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), hostGroupMapping.getKey());
@@ -395,8 +397,9 @@ public class AmbariClusterConnector {
                 hostMetadata.add(hostMetadataEntry);
             }
             hostGroup.setHostMetadata(hostMetadata);
-            hostGroupRepository.save(hostGroup);
+            hostGroups.add(hostGroupRepository.save(hostGroup));
         }
+        return hostGroups;
     }
 
     private void addBlueprint(Stack stack, AmbariClient ambariClient, Blueprint blueprint) {
@@ -425,18 +428,17 @@ public class AmbariClusterConnector {
                 MAX_ATTEMPTS_FOR_HOSTS);
     }
 
-    private Map<String, List<String>> recommend(Cluster cluster) throws InvalidHostGroupHostAssociation {
-        MDCBuilder.buildMdcContext(cluster);
+    private Map<String, List<String>> buildHostGroupAssociations(Set<HostGroup> hostGroups) throws InvalidHostGroupHostAssociation {
         Map<String, List<String>> hostGroupMappings = new HashMap<>();
-        LOGGER.info("Computing host - hostGroup mappings based on hostGroup - instanceGroup assignments");
-        for (HostGroup hostGroup : hostGroupRepository.findHostGroupsInCluster(cluster.getId())) {
+        LOGGER.info("Computing host - hostGroup mappings based on hostGroup - instanceGroup associations");
+        for (HostGroup hostGroup : hostGroups) {
             hostGroupMappings.put(hostGroup.getName(), instanceMetadataRepository.findHostNamesInInstanceGroup(hostGroup.getInstanceGroup().getId()));
         }
-        LOGGER.info("Computed host-hostGroup assignments: {}", hostGroupMappings);
+        LOGGER.info("Computed host-hostGroup associations: {}", hostGroupMappings);
         return hostGroupMappings;
     }
 
-    private void addHostMetadata(Cluster cluster, List<String> hosts, HostGroupAdjustmentJson hostGroupAdjustment) {
+    private Set<HostMetadata> addHostMetadata(Cluster cluster, List<String> hosts, HostGroupAdjustmentJson hostGroupAdjustment) {
         Set<HostMetadata> hostMetadata = new HashSet<>();
         HostGroup hostGroup = hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), hostGroupAdjustment.getHostGroup());
         for (String host : hosts) {
@@ -447,6 +449,7 @@ public class AmbariClusterConnector {
         }
         hostGroup.getHostMetadata().addAll(hostMetadata);
         hostGroupRepository.save(hostGroup);
+        return hostMetadata;
     }
 
     private PollingResult waitForClusterInstall(Stack stack, AmbariClient ambariClient) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ConsulPluginManager.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ConsulPluginManager.java
@@ -2,18 +2,27 @@ package com.sequenceiq.cloudbreak.service.cluster.flow;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.ecwid.consul.v1.ConsulClient;
+import com.ecwid.consul.v1.event.model.EventParams;
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.domain.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.PluginExecutionType;
 import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
 import com.sequenceiq.cloudbreak.service.PollingService;
 import com.sequenceiq.cloudbreak.service.cluster.PluginFailureException;
 import com.sequenceiq.cloudbreak.service.stack.flow.ConsulUtils;
@@ -33,6 +42,9 @@ public class ConsulPluginManager implements PluginManager {
     @Autowired
     private PollingService<ConsulKVCheckerContext> keyValuePollingService;
 
+    @Autowired
+    private HostMetadataRepository hostMetadataRepository;
+
     @Override
     public void prepareKeyValues(Collection<InstanceMetaData> instanceMetaData, Map<String, String> keyValues) {
         List<ConsulClient> clients = ConsulUtils.createClients(instanceMetaData);
@@ -44,19 +56,28 @@ public class ConsulPluginManager implements PluginManager {
     }
 
     @Override
-    public Set<String> installPlugins(Collection<InstanceMetaData> instanceMetaData, Collection<String> plugins) {
+    public Map<String, Set<String>> installPlugins(Collection<InstanceMetaData> instanceMetaData, Map<String, PluginExecutionType> plugins, Set<String> hosts) {
+        Map<String, Set<String>> eventIdMap = new HashMap<>();
         List<ConsulClient> clients = ConsulUtils.createClients(instanceMetaData);
-        Set<String> eventIds = new HashSet<>();
-        for (String plugin : plugins) {
-            String eventId = ConsulUtils.fireEvent(clients, INSTALL_PLUGIN_EVENT, plugin + " " + getPluginName(plugin), null, null);
+        for (Map.Entry<String, PluginExecutionType> plugin : plugins.entrySet()) {
+            Set<String> installedHosts = new HashSet<>();
+            EventParams eventParams = new EventParams();
+            if (PluginExecutionType.ONE_NODE.equals(plugin.getValue())) {
+                String installedHost = FluentIterable.from(hosts).first().get();
+                installedHosts.add(installedHost);
+                eventParams.setNode(installedHost.replace(".node.consul", ""));
+            } else {
+                installedHosts.addAll(hosts);
+            }
+            String eventId = ConsulUtils.fireEvent(clients, INSTALL_PLUGIN_EVENT, plugin.getKey() + " " + getPluginName(plugin.getKey()), eventParams, null);
             if (eventId != null) {
-                eventIds.add(eventId);
+                eventIdMap.put(eventId, installedHosts);
             } else {
                 throw new PluginFailureException("Failed to install plugins, Consul client couldn't fire the event or failed to retrieve an event ID."
                         + "Maybe the payload was too long (max. 512 bytes)?");
             }
         }
-        return eventIds;
+        return eventIdMap;
     }
 
     @Override
@@ -72,9 +93,9 @@ public class ConsulPluginManager implements PluginManager {
     }
 
     @Override
-    public void waitForEventFinish(Stack stack, Collection<InstanceMetaData> instanceMetaData, Set<String> eventIds) {
+    public void waitForEventFinish(Stack stack, Collection<InstanceMetaData> instanceMetaData, Map<String, Set<String>> eventIds) {
         List<ConsulClient> clients = ConsulUtils.createClients(instanceMetaData);
-        List<String> keys = generateKeys(instanceMetaData, eventIds);
+        List<String> keys = generateKeys(eventIds);
         keyValuePollingService.pollWithTimeout(
                 consulKVCheckerTask,
                 new ConsulKVCheckerContext(stack, clients, keys, FINISH_SIGNAL, FAILED_SIGNAL),
@@ -82,11 +103,23 @@ public class ConsulPluginManager implements PluginManager {
         );
     }
 
-    private List<String> generateKeys(Collection<InstanceMetaData> instanceMetaData, Set<String> eventIds) {
+    @Override
+    public void triggerAndWaitForPlugins(Stack stack, ConsulPluginEvent event) {
+        Set<InstanceMetaData> instances = stack.getRunningInstanceMetaData();
+        Set hosts = getHostnames(hostMetadataRepository.findHostsInCluster(stack.getCluster().getId()));
+        Set<String> triggerEventIds = triggerPlugins(instances, event);
+        Map<String, Set<String>> eventIdMap = new HashMap<>();
+        for (String eventId : triggerEventIds) {
+            eventIdMap.put(eventId, hosts);
+        }
+        waitForEventFinish(stack, instances, eventIdMap);
+    }
+
+    private List<String> generateKeys(Map<String, Set<String>> eventIds) {
         List<String> keys = new ArrayList<>();
-        for (String eventId : eventIds) {
-            for (InstanceMetaData metaData : instanceMetaData) {
-                keys.add(String.format("events/%s/%s", eventId, metaData.getLongName()));
+        for (Map.Entry<String, Set<String>> event : eventIds.entrySet()) {
+            for (String host : event.getValue()) {
+                keys.add(String.format("events/%s/%s", event.getKey(), host));
             }
         }
         return keys;
@@ -95,5 +128,15 @@ public class ConsulPluginManager implements PluginManager {
     private String getPluginName(String url) {
         String[] splits = url.split("/");
         return splits[splits.length - 1].replace("consul-plugins-", "").replace(".git", "");
+    }
+
+    private Set<String> getHostnames(Set<HostMetadata> hostMetadata) {
+        return FluentIterable.from(hostMetadata).transform(new Function<HostMetadata, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable HostMetadata metadata) {
+                return metadata.getHostName();
+            }
+        }).toSet();
     }
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/PluginManager.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/PluginManager.java
@@ -5,15 +5,18 @@ import java.util.Map;
 import java.util.Set;
 
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.PluginExecutionType;
 import com.sequenceiq.cloudbreak.domain.Stack;
 
 public interface PluginManager {
 
     void prepareKeyValues(Collection<InstanceMetaData> instanceMetaData, Map<String, String> keyValues);
 
-    Set<String> installPlugins(Collection<InstanceMetaData> instanceMetaData, Collection<String> plugins);
+    Map<String, Set<String>> installPlugins(Collection<InstanceMetaData> instanceMetaData, Map<String, PluginExecutionType> plugins, Set<String> hosts);
 
     Set<String> triggerPlugins(Collection<InstanceMetaData> instanceMetaData, ConsulPluginEvent event);
 
-    void waitForEventFinish(Stack stack, Collection<InstanceMetaData> instanceMetaData, Set<String> eventIds);
+    void waitForEventFinish(Stack stack, Collection<InstanceMetaData> instanceMetaData, Map<String, Set<String>> eventIds);
+
+    void triggerAndWaitForPlugins(Stack stack, ConsulPluginEvent event);
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/RecipeEngine.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/RecipeEngine.java
@@ -3,11 +3,18 @@ package com.sequenceiq.cloudbreak.service.cluster.flow;
 import java.util.Map;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
+import com.google.common.base.Function;
+import com.google.common.collect.FluentIterable;
+import com.sequenceiq.cloudbreak.domain.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.PluginExecutionType;
 import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
 import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
 
 @Component
@@ -17,29 +24,37 @@ public class RecipeEngine {
     private InstanceMetaDataRepository instanceMetadataRepository;
 
     @Autowired
+    private HostMetadataRepository hostMetadataRepository;
+
+    @Autowired
     private PluginManager pluginManager;
 
     public void setupRecipe(Stack stack) {
         Set<InstanceMetaData> instances = instanceMetadataRepository.findAllInStack(stack.getId());
         Map<String, String> properties = stack.getCluster().getRecipe().getKeyValues();
-        Set<String> plugins = stack.getCluster().getRecipe().getPlugins();
         pluginManager.prepareKeyValues(instances, properties);
-        Set<String> installEventIds = pluginManager.installPlugins(instances, plugins);
-        pluginManager.waitForEventFinish(stack, instances, installEventIds);
+        Map<String, PluginExecutionType> plugins = stack.getCluster().getRecipe().getPlugins();
+        Set<HostMetadata> hostMetadata = hostMetadataRepository.findHostsInCluster(stack.getCluster().getId());
+        Map<String, Set<String>> eventIdMap = pluginManager.installPlugins(instances, plugins, getHostnames(hostMetadata));
+        pluginManager.waitForEventFinish(stack, instances, eventIdMap);
     }
 
     public void executePreInstall(Stack stack) {
-        triggerAndWaitForPlugins(stack, ConsulPluginEvent.PRE_INSTALL);
+        pluginManager.triggerAndWaitForPlugins(stack, ConsulPluginEvent.PRE_INSTALL);
     }
 
     public void executePostInstall(Stack stack) {
-        triggerAndWaitForPlugins(stack, ConsulPluginEvent.POST_INSTALL);
+        pluginManager.triggerAndWaitForPlugins(stack, ConsulPluginEvent.POST_INSTALL);
     }
 
-    private void triggerAndWaitForPlugins(Stack stack, ConsulPluginEvent event) {
-        Set<InstanceMetaData> instances = instanceMetadataRepository.findAllInStack(stack.getId());
-        Set<String> triggerEventIds = pluginManager.triggerPlugins(instances, event);
-        pluginManager.waitForEventFinish(stack, instances, triggerEventIds);
+    private Set<String> getHostnames(Set<HostMetadata> hostMetadata) {
+        return FluentIterable.from(hostMetadata).transform(new Function<HostMetadata, String>() {
+            @Nullable
+            @Override
+            public String apply(@Nullable HostMetadata metadata) {
+                return metadata.getHostName();
+            }
+        }).toSet();
     }
 
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/RecipeEngine.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/RecipeEngine.java
@@ -1,42 +1,49 @@
 package com.sequenceiq.cloudbreak.service.cluster.flow;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
+import com.sequenceiq.cloudbreak.domain.HostGroup;
 import com.sequenceiq.cloudbreak.domain.HostMetadata;
 import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.PluginExecutionType;
+import com.sequenceiq.cloudbreak.domain.Recipe;
 import com.sequenceiq.cloudbreak.domain.Stack;
-import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.repository.InstanceMetaDataRepository;
 
 @Component
 public class RecipeEngine {
 
+    private static final Logger LOGGER = LoggerFactory.getLogger(RecipeEngine.class);
+
     @Autowired
     private InstanceMetaDataRepository instanceMetadataRepository;
 
     @Autowired
-    private HostMetadataRepository hostMetadataRepository;
-
-    @Autowired
     private PluginManager pluginManager;
 
-    public void setupRecipe(Stack stack) {
+    public void setupRecipes(Stack stack, Set<HostGroup> hostGroups) {
+        MDCBuilder.buildMdcContext(stack);
         Set<InstanceMetaData> instances = instanceMetadataRepository.findAllInStack(stack.getId());
-        Map<String, String> properties = stack.getCluster().getRecipe().getKeyValues();
-        pluginManager.prepareKeyValues(instances, properties);
-        Map<String, PluginExecutionType> plugins = stack.getCluster().getRecipe().getPlugins();
-        Set<HostMetadata> hostMetadata = hostMetadataRepository.findHostsInCluster(stack.getCluster().getId());
-        Map<String, Set<String>> eventIdMap = pluginManager.installPlugins(instances, plugins, getHostnames(hostMetadata));
-        pluginManager.waitForEventFinish(stack, instances, eventIdMap);
+        setupProperties(hostGroups, instances);
+        installPlugins(stack, hostGroups, instances);
+    }
+
+    public void setupRecipesOnHosts(Stack stack, Set<Recipe> recipes, Set<HostMetadata> hostMetadata) {
+        MDCBuilder.buildMdcContext(stack);
+        Set<InstanceMetaData> instances = instanceMetadataRepository.findAllInStack(stack.getId());
+        installPluginsOnHosts(stack, recipes, hostMetadata, instances);
     }
 
     public void executePreInstall(Stack stack) {
@@ -45,6 +52,36 @@ public class RecipeEngine {
 
     public void executePostInstall(Stack stack) {
         pluginManager.triggerAndWaitForPlugins(stack, ConsulPluginEvent.POST_INSTALL);
+    }
+
+    private void setupProperties(Set<HostGroup> hostGroups, Set<InstanceMetaData> instances) {
+        LOGGER.info("Setting up recipe properties.");
+        pluginManager.prepareKeyValues(instances, getAllPropertiesFromRecipes(hostGroups));
+    }
+
+    private void installPlugins(Stack stack, Set<HostGroup> hostGroups, Set<InstanceMetaData> instances) {
+        for (HostGroup hostGroup : hostGroups) {
+            LOGGER.info("Installing plugins for recipes on hostgroup {}.", hostGroup.getName());
+            installPluginsOnHosts(stack, hostGroup.getRecipes(), hostGroup.getHostMetadata(), instances);
+        }
+    }
+
+    private void installPluginsOnHosts(Stack stack, Set<Recipe> recipes, Set<HostMetadata> hostMetadata, Set<InstanceMetaData> instances) {
+        for (Recipe recipe : recipes) {
+            Map<String, PluginExecutionType> plugins = recipe.getPlugins();
+            Map<String, Set<String>> eventIdMap = pluginManager.installPlugins(instances, plugins, getHostnames(hostMetadata));
+            pluginManager.waitForEventFinish(stack, instances, eventIdMap);
+        }
+    }
+
+    private Map<String, String> getAllPropertiesFromRecipes(Set<HostGroup> hostGroups) {
+        Map<String, String> properties = new HashMap<>();
+        for (HostGroup hostGroup : hostGroups) {
+            for (Recipe recipe : hostGroup.getRecipes()) {
+                properties.putAll(recipe.getKeyValues());
+            }
+        }
+        return properties;
     }
 
     private Set<String> getHostnames(Set<HostMetadata> hostMetadata) {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/events/DefaultCloudbreakEventService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/events/DefaultCloudbreakEventService.java
@@ -43,7 +43,7 @@ public class DefaultCloudbreakEventService implements CloudbreakEventService {
     public void fireCloudbreakEvent(Long stackId, String eventType, String eventMessage) {
         CloudbreakEventData eventData = new CloudbreakEventData(stackId, eventType, eventMessage);
         MDCBuilder.buildMdcContext(eventData);
-        LOGGER.info("Fireing cloudbreak event: {}", eventData);
+        LOGGER.info("Firing Cloudbreak event: {}", eventData);
         Event reactorEvent = Event.wrap(eventData);
         reactor.notify(ReactorConfig.CLOUDBREAK_EVENT, reactorEvent);
     }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/recipe/SimpleRecipeService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/recipe/SimpleRecipeService.java
@@ -13,7 +13,7 @@ import com.sequenceiq.cloudbreak.domain.CbUser;
 import com.sequenceiq.cloudbreak.domain.CbUserRole;
 import com.sequenceiq.cloudbreak.domain.Recipe;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
-import com.sequenceiq.cloudbreak.repository.ClusterRepository;
+import com.sequenceiq.cloudbreak.repository.HostGroupRepository;
 import com.sequenceiq.cloudbreak.repository.RecipeRepository;
 import com.sequenceiq.cloudbreak.service.DuplicateKeyValueException;
 
@@ -24,7 +24,7 @@ public class SimpleRecipeService implements RecipeService {
     private RecipeRepository recipeRepository;
 
     @Autowired
-    private ClusterRepository clusterRepository;
+    private HostGroupRepository hostGroupRepository;
 
     @Override
     public Recipe create(CbUser user, Recipe recipe) {
@@ -99,7 +99,7 @@ public class SimpleRecipeService implements RecipeService {
 
     private void delete(Recipe recipe, CbUser user) {
         MDCBuilder.buildMdcContext(recipe);
-        if (clusterRepository.findAllClustersByRecipe(recipe.getId()).isEmpty()) {
+        if (hostGroupRepository.findAllHostGroupsByRecipe(recipe.getId()).isEmpty()) {
             if (!user.getUserId().equals(recipe.getOwner()) && !user.getRoles().contains(CbUserRole.ADMIN)) {
                 throw new BadRequestException("Public recipes can only be deleted by owners or account admins.");
             } else {


### PR DESCRIPTION
@doktoric 

- Recipes are associated with host groups instead of the cluster itself. Also one host group can contain multiple recipes (e.g.: spark and GCS connector). 
- Recipe plugins now have an execution type - `one-node` or `all-nodes`. If `one-node` is set, the plugin will only be installed on one of the nodes in the host group. It can be used for example to run HDFS commands in the plugin.
- Only the newly added hosts run the recipes on upscale 

DB migrations submitted

Rest-client changes: sequenceiq/cloudbreak-rest-client#46
Shell changes: sequenceiq/cloudbreak-shell#63