### PR TITLE
CLOUD-576 start ambari db with net=host

### DIFF
--- a/orcestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orcestrator/swarm/SwarmContainerOrchestrator.java
+++ b/orcestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orcestrator/swarm/SwarmContainerOrchestrator.java
@@ -99,10 +99,9 @@ public class SwarmContainerOrchestrator implements ContainerOrchestrator {
     @Override
     public void startAmbariServer(ContainerOrchestratorCluster cluster, String dbImageName, String serverImageName) throws CloudbreakOrchestratorException {
         try {
-            Node gateway = getGatewayNode(cluster.getApiAddress(), cluster.getNodes());
             DockerClient swarmManagerClient = ((SwarmCluster) cluster).getDockerClient();
-            String databaseIp = new AmbariServerDatabaseBootstrap(swarmManagerClient, dbImageName).call();
-            new AmbariServerBootstrap(swarmManagerClient, gateway.getPrivateIp(), databaseIp, serverImageName).call();
+            new AmbariServerDatabaseBootstrap(swarmManagerClient, dbImageName).call();
+            new AmbariServerBootstrap(swarmManagerClient, serverImageName).call();
         } catch (Exception e) {
             throw new CloudbreakOrchestratorException(e);
         }

--- a/orcestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orcestrator/swarm/containers/AmbariServerBootstrap.java
+++ b/orcestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orcestrator/swarm/containers/AmbariServerBootstrap.java
@@ -19,14 +19,10 @@ public class AmbariServerBootstrap {
 
     private static final int PORT = 8080;
     private final DockerClient docker;
-    private final String privateIp;
-    private final String databaseIp;
     private final String imageName;
 
-    public AmbariServerBootstrap(DockerClient docker, String privateIp, String databaseIp, String imageName) {
+    public AmbariServerBootstrap(DockerClient docker, String imageName) {
         this.docker = docker;
-        this.privateIp = privateIp;
-        this.databaseIp = databaseIp;
         this.imageName = imageName;
     }
 
@@ -43,7 +39,7 @@ public class AmbariServerBootstrap {
                 .withHostConfig(hostConfig)
                 .withExposedPorts(new ExposedPort(PORT))
                 .withEnv("constraint:type==gateway",
-                        String.format("POSTGRES_DB=%s", databaseIp),
+                        String.format("POSTGRES_DB=localhost"),
                         String.format("SERVICE_NAME=%s", "ambari-8080"))
                 .withName(AMBARI_SERVER.getName())
                 .withCmd("/start-server"));

--- a/orcestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orcestrator/swarm/containers/AmbariServerDatabaseBootstrap.java
+++ b/orcestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orcestrator/swarm/containers/AmbariServerDatabaseBootstrap.java
@@ -27,6 +27,7 @@ public class AmbariServerDatabaseBootstrap {
     public String call() throws Exception {
         HostConfig hostConfig = new HostConfig();
         hostConfig.setPrivileged(true);
+        hostConfig.setNetworkMode("host");
         hostConfig.setRestartPolicy(RestartPolicy.alwaysRestart());
 
         String containerId = DockerClientUtil.createContainer(docker, docker.createContainerCmd(imageName)
@@ -37,6 +38,7 @@ public class AmbariServerDatabaseBootstrap {
                 .withName(AMBARI_DB.getName()));
         DockerClientUtil.startContainer(docker, docker.startContainerCmd(containerId)
                 .withRestartPolicy(RestartPolicy.alwaysRestart())
+                .withNetworkMode("host")
                 .withBinds(new Bind("/data/ambari-server/pgsql/data", new Volume("/var/lib/postgresql/data"))));
 
         LOGGER.info("Database container for Ambari server started successfully");


### PR DESCRIPTION
The IP address of the ambari db may change after restart and the server won't be able to connect to it. There are 2 solutions:
* launch with net=host this is what i just did
* let registrator register the db and modify the ambari-server start script to get the db IP from consul