### PR TITLE
CLOUD-549: Move consul-watch and plugn into a separated container, CLOUD-546 fix: mounting attached disks under hadoopfs dir instead of mnt

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ConsulPluginManager.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/ConsulPluginManager.java
@@ -71,7 +71,8 @@ public class ConsulPluginManager implements PluginManager {
             for (Map.Entry<String, Set<String>> nodeFilter : getNodeFilters(installedHosts).entrySet()) {
                 EventParams eventParams = new EventParams();
                 eventParams.setNode(nodeFilter.getKey());
-                String eventId = ConsulUtils.fireEvent(clients, INSTALL_PLUGIN_EVENT, plugin.getKey() + " " + getPluginName(plugin.getKey()), eventParams, null);
+                String eventId = ConsulUtils.fireEvent(clients, INSTALL_PLUGIN_EVENT, "TRIGGER_PLUGN " + plugin.getKey() + " " + getPluginName(plugin.getKey()),
+                        eventParams, null);
                 if (eventId != null) {
                     eventIdMap.put(eventId, nodeFilter.getValue());
                 } else {
@@ -104,7 +105,7 @@ public class ConsulPluginManager implements PluginManager {
     @Override
     public Set<String> triggerPlugins(Collection<InstanceMetaData> instanceMetaData, ConsulPluginEvent event) {
         List<ConsulClient> clients = ConsulUtils.createClients(instanceMetaData);
-        String eventId = ConsulUtils.fireEvent(clients, event.getName(), "", null, null);
+        String eventId = ConsulUtils.fireEvent(clients, event.getName(), "TRIGGER_PLUGN_IN_CONTAINER ambari-agent", null, null);
         if (eventId != null) {
             return Sets.newHashSet(eventId);
         } else {

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/DiskAttachUtils.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/DiskAttachUtils.java
@@ -9,7 +9,7 @@ public final class DiskAttachUtils {
     public static String buildDiskPathString(int volumeCount, String directory) {
         StringBuilder localDirs = new StringBuilder("");
         for (int i = 1; i <= volumeCount; i++) {
-            localDirs.append("/mnt/fs").append(i).append("/").append(directory);
+            localDirs.append("/hadoopfs/fs").append(i).append("/").append(directory);
             if (i != volumeCount) {
                 localDirs.append(",");
             }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/HeatTemplateBuilder.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/HeatTemplateBuilder.java
@@ -32,7 +32,7 @@ public class HeatTemplateBuilder {
     public static final String CB_INSTANCE_GROUP_NAME = "cb_instance_group_name";
     public static final String CB_INSTANCE_PRIVATE_ID = "cb_instance_private_id";
     private static final int PRIVATE_ID_PART = 2;
-    private static final String MOUNT_PREFIX = "/mnt/fs";
+    private static final String MOUNT_PREFIX = "/hadoopfs/fs";
     private static final String DEVICE_PREFIX = "/dev/vd";
     private static final char[] DEVICE_CHAR = {'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k'};
 

--- a/src/main/resources/azure-gateway-init.sh
+++ b/src/main/resources/azure-gateway-init.sh
@@ -1,4 +1,5 @@
 : ${CONSUL_IMAGE:=sequenceiq/consul:v0.4.1.ptr}
+: ${CONSUL_WATCH_IMAGE:=sequenceiq/docker-consul-watch-plugn:1.7.0-consul}
 
 set -x
 
@@ -68,6 +69,19 @@ get_consul_opts() {
   fi
 }
 
+start_consul_watch() {
+  docker rm -f consul-watch &> /dev/null
+  docker run -d \
+    --name consul-watch \
+    --privileged \
+    --net=host \
+    --restart=always \
+    -e TRACE=1 \
+    -e BRIDGE_IP=$(get_ip) \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    $CONSUL_WATCH_IMAGE
+}
+
 does_cluster_exist() {
   ip_arr=($(get_vpc_peers))
   for ip in "${ip_arr[@]}"; do
@@ -120,8 +134,8 @@ start_ambari_server() {
 }
 
 set_disk_as_volumes() {
-  for fn in `ls /mnt/ | grep fs`; do
-    VOLUMES="$VOLUMES -v /mnt/$fn:/mnt/$fn"
+  for fn in `ls /hadoopfs/ | grep fs`; do
+    VOLUMES="$VOLUMES -v /hadoopfs/$fn:/hadoopfs/$fn"
   done
 }
 
@@ -138,6 +152,7 @@ main() {
     fix_hostname
     start_consul
     start_ambari_server
+    start_consul_watch
   fi
 }
 

--- a/src/main/resources/azure-hostgroup-init.sh
+++ b/src/main/resources/azure-hostgroup-init.sh
@@ -1,4 +1,5 @@
 : ${CONSUL_IMAGE:=sequenceiq/consul:v0.4.1.ptr}
+: ${CONSUL_WATCH_IMAGE:=sequenceiq/docker-consul-watch-plugn:1.7.0-consul}
 
 set -x
 
@@ -68,6 +69,19 @@ get_consul_opts() {
   fi
 }
 
+start_consul_watch() {
+  docker rm -f consul-watch &> /dev/null
+  docker run -d \
+    --name consul-watch \
+    --privileged \
+    --net=host \
+    --restart=always \
+    -e TRACE=1 \
+    -e BRIDGE_IP=$(get_ip) \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    $CONSUL_WATCH_IMAGE
+}
+
 does_cluster_exist() {
   ip_arr=($(get_vpc_peers))
   for ip in "${ip_arr[@]}"; do
@@ -104,8 +118,8 @@ start_ambari_agent() {
 }
 
 set_disk_as_volumes() {
-  for fn in `ls /mnt/ | grep fs`; do
-    VOLUMES="$VOLUMES -v /mnt/$fn:/mnt/$fn"
+  for fn in `ls /hadoopfs/ | grep fs`; do
+    VOLUMES="$VOLUMES -v /hadoopfs/$fn:/hadoopfs/$fn"
   done
 }
 
@@ -126,6 +140,7 @@ main() {
     fix_hostname
     start_consul
     start_ambari_agent
+    start_consul_watch
   fi
 }
 

--- a/src/main/resources/ec2-gateway-init.sh
+++ b/src/main/resources/ec2-gateway-init.sh
@@ -1,4 +1,5 @@
 : ${CONSUL_IMAGE:=sequenceiq/consul:v0.4.1.ptr}
+: ${CONSUL_WATCH_IMAGE:=sequenceiq/docker-consul-watch-plugn:1.7.0-consul}
 set -x
 get_ip() {
   ifconfig eth0 | awk '/inet addr/{print substr($2,6)}'
@@ -50,6 +51,18 @@ get_consul_opts() {
     fi
   fi
 }
+start_consul_watch() {
+  docker rm -f consul-watch &> /dev/null
+  docker run -d \
+    --name consul-watch \
+    --privileged \
+    --net=host \
+    --restart=always \
+    -e TRACE=1 \
+    -e BRIDGE_IP=$(get_ip) \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    $CONSUL_WATCH_IMAGE
+}
 does_cluster_exist() {
   ip_arr=($(get_vpc_peers))
   for ip in "${ip_arr[@]}"; do
@@ -95,8 +108,8 @@ start_ambari_server() {
   register_ambari
 }
 set_disk_as_volumes() {
-  for fn in `ls /mnt/ | grep fs`; do
-    VOLUMES="$VOLUMES -v /mnt/$fn:/mnt/$fn"
+  for fn in `ls /hadoopfs/ | grep fs`; do
+    VOLUMES="$VOLUMES -v /hadoopfs/$fn:/hadoopfs/$fn"
   done
 }
 format_disks() {
@@ -111,6 +124,7 @@ main() {
     fix_hostname
     start_consul
     start_ambari_server
+    start_consul_watch
   fi
 }
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/src/main/resources/ec2-hostgroup-init.sh
+++ b/src/main/resources/ec2-hostgroup-init.sh
@@ -1,4 +1,5 @@
 : ${CONSUL_IMAGE:=sequenceiq/consul:v0.4.1.ptr}
+: ${CONSUL_WATCH_IMAGE:=sequenceiq/docker-consul-watch-plugn:1.7.0-consul}
 set -x
 get_ip() {
   ifconfig eth0 | awk '/inet addr/{print substr($2,6)}'
@@ -50,6 +51,18 @@ get_consul_opts() {
     fi
   fi
 }
+start_consul_watch() {
+  docker rm -f consul-watch &> /dev/null
+  docker run -d \
+    --name consul-watch \
+    --privileged \
+    --net=host \
+    --restart=always \
+    -e TRACE=1 \
+    -e BRIDGE_IP=$(get_ip) \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    $CONSUL_WATCH_IMAGE
+}
 does_cluster_exist() {
   ip_arr=($(get_vpc_peers))
   for ip in "${ip_arr[@]}"; do
@@ -81,8 +94,8 @@ start_ambari_agent() {
   docker run -d --name=ambari-agent --privileged --net=host --restart=always -e BRIDGE_IP=$(get_ip) -e HADOOP_CLASSPATH=/data/jars/*:/usr/lib/hadoop/lib/* -v /data/jars:/data/jars $VOLUMES sequenceiq/ambari:$AMBARI_DOCKER_TAG /start-agent
 }
 set_disk_as_volumes() {
-  for fn in `ls /mnt/ | grep fs`; do
-    VOLUMES="$VOLUMES -v /mnt/$fn:/mnt/$fn"
+  for fn in `ls /hadoopfs/ | grep fs`; do
+    VOLUMES="$VOLUMES -v /hadoopfs/$fn:/hadoopfs/$fn"
   done
 }
 set_public_host_script() {
@@ -100,6 +113,7 @@ main() {
     fix_hostname
     start_consul
     start_ambari_agent
+    start_consul_watch
   fi
 }
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/src/main/resources/gcc-hostgroup-init.sh
+++ b/src/main/resources/gcc-hostgroup-init.sh
@@ -1,4 +1,5 @@
 : ${CONSUL_IMAGE:=sequenceiq/consul:v0.4.1.ptr}
+: ${CONSUL_WATCH_IMAGE:=sequenceiq/docker-consul-watch-plugn:1.7.0-consul}
 
 set -x
 
@@ -64,6 +65,19 @@ get_consul_opts() {
   fi
 }
 
+start_consul_watch() {
+  docker rm -f consul-watch &> /dev/null
+  docker run -d \
+    --name consul-watch \
+    --privileged \
+    --net=host \
+    --restart=always \
+    -e TRACE=1 \
+    -e BRIDGE_IP=$(get_ip) \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    $CONSUL_WATCH_IMAGE
+}
+
 does_cluster_exist() {
   ip_arr=($(get_vpc_peers))
   for ip in "${ip_arr[@]}"; do
@@ -96,6 +110,7 @@ con() {
 use_dns_first() {
   docker exec ambari-agent sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
   docker exec consul sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
+  docker exec consul-watch sed -i "/^hosts:/ s/ *files dns/ dns files/" /etc/nsswitch.conf
 }
 
 start_ambari_agent() {
@@ -105,8 +120,8 @@ start_ambari_agent() {
 }
 
 set_disk_as_volumes() {
-  for fn in `ls /mnt/ | grep fs`; do
-    VOLUMES="$VOLUMES -v /mnt/$fn:/mnt/$fn"
+  for fn in `ls /hadoopfs/ | grep fs`; do
+    VOLUMES="$VOLUMES -v /hadoopfs/$fn:/hadoopfs/$fn"
   done
 }
 
@@ -133,9 +148,9 @@ main() {
     fix_hostname
     start_consul
     start_ambari_agent
+    start_consul_watch
     use_dns_first
   fi
 }
 
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"
-

--- a/src/main/resources/openstack-hostgroup-init.sh
+++ b/src/main/resources/openstack-hostgroup-init.sh
@@ -1,4 +1,5 @@
 : ${CONSUL_IMAGE:=sequenceiq/consul:v0.4.1.ptr}
+: ${CONSUL_WATCH_IMAGE:=sequenceiq/docker-consul-watch-plugn:1.7.0-consul}
 
 set -x
 
@@ -68,6 +69,19 @@ get_consul_opts() {
   fi
 }
 
+start_consul_watch() {
+  docker rm -f consul-watch &> /dev/null
+  docker run -d \
+    --name consul-watch \
+    --privileged \
+    --net=host \
+    --restart=always \
+    -e TRACE=1 \
+    -e BRIDGE_IP=$(get_ip) \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    $CONSUL_WATCH_IMAGE
+}
+
 does_cluster_exist() {
   ip_arr=($(get_vpc_peers))
   for ip in "${ip_arr[@]}"; do
@@ -104,8 +118,8 @@ start_ambari_agent() {
 }
 
 set_disk_as_volumes() {
-  for fn in `ls /mnt/ | grep fs`; do
-    VOLUMES="$VOLUMES -v /mnt/$fn:/mnt/$fn"
+  for fn in `ls /hadoopfs/ | grep fs`; do
+    VOLUMES="$VOLUMES -v /hadoopfs/$fn:/hadoopfs/$fn"
   done
 }
 
@@ -126,6 +140,7 @@ main() {
     fix_hostname
     start_consul
     start_ambari_agent
+    start_consul_watch
   fi
 }
 


### PR DESCRIPTION
CLOUD-549: Move consul-watch and plugn into a separated container, CLOUD-546 fix: mounting attached disks under hadoopfs dir instead of mnt
