### PR TITLE
CLOUD-666 RoleArn can only be used from 1 account

### DIFF
--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/AWSCredentialParam.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/AWSCredentialParam.java
@@ -1,13 +1,10 @@
 package com.sequenceiq.cloudbreak.controller.validation;
 
-import java.util.Set;
-
 import com.google.common.base.Optional;
 
 public enum AWSCredentialParam implements TemplateParam {
 
-    ROLE_ARN("roleArn", true, String.class, Optional.<String>absent()),
-    SNS_TOPICS("snsTopics", false, Set.class, Optional.<String>absent());
+    ROLE_ARN("roleArn", true, String.class, Optional.<String>absent());
 
     private final String paramName;
     private final Class clazz;

--- a/src/main/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidator.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidator.java
@@ -2,12 +2,14 @@ package com.sequenceiq.cloudbreak.controller.validation;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import javax.validation.ConstraintValidator;
 import javax.validation.ConstraintValidatorContext;
 
-import com.sequenceiq.cloudbreak.controller.json.CredentialRequest;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.sequenceiq.cloudbreak.controller.json.CredentialRequest;
 
 public class CredentialParametersValidator implements ConstraintValidator<ValidCredentialRequest, CredentialRequest> {
 
@@ -37,13 +39,13 @@ public class CredentialParametersValidator implements ConstraintValidator<ValidC
         boolean valid = true;
         switch (request.getCloudPlatform()) {
             case AWS:
-                valid = validateAWSParams(request, context);
+                valid = validateParams(request.getParameters(), context, requiredAWSParams);
                 break;
             case AZURE:
-                valid = validateAzureParams(request, context);
+                valid = validateParams(request.getParameters(), context, requiredAzureParams);
                 break;
             case GCC:
-                valid = validateGccParams(request, context);
+                valid = validateParams(request.getParameters(), context, requiredGccParams);
                 break;
             default:
                 break;
@@ -51,27 +53,9 @@ public class CredentialParametersValidator implements ConstraintValidator<ValidC
         return valid;
     }
 
-    private boolean validateGccParams(CredentialRequest request, ConstraintValidatorContext context) {
+    private boolean validateParams(Map<String, Object> params, ConstraintValidatorContext context, List<TemplateParam> paramConstraints) {
         for (ParameterValidator validator : parameterValidators) {
-            if (!validator.validate(request.getParameters(), context, requiredGccParams)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean validateAzureParams(CredentialRequest request, ConstraintValidatorContext context) {
-        for (ParameterValidator validator : parameterValidators) {
-            if (!validator.validate(request.getParameters(), context, requiredAzureParams)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    private boolean validateAWSParams(CredentialRequest request, ConstraintValidatorContext context) {
-        for (ParameterValidator validator : parameterValidators) {
-            if (!validator.validate(request.getParameters(), context, requiredAWSParams)) {
+            if (!validator.validate(params, context, paramConstraints)) {
                 return false;
             }
         }

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/AwsCredential.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/AwsCredential.java
@@ -1,9 +1,19 @@
 package com.sequenceiq.cloudbreak.domain;
 
 import javax.persistence.Entity;
+import javax.persistence.NamedQuery;
 import javax.persistence.OneToOne;
+import javax.persistence.Table;
+import javax.persistence.UniqueConstraint;
 
 @Entity
+@Table(uniqueConstraints = {
+        @UniqueConstraint(columnNames = { "account", "name" })
+})
+@NamedQuery(
+        name = "Credential.findByRoleArn",
+        query = "SELECT c FROM Credential c "
+                + "WHERE c.roleArn = :roleArn")
 public class AwsCredential extends Credential implements ProvisionEntity {
 
     private String roleArn;

--- a/src/main/java/com/sequenceiq/cloudbreak/domain/Credential.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/domain/Credential.java
@@ -43,9 +43,10 @@ import javax.persistence.UniqueConstraint;
                         + "WHERE c.name= :name and ((c.publicInAccount=true and c.account= :account) or c.owner= :owner)"),
         @NamedQuery(
                 name = "Credential.findByNameInUser",
-                query = "SELECT b FROM Credential b "
-                        + "WHERE b.owner= :owner and b.name= :name")
+                query = "SELECT c FROM Credential c "
+                        + "WHERE c.owner= :owner and c.name= :name")
 })
+
 public abstract class Credential {
 
     @Id

--- a/src/main/java/com/sequenceiq/cloudbreak/repository/CredentialRepository.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/repository/CredentialRepository.java
@@ -28,4 +28,6 @@ public interface CredentialRepository extends CrudRepository<Credential, Long> {
 
     Credential findByNameInUser(@Param("name") String name, @Param("owner") String owner);
 
+    Set<Credential> findByRoleArn(@Param("roleArn") String roleArn);
+
 }

--- a/src/main/java/com/sequenceiq/cloudbreak/service/credential/SimpleCredentialService.java
+++ b/src/main/java/com/sequenceiq/cloudbreak/service/credential/SimpleCredentialService.java
@@ -65,9 +65,9 @@ public class SimpleCredentialService implements CredentialService {
     @Override
     public Credential create(CbUser user, Credential credential) {
         LOGGER.debug("Creating credential: [User: '{}', Account: '{}']", user.getUsername(), user.getAccount());
-        credentialHandlers.get(credential.cloudPlatform()).init(credential);
         credential.setOwner(user.getUserId());
         credential.setAccount(user.getAccount());
+        credentialHandlers.get(credential.cloudPlatform()).init(credential);
         Credential savedCredential;
         try {
             savedCredential = credentialRepository.save(credential);


### PR DESCRIPTION
@doktoric 
This change allows an IAM role to be exposed as public (it is already handled like that now - stored in db as plain text, exposed on UI as plain text, etc..).
The IAM role cannot be reused outside of Cloudbreak, because it is configured to trust only the Cloudbreak deployer account, but it can be reused in Cloudbreak itself if it is captured by an attacker. This change restricts the usage to only one account (but multiple users inside), so it won't be reusable in Cloudbreak either.