### PR TITLE
support for d2 instances

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -56,7 +56,7 @@ dependencies {
     compile group: 'com.google.http-client',        name: 'google-http-client-jackson2',    version: '1.17.0-rc'
     compile (group: 'com.google.oauth-client',      name: 'google-oauth-client-jetty',      version: '1.17.0-rc')   { exclude module: 'servlet-api' }
     compile ("com.sequenceiq:azure-rest-client:${azureRestClientVersion}")                                          { exclude group: 'log4j' }
-    compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: '1.9.23')      { exclude group: 'commons-logging' }
+    compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: '1.9.35')      { exclude group: 'commons-logging' }
 
     compile project(':orchestrator-swarm')
     compile project(':orchestrator-api')

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/TemplateRequest.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/TemplateRequest.java
@@ -7,7 +7,7 @@ import com.wordnik.swagger.annotations.ApiModel;
 
 @ApiModel
 @ValidProvisionRequest
-@ValidVolume(minCount = 1, maxCount = 15, minSize = 10, maxSize = 1000)
+@ValidVolume(minCount = 1, maxCount = 24, minSize = 10, maxSize = 1000)
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class TemplateRequest extends TemplateBase {
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/ClusterBootstrapper.java
@@ -35,7 +35,7 @@ import com.sequenceiq.cloudbreak.service.PollingService;
 public class ClusterBootstrapper {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClusterBootstrapper.class);
     private static final int POLLING_INTERVAL = 5000;
-    private static final int MAX_POLLING_ATTEMPTS = 100;
+    private static final int MAX_POLLING_ATTEMPTS = 500;
 
     @Value("${cb.container.orchestrator:" + CB_CONTAINER_ORCHESTRATOR + "}")
     private ContainerOrchestratorTool containerOrchestratorTool;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/domain/AwsInstanceType.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/domain/AwsInstanceType.java
@@ -30,12 +30,17 @@ public enum AwsInstanceType {
     R3Xlarge("r3.xlarge", 1),
     R32xlarge("r3.2xlarge", 1),
     R34xlarge("r3.4xlarge", 1),
-    R38xlarge("r3.8xlarge", 2);
+    R38xlarge("r3.8xlarge", 2),
+
+    D2Xlarge("d2.xlarge", 3),
+    D22xlarge("d2.2xlarge", 6),
+    D24xlarge("d2.4xlarge", 12),
+    D28xlarge("d2.8xlarge", 24);
 
     private String value;
     private int ephemeralVolumes;
 
-    private AwsInstanceType(String value, int ephemeralVolumes) {
+    AwsInstanceType(String value, int ephemeralVolumes) {
         this.value = value;
         this.ephemeralVolumes = ephemeralVolumes;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/domain/CloudPlatform.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/domain/CloudPlatform.java
@@ -1,10 +1,10 @@
 package com.sequenceiq.cloudbreak.domain;
 
 public enum CloudPlatform {
-    AWS("ec2", true, 0, "xvd", 65),
-    AZURE("azure", false, 6, "sd", 62),
-    GCC("gcc", false, 30, "sd", 61),
-    OPENSTACK("openstack", true, 0, "vd", 61);
+    AWS("ec2", true, 0, "xvd", 97),
+    AZURE("azure", false, 6, "sd", 98),
+    GCC("gcc", false, 30, "sd", 97),
+    OPENSTACK("openstack", true, 0, "vd", 97);
 
     private final String initScriptPrefix;
     private final boolean withTemplate;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
@@ -351,7 +351,7 @@ public class AwsConnector implements CloudPlatformConnector {
             try {
                 client.describeStacks(describeStacksRequest);
             } catch (AmazonServiceException e) {
-                if (e.getErrorMessage().equals("Stack with id " + cFStackName + " does not exist")) {
+                if (e.getErrorMessage().contains(cFStackName + " does not exist")) {
                     AmazonEC2Client amazonEC2Client = awsStackUtil.createEC2Client(stack);
                     releaseReservedIp(stack, amazonEC2Client);
                     return;

--- a/core/src/main/resources/init/init.ftl
+++ b/core/src/main/resources/init/init.ftl
@@ -33,8 +33,8 @@ configure_docker() {
 
 format_disks() {
   mkdir /hadoopfs
-  for (( i=1; i<=15; i++ )); do
-    LABEL=$(printf "\x$((START_LABEL+i))")
+  for (( i=1; i<=24; i++ )); do
+    LABEL=$(printf "\x$(printf %x $((START_LABEL+i)))")
     if [ -e /dev/${PLATFORM_DISK_PREFIX}"$LABEL" ]; then
       mkfs -E lazy_itable_init=1 -O uninit_bg -F -t ext4 /dev/${PLATFORM_DISK_PREFIX}${LABEL}
       mkdir /hadoopfs/fs${i}

--- a/core/src/main/resources/templates/aws-cf-stack.ftl
+++ b/core/src/main/resources/templates/aws-cf-stack.ftl
@@ -214,24 +214,8 @@
               "VolumeSize" : "50",
               "VolumeType" : "gp2"
             }
-          }, {
-            "DeviceName" : "/dev/sdb",
-            "NoDevice" : true,
-            "Ebs": {}
-      	  }, {
-            "DeviceName" : "/dev/sdc",
-            "NoDevice" : true,
-            "Ebs": {}
-          }, {
-            "DeviceName" : "/dev/sdd",
-            "NoDevice" : true,
-            "Ebs": {}
-          }, {
-            "DeviceName" : "/dev/sde",
-            "NoDevice" : true,
-            "Ebs": {}
           }
-		  <#assign seq = ["f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]>
+		  <#assign seq = ["b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z"]>
 			<#list seq as x>
 			<#if x_index = instanceGroup.template.volumeCount><#break></#if>
   		  ,{

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationTemplateBuilderTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/CloudFormationTemplateBuilderTest.java
@@ -71,9 +71,9 @@ public class CloudFormationTemplateBuilderTest {
         // WHEN
         String result = underTest.build(stack, null, false, "templates/aws-cf-stack.ftl");
         // THEN
-        assertTrue(result.contains("\"DeviceName\" : \"/dev/xvdf\""));
-        assertTrue(result.contains("\"DeviceName\" : \"/dev/xvdg\""));
-        assertFalse(result.contains("\"DeviceName\" : \"/dev/xvdh\""));
+        assertTrue(result.contains("\"DeviceName\" : \"/dev/xvdb\""));
+        assertTrue(result.contains("\"DeviceName\" : \"/dev/xvdc\""));
+        assertFalse(result.contains("\"DeviceName\" : \"/dev/xvdd\""));
     }
 
     @Test

--- a/core/src/test/resources/azure-core-init.sh
+++ b/core/src/test/resources/azure-core-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-START_LABEL=62
+START_LABEL=98
 PLATFORM_DISK_PREFIX=sd
 
 
@@ -27,8 +27,8 @@ configure_docker() {
 
 format_disks() {
   mkdir /hadoopfs
-  for (( i=1; i<=15; i++ )); do
-    LABEL=$(printf "\x$((START_LABEL+i))")
+  for (( i=1; i<=24; i++ )); do
+    LABEL=$(printf "\x$(printf %x $((START_LABEL+i)))")
     if [ -e /dev/${PLATFORM_DISK_PREFIX}"$LABEL" ]; then
       mkfs -E lazy_itable_init=1 -O uninit_bg -F -t ext4 /dev/${PLATFORM_DISK_PREFIX}${LABEL}
       mkdir /hadoopfs/fs${i}

--- a/core/src/test/resources/azure-gateway-init.sh
+++ b/core/src/test/resources/azure-gateway-init.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -x
 
-START_LABEL=62
+START_LABEL=98
 PLATFORM_DISK_PREFIX=sd
 
 start_proxy() {
@@ -30,8 +30,8 @@ configure_docker() {
 
 format_disks() {
   mkdir /hadoopfs
-  for (( i=1; i<=15; i++ )); do
-    LABEL=$(printf "\x$((START_LABEL+i))")
+  for (( i=1; i<=24; i++ )); do
+    LABEL=$(printf "\x$(printf %x $((START_LABEL+i)))")
     if [ -e /dev/${PLATFORM_DISK_PREFIX}"$LABEL" ]; then
       mkfs -E lazy_itable_init=1 -O uninit_bg -F -t ext4 /dev/${PLATFORM_DISK_PREFIX}${LABEL}
       mkdir /hadoopfs/fs${i}

--- a/orchestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orchestrator/swarm/SwarmContainerOrchestrator.java
+++ b/orchestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orchestrator/swarm/SwarmContainerOrchestrator.java
@@ -38,7 +38,7 @@ import com.sequenceiq.cloudbreak.orchestrator.swarm.containers.RegistratorBootst
 public class SwarmContainerOrchestrator extends SimpleContainerOrchestrator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SwarmContainerOrchestrator.class);
     private static final int READ_TIMEOUT = 30000;
-    private static final String MUNCHAUSEN_WAIT = "360";
+    private static final String MUNCHAUSEN_WAIT = "3600";
     private static final String MUNCHAUSEN_DOCKER_IMAGE = "sequenceiq/munchausen:0.3";
     private static final int MAX_IP_FOR_ONE_REQUEST = 600;
 


### PR DESCRIPTION
@schfeca75 please review
added support for d2 type instances:
- d2xlarge, d22xlarge, d24xlarge instances work as expected
- d28xlarge instances cannot be started (even with our base ami), so those won't be available on the UI
- increased timeout for Munchausen wait and cluster bootstrapping, because if the gateway doesn't have any large volumes attached its Docker API will be available much faster than on the other instances with lots of large volumes (e.g: 12 2TB instance store volumes for d24xlarge).
- fixed bug with volume labels (labels were converted from the hex value to ascii characters)
- aws volume labeling now starts from "b"