### PR TITLE
 CLOUD-496 separate postgres

### DIFF
--- a/src/main/resources/gcc-init.sh
+++ b/src/main/resources/gcc-init.sh
@@ -111,16 +111,18 @@ ENDOFJSON
   con agent/service/register -X PUT -d @- <<<"$JSON"
 }
 
+use_dns_first() {
+  docker exec ambari-agent sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
+  docker exec ambari-server sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
+  docker exec consul sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
+}
+
 start_ambari_server() {
   docker rm -f ambari-server &>/dev/null
   if [[ "$(consul_leader)" ==  "$(get_ip)" ]]; then
-    docker run -d \
-     --name ambari-server \
-     --net=host \
-     --restart=always \
-     -e BRIDGE_IP=$(get_ip) \
-     sequenceiq/ambari:$AMBARI_DOCKER_TAG /start-server
-
+    docker run -d --name=ambari_db --privileged --restart=always -v /data/ambari-server/pgsql/data:/var/lib/postgresql/data -e POSTGRES_PASSWORD=bigdata -e POSTGRES_USER=ambari postgres:9.4.1
+    sleep 10
+    docker run -d --name=ambari-server --privileged --net=host --restart=always -e POSTGRES_DB=$(docker inspect -f "{{.NetworkSettings.IPAddress}}" ambari_db) -e BRIDGE_IP=$(get_ip) sequenceiq/ambari:$AMBARI_DOCKER_TAG /start-server
     register_ambari
   fi
 }
@@ -128,15 +130,7 @@ start_ambari_server() {
 start_ambari_agent() {
   set_public_host_script
   set_disk_as_volumes
-  docker run -d \
-    --name ambari-agent \
-    --net=host \
-    --restart=always \
-    -e BRIDGE_IP=$(get_ip) \
-    -e HADOOP_CLASSPATH=/data/jars/*:/usr/lib/hadoop/lib/* \
-    -v /data/jars:/data/jars \
-    $VOLUMES \
-    sequenceiq/ambari:$AMBARI_DOCKER_TAG /start-agent
+  docker run -d --name=ambari-agent --privileged --net=host --restart=always -e BRIDGE_IP=$(get_ip) -e HADOOP_CLASSPATH=/data/jars/*:/usr/lib/hadoop/lib/* -v /data/jars:/data/jars $VOLUMES sequenceiq/ambari:$AMBARI_DOCKER_TAG /start-agent
 }
 
 set_disk_as_volumes() {
@@ -169,6 +163,7 @@ main() {
     start_consul
     start_ambari_server
     start_ambari_agent
+    use_dns_first
   fi
 }
 


### PR DESCRIPTION
@keyki 
-Dcb.azure.image.uri=http://102589fae040d8westeurope.blob.core.windows.net/images/packer-cloudbreak-2015-03-10-centos6_2015-March-10_17-15-os-2015-03-10.vhd
-Dcb.gcp.source.image.path=sequenceiqimage/sequenceiq-ambari17-consul-centos-2015-03-10-1449.image.tar.gz
-Dcb.aws.ami.map=ap-northeast-1:ami-c528c3c5,ap-southeast-2:ami-e7c3b2dd,sa-east-1:ami-c5e55dd8,ap-southeast-1:ami-42c3f510,eu-west-1:ami-bb35a7cc,us-west-1:ami-4b20c70f,us-west-2:ami-eb1f3ddb,us-east-1:ami-00391e68
-Dcb.openstack.image=packer-cloudbreak-centos-2015-03-11