### PR TITLE
CLOUD-542 fix test date

### DIFF
--- a/src/test/java/com/sequenceiq/cloudbreak/service/usages/IntervalInstanceUsageGeneratorTest.java
+++ b/src/test/java/com/sequenceiq/cloudbreak/service/usages/IntervalInstanceUsageGeneratorTest.java
@@ -236,7 +236,7 @@ public class IntervalInstanceUsageGeneratorTest {
     public void testGetInstanceHoursShouldCalcExactInstanceHourWhenInstanceIsRunningForTwoDays() throws ParseException {
         InstanceMetaData instance = new InstanceMetaData();
         Calendar cal = Calendar.getInstance();
-        cal.set(2015, 2, 27);
+        cal.set(2015, 2, 12);
         setCalendarTo(cal, 12, 1, 11, 111);
         Date intervalStart = cal.getTime();
         cal.set(DATE, cal.get(DATE) + 1);


### PR DESCRIPTION
@keyki 

Set date to avoid time changing related to summer time in IntervalInstanceUsageGeneratorTest.