### PR TITLE
CLOUD-738: Timeout can be too short when multiple large volumes are attached

### DIFF
--- a/core/src/main/resources/init/init.sh
+++ b/core/src/main/resources/init/init.sh
@@ -27,7 +27,7 @@ format_disks() {
   for (( i=1; i<=15; i++ )); do
     LABEL=$(printf "\x$((START_LABEL+i))")
     if [ -e /dev/platform_disk_prefix"$LABEL" ]; then
-      mkfs -F -t ext4 /dev/platform_disk_prefix${LABEL}
+      mkfs -E lazy_itable_init=1 -O uninit_bg -F -t ext4 /dev/platform_disk_prefix${LABEL}
       mkdir /hadoopfs/fs${i}
       echo /dev/platform_disk_prefix${LABEL} /hadoopfs/fs${i} ext4  defaults 0 2 >> /etc/fstab
       mount /hadoopfs/fs${i}

--- a/orchestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orchestrator/swarm/SwarmContainerOrchestrator.java
+++ b/orchestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orchestrator/swarm/SwarmContainerOrchestrator.java
@@ -38,7 +38,7 @@ import com.sequenceiq.cloudbreak.orchestrator.swarm.containers.RegistratorBootst
 public class SwarmContainerOrchestrator extends SimpleContainerOrchestrator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SwarmContainerOrchestrator.class);
     private static final int READ_TIMEOUT = 30000;
-    private static final String MUNCHAUSEN_WAIT = "180";
+    private static final String MUNCHAUSEN_WAIT = "360";
     private static final String MUNCHAUSEN_DOCKER_IMAGE = "sequenceiq/munchausen:0.3";
     private static final int MAX_IP_FOR_ONE_REQUEST = 600;
 


### PR DESCRIPTION
@akanto or @martonsereg pls review

* increasing munchausen timeout to 360
* using lazy_itable_init mkfs parameter to speed up the disk formatting

* was tested on azure with teragen / terasort / teravalidate on hadoop cluster with 12 nodes
* was tested on aws, azure and gcp with TestDFSIO read / write
