### PR TITLE
CLOUD-708 bypass blueprint validation

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/ClusterController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/ClusterController.java
@@ -72,10 +72,10 @@ public class ClusterController {
     @ApiOperation(value = ClusterOpDescription.POST_FOR_STACK, produces = ContentType.JSON, notes = Notes.CLUSTER_NOTES)
     @RequestMapping(value = "/stacks/{stackId}/cluster", method = RequestMethod.POST)
     @ResponseBody
-    public ResponseEntity<String> create(@ModelAttribute("user") CbUser user, @PathVariable Long stackId, @RequestBody @Valid ClusterRequest clusterRequest) {
+    public ResponseEntity<String> create(@ModelAttribute("user") CbUser user, @PathVariable Long stackId, @RequestBody @Valid ClusterRequest request) {
         MDCBuilder.buildMdcContext(user);
-        Cluster cluster = conversionService.convert(clusterRequest, Cluster.class);
-        cluster = clusterDecorator.decorate(cluster, stackId, clusterRequest.getBlueprintId(), clusterRequest.getHostGroups());
+        Cluster cluster = conversionService.convert(request, Cluster.class);
+        cluster = clusterDecorator.decorate(cluster, stackId, request.getBlueprintId(), request.getHostGroups(), request.getValidateBlueprint());
         clusterService.create(user, stackId, cluster);
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
@@ -136,7 +136,7 @@ public class ClusterController {
                 hostGroup = hostGroupDecorator.decorate(hostGroup, stackId, json.getInstanceGroupName(), json.getRecipeIds(), false);
                 hostGroups.add(hostGroupService.save(hostGroup));
             }
-            clusterService.recreate(stackId, updateJson.getBlueprintId(), hostGroups);
+            clusterService.recreate(stackId, updateJson.getBlueprintId(), hostGroups, updateJson.getValidateBlueprint());
             return new ResponseEntity<>(HttpStatus.NO_CONTENT);
         }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/ClusterRequest.java
@@ -35,6 +35,7 @@ public class ClusterRequest {
     private String kerberosMasterKey;
     private String kerberosAdmin;
     private String kerberosPassword;
+    private Boolean validateBlueprint = true;
 
     public String getDescription() {
         return description;
@@ -106,5 +107,13 @@ public class ClusterRequest {
 
     public void setKerberosPassword(String kerberosPassword) {
         this.kerberosPassword = kerberosPassword;
+    }
+
+    public boolean getValidateBlueprint() {
+        return validateBlueprint == null ? false : validateBlueprint;
+    }
+
+    public void setValidateBlueprint(Boolean validateBlueprint) {
+        this.validateBlueprint = validateBlueprint;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/UpdateClusterJson.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/UpdateClusterJson.java
@@ -18,6 +18,7 @@ public class UpdateClusterJson implements JsonEntity {
     private StatusRequest status;
     @ApiModelProperty(StackModelDescription.BLUEPRINT_ID)
     private Long blueprintId;
+    private Boolean validateBlueprint = true;
     private Set<HostGroupJson> hostgroups;
 
     public UpdateClusterJson() {
@@ -53,5 +54,13 @@ public class UpdateClusterJson implements JsonEntity {
 
     public void setHostgroups(Set<HostGroupJson> hostgroups) {
         this.hostgroups = hostgroups;
+    }
+
+    public boolean getValidateBlueprint() {
+        return validateBlueprint == null ? false : validateBlueprint;
+    }
+
+    public void setValidateBlueprint(Boolean validateBlueprint) {
+        this.validateBlueprint = validateBlueprint;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterService.java
@@ -243,7 +243,7 @@ public class AmbariClusterService implements ClusterService {
     }
 
     @Override
-    public Cluster recreate(Long stackId, Long blueprintId, Set<HostGroup> hostGroups) {
+    public Cluster recreate(Long stackId, Long blueprintId, Set<HostGroup> hostGroups, boolean validateBlueprint) {
         if (blueprintId == null || hostGroups == null) {
             throw new BadRequestException("Blueprint id and hostGroup assignments can not be null.");
         }
@@ -253,7 +253,9 @@ public class AmbariClusterService implements ClusterService {
             throw new BadRequestException(String.format("Blueprint not exist with '%s' id.", blueprintId));
         }
         Cluster cluster = stack.getCluster();
-        blueprintValidator.validateBlueprintForStack(blueprint, hostGroups, stackRepository.findOne(stackId).getInstanceGroups());
+        if (validateBlueprint) {
+            blueprintValidator.validateBlueprintForStack(blueprint, hostGroups, stackRepository.findOne(stackId).getInstanceGroups());
+        }
         cluster.setBlueprint(blueprint);
         cluster.getHostGroups().removeAll(cluster.getHostGroups());
         cluster.getHostGroups().addAll(hostGroups);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/ClusterService.java
@@ -29,5 +29,5 @@ public interface ClusterService {
 
     Cluster updateCluster(Cluster cluster);
 
-    Cluster recreate(Long stackId, Long blueprintId, Set<HostGroup> hostgroups);
+    Cluster recreate(Long stackId, Long blueprintId, Set<HostGroup> hostGroups, boolean validateBlueprint);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/ClusterDecorator.java
@@ -21,7 +21,8 @@ public class ClusterDecorator implements Decorator<Cluster> {
     private enum DecorationData {
         STACK_ID,
         BLUEPRINT_ID,
-        HOSTGROUP_JSONS
+        HOSTGROUP_JSONS,
+        VALIDATE_BLUEPRINT
     }
 
     @Autowired
@@ -47,12 +48,13 @@ public class ClusterDecorator implements Decorator<Cluster> {
         Long stackId = (Long) data[DecorationData.STACK_ID.ordinal()];
         Long blueprintId = (Long) data[DecorationData.BLUEPRINT_ID.ordinal()];
         Set<HostGroupJson> hostGroupsJsons = (Set<HostGroupJson>) data[DecorationData.HOSTGROUP_JSONS.ordinal()];
-        Blueprint blueprint = blueprintRepository.findOne(blueprintId);
         subject.setBlueprint(blueprintRepository.findOne(blueprintId));
-
         subject.setHostGroups(convertHostGroupsFromJson(stackId, subject, hostGroupsJsons));
-        blueprintValidator.validateBlueprintForStack(blueprint, subject.getHostGroups(), stackRepository.findOne(stackId).getInstanceGroups());
-
+        boolean validate = (boolean) data[DecorationData.VALIDATE_BLUEPRINT.ordinal()];
+        if (validate) {
+            Blueprint blueprint = blueprintRepository.findOne(blueprintId);
+            blueprintValidator.validateBlueprintForStack(blueprint, subject.getHostGroups(), stackRepository.findOne(stackId).getInstanceGroups());
+        }
         return subject;
     }
 


### PR DESCRIPTION
@biharitomi @schfeca75 
This PR adds the ability to bypass the blueprint validation. By default it is turned on, otherwise it should be specified in the JSON both when creating the cluster and we re-creating it.