### PR TITLE
CLOUD-682: Azure can't process more than one network operations simultaneously

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -480,7 +480,7 @@ public class AmbariClusterConnector {
     private List<String> findFreeHosts(Long stackId, HostGroup hostGroup, int scalingAdjustment) {
         Set<InstanceMetaData> unregisteredHosts = instanceMetadataRepository.findUnregisteredHostsInInstanceGroup(hostGroup.getInstanceGroup().getId());
         Set<InstanceMetaData> instances = FluentIterable.from(unregisteredHosts).limit(scalingAdjustment).toSet();
-        String statusReason = String.format("Adding '%s' new host(s) to the '%s' host group.", scalingAdjustment, hostGroup.getName());
+        String statusReason = String.format("Adding '%s' new host(s) to the '%s' host group.", instances.size(), hostGroup.getName());
         eventService.fireCloudbreakInstanceGroupEvent(stackId, Status.UPDATE_IN_PROGRESS.name(), statusReason, hostGroup.getName());
         return getHostNames(instances);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariOperationsStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariOperationsStatusCheckerTask.java
@@ -29,8 +29,8 @@ public class AmbariOperationsStatusCheckerTask extends StackBasedStatusCheckerTa
             AmbariClient ambariClient = t.getAmbariClient();
             BigDecimal installProgress = ambariClient.getRequestProgress(request.getValue());
             LOGGER.info("Ambari operation: '{}', Progress: {}", request.getKey(), installProgress);
-            allFinished = allFinished && installProgress.compareTo(COMPLETED) == 0;
-            if (installProgress.compareTo(FAILED) == 0) {
+            allFinished = allFinished && COMPLETED.compareTo(installProgress) == 0;
+            if (FAILED.compareTo(installProgress) == 0) {
                 boolean failed = true;
                 for (int i = 0; i < MAX_RETRY; i++) {
                     if (ambariClient.getRequestProgress(request.getValue()).compareTo(FAILED) != 0) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AddInstancesOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AddInstancesOperation.java
@@ -1,0 +1,57 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.domain.Resource;
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class AddInstancesOperation extends AzureOperation<Set<Resource>> {
+    private String gateWayUserData;
+    private String coreUserData;
+    private Integer instanceCount;
+    private String instanceGroup;
+
+    private AddInstancesOperation(Builder builder) {
+        super(builder);
+        this.gateWayUserData = builder.gateWayUserData;
+        this.coreUserData = builder.coreUserData;
+        this.instanceCount = builder.instanceCount;
+        this.instanceGroup = builder.instanceGroup;
+    }
+
+    @Override
+    protected Set<Resource> doExecute(Stack stack) {
+        return getCloudResourceManager().addNewResources(stack, coreUserData, instanceCount, instanceGroup, getAzureResourceBuilderInit());
+    }
+
+    public static class Builder extends AzureOperation.Builder {
+        private String gateWayUserData;
+        private String coreUserData;
+        private Integer instanceCount;
+        private String instanceGroup;
+
+        public Builder withGateWayUserData(String gateWayUserData) {
+            this.gateWayUserData = gateWayUserData;
+            return this;
+        }
+
+        public Builder withCoreUserData(String coreUserData) {
+            this.coreUserData = coreUserData;
+            return this;
+        }
+
+        public Builder withInstanceCount(Integer instanceCount) {
+            this.instanceCount = instanceCount;
+            return this;
+        }
+
+        public Builder withInstanceGroup(String instanceGroup) {
+            this.instanceGroup = instanceGroup;
+            return this;
+        }
+
+        public AddInstancesOperation build() {
+            return new AddInstancesOperation(this);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureConnector.java
@@ -1,7 +1,10 @@
 package com.sequenceiq.cloudbreak.service.stack.connector.azure;
 
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.locks.Lock;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -12,6 +15,7 @@ import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.Credential;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.service.events.CloudbreakEventService;
 import com.sequenceiq.cloudbreak.service.stack.connector.CloudPlatformConnector;
 import com.sequenceiq.cloudbreak.service.stack.connector.ParallelCloudResourceManager;
 import com.sequenceiq.cloudbreak.service.stack.resource.azure.builders.AzureResourceBuilderInit;
@@ -26,39 +30,69 @@ public class AzureConnector implements CloudPlatformConnector {
     @Autowired
     private ParallelCloudResourceManager cloudResourceManager;
 
+    @Autowired
+    private CloudbreakEventService cloudbreakEventService;
+
+    private Map<String, Lock> lockMap = Collections.synchronizedMap(new HashMap<String, Lock>());
+
     @Override
-    public Set<Resource> buildStack(Stack stack, String gateWayUserData, String coreUserData, Map<String, Object> setupProperties) {
-        return cloudResourceManager.buildStackResources(stack, gateWayUserData, coreUserData, azureResourceBuilderInit);
+    public Set<Resource> buildStack(final Stack stack, final String gateWayUserData, final String coreUserData,
+            final Map<String, Object> setupProperties) {
+        BuildStackOperation buildStackOperation = buildAzureOperation(new BuildStackOperation.Builder(), stack)
+                .withGateWayUserData(gateWayUserData)
+                .withCoreUserData(coreUserData)
+                .build();
+        return buildStackOperation.execute();
     }
 
     @Override
     public Set<Resource> addInstances(Stack stack, String gateWayUserData, String coreUserData, Integer instanceCount, String instanceGroup) {
-        return cloudResourceManager.addNewResources(stack, coreUserData, instanceCount, instanceGroup, azureResourceBuilderInit);
+        AddInstancesOperation addInstancesOperation = buildAzureOperation(new AddInstancesOperation.Builder(), stack)
+                .withGateWayUserData(gateWayUserData)
+                .withCoreUserData(coreUserData)
+                .withInstanceCount(instanceCount)
+                .withInstanceGroup(instanceGroup)
+                .build();
+        return addInstancesOperation.execute();
     }
 
     @Override
     public Set<String> removeInstances(Stack stack, Set<String> origInstanceIds, String instanceGroup) {
-        return cloudResourceManager.removeExistingResources(stack, origInstanceIds, azureResourceBuilderInit);
+        RemoveInstancesOperation removeInstancesOperation = buildAzureOperation(new RemoveInstancesOperation.Builder(), stack)
+                .withOrigInstanceIds(origInstanceIds).build();
+        return removeInstancesOperation.execute();
     }
 
     @Override
     public void deleteStack(final Stack stack, Credential credential) {
-        cloudResourceManager.terminateResources(stack, azureResourceBuilderInit);
+        DeleteStackOperation deleteStackOperation = buildAzureOperation(new DeleteStackOperation.DeleteStackOperationBuilder(), stack).build();
+        deleteStackOperation.execute();
     }
 
     @Override
     public void rollback(final Stack stack, Set<Resource> resourceSet) {
-        cloudResourceManager.rollbackResources(stack, azureResourceBuilderInit);
+        RollbackOperation rollbackOperation = buildAzureOperation(new RollbackOperation.Builder(), stack).build();
+        rollbackOperation.execute();
     }
 
     @Override
     public boolean startAll(Stack stack) {
-        return cloudResourceManager.startStopResources(stack, true, azureResourceBuilderInit);
+        StartStopOperation startOperation = buildAzureOperation(new StartStopOperation.Builder(), stack)
+                .withStarted(true).build();
+        return startOperation.execute();
     }
 
     @Override
     public boolean stopAll(Stack stack) {
-        return cloudResourceManager.startStopResources(stack, false, azureResourceBuilderInit);
+        StartStopOperation stopOperation = buildAzureOperation(new StartStopOperation.Builder(), stack)
+                .withStarted(false).build();
+        return stopOperation.execute();
+    }
+
+    @Override
+    public void updateAllowedSubnets(Stack stack, String gateWayUserData, String coreUserData) {
+        UpdateAllowedSubnetsOperation updateOperation = buildAzureOperation(new UpdateAllowedSubnetsOperation.Builder(), stack).build();
+        updateOperation.execute();
     }
 
     @Override
@@ -66,8 +100,13 @@ public class AzureConnector implements CloudPlatformConnector {
         return CloudPlatform.AZURE;
     }
 
-    @Override
-    public void updateAllowedSubnets(Stack stack, String gateWayUserData, String coreUserData) {
-        cloudResourceManager.updateAllowedSubnets(stack, azureResourceBuilderInit);
+    private <T extends AzureOperation.Builder> T buildAzureOperation(T builder, Stack stack) {
+        builder.withCloudbreakEventService(cloudbreakEventService)
+                .withLockMap(lockMap)
+                .withCloudResourceManager(cloudResourceManager)
+                .withAzureResourceBuilderInit(azureResourceBuilderInit)
+                .withStack(stack)
+                .withQueued(true);
+        return builder;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureOperation.java
@@ -1,0 +1,119 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import java.util.Map;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import com.sequenceiq.cloudbreak.domain.AzureCredential;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.service.events.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.service.stack.connector.ParallelCloudResourceManager;
+import com.sequenceiq.cloudbreak.service.stack.resource.azure.builders.AzureResourceBuilderInit;
+
+public abstract class AzureOperation<T> {
+    private CloudbreakEventService cloudbreakEventService;
+    private Map<String, Lock> lockMap;
+    private AzureResourceBuilderInit azureResourceBuilderInit;
+    private ParallelCloudResourceManager cloudResourceManager;
+    private Stack stack;
+    private boolean queued;
+
+    protected AzureOperation(Builder builder) {
+        this.azureResourceBuilderInit = builder.azureResourceBuilderInit;
+        this.cloudResourceManager = builder.cloudResourceManager;
+        this.cloudbreakEventService = builder.cloudbreakEventService;
+        this.lockMap = builder.lockMap;
+        this.stack = builder.stack;
+        this.queued = builder.queued;
+    }
+
+    public T execute() {
+        if (queued) {
+            Lock lock = getLock(stack);
+            try {
+                boolean lockSuccess = lock.tryLock();
+                if (!lockSuccess) {
+                    cloudbreakEventService.fireCloudbreakEvent(stack.getId(), stack.getStatus().name(),
+                            "Waiting for other azure stack operation with the same subscriptionId to be finished.");
+                    lock.lock();
+                    cloudbreakEventService.fireCloudbreakEvent(stack.getId(), stack.getStatus().name(),
+                            "Continue: " + stack.getStatusReason());
+                }
+                return doExecute(stack);
+            } finally {
+                lock.unlock();
+                removeLock(stack, lock);
+            }
+        } else {
+            return doExecute(stack);
+        }
+    }
+
+    protected abstract T doExecute(Stack stack);
+
+    protected AzureResourceBuilderInit getAzureResourceBuilderInit() {
+        return azureResourceBuilderInit;
+    }
+
+    protected ParallelCloudResourceManager getCloudResourceManager() {
+        return cloudResourceManager;
+    }
+
+    private Lock getLock(Stack stack) {
+        synchronized (lockMap) {
+            String subscriptionId = ((AzureCredential) stack.getCredential()).getSubscriptionId();
+            Lock lock = lockMap.get(subscriptionId);
+            if (lock == null) {
+                lock = new ReentrantLock(true);
+                lockMap.put(subscriptionId, lock);
+            }
+            return lock;
+        }
+    }
+
+    private void removeLock(Stack stack, Lock lock) {
+        if (lock.tryLock()) {
+            lockMap.remove(((AzureCredential) stack.getCredential()).getSubscriptionId());
+            lock.unlock();
+        }
+    }
+
+    public static class Builder {
+        private CloudbreakEventService cloudbreakEventService;
+        private Map<String, Lock> lockMap;
+        private AzureResourceBuilderInit azureResourceBuilderInit;
+        private ParallelCloudResourceManager cloudResourceManager;
+        private Stack stack;
+        private boolean queued = true;
+
+        public Builder withCloudbreakEventService(CloudbreakEventService cloudbreakEventService) {
+            this.cloudbreakEventService = cloudbreakEventService;
+            return this;
+        }
+
+        public Builder withLockMap(Map<String, Lock> lockMap) {
+            this.lockMap = lockMap;
+            return this;
+        }
+
+        public Builder withAzureResourceBuilderInit(AzureResourceBuilderInit azureResourceBuilderInit) {
+            this.azureResourceBuilderInit = azureResourceBuilderInit;
+            return this;
+        }
+
+        public Builder withCloudResourceManager(ParallelCloudResourceManager cloudResourceManager) {
+            this.cloudResourceManager = cloudResourceManager;
+            return this;
+        }
+
+        public Builder withStack(Stack stack) {
+            this.stack = stack;
+            return this;
+        }
+
+        public Builder withQueued(boolean queued) {
+            this.queued = queued;
+            return this;
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/BuildStackOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/BuildStackOperation.java
@@ -1,0 +1,41 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.domain.Resource;
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class BuildStackOperation extends AzureOperation<Set<Resource>> {
+    private String gateWayUserData;
+    private String coreUserData;
+
+    private BuildStackOperation(Builder builder) {
+        super(builder);
+        this.gateWayUserData = builder.gateWayUserData;
+        this.coreUserData = builder.coreUserData;
+    }
+
+    @Override
+    protected Set<Resource> doExecute(Stack stack) {
+        return getCloudResourceManager().buildStackResources(stack, gateWayUserData, coreUserData, getAzureResourceBuilderInit());
+    }
+
+    public static class Builder extends AzureOperation.Builder {
+        private String gateWayUserData;
+        private String coreUserData;
+
+        public Builder withGateWayUserData(String gateWayUserData) {
+            this.gateWayUserData = gateWayUserData;
+            return this;
+        }
+
+        public Builder withCoreUserData(String coreUserData) {
+            this.coreUserData = coreUserData;
+            return this;
+        }
+
+        public BuildStackOperation build() {
+            return new BuildStackOperation(this);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/DeleteStackOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/DeleteStackOperation.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class DeleteStackOperation extends AzureOperation<Void> {
+    private DeleteStackOperation(DeleteStackOperationBuilder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected Void doExecute(Stack stack) {
+        getCloudResourceManager().terminateResources(stack, getAzureResourceBuilderInit());
+        return null;
+    }
+
+    public static class DeleteStackOperationBuilder extends AzureOperation.Builder {
+        public DeleteStackOperation build() {
+            return new DeleteStackOperation(this);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/RemoveInstancesOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/RemoveInstancesOperation.java
@@ -1,0 +1,32 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class RemoveInstancesOperation extends AzureOperation<Set<String>> {
+    private Set<String> origInstanceIds;
+
+    private RemoveInstancesOperation(Builder builder) {
+        super(builder);
+        this.origInstanceIds = builder.origInstanceIds;
+    }
+
+    @Override
+    protected Set<String> doExecute(Stack stack) {
+        return getCloudResourceManager().removeExistingResources(stack, origInstanceIds, getAzureResourceBuilderInit());
+    }
+
+    public static class Builder extends AzureOperation.Builder {
+        private Set<String> origInstanceIds;
+
+        public Builder withOrigInstanceIds(Set<String> origInstanceIds) {
+            this.origInstanceIds = origInstanceIds;
+            return this;
+        }
+
+        public RemoveInstancesOperation build() {
+            return new RemoveInstancesOperation(this);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/RollbackOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/RollbackOperation.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class RollbackOperation extends AzureOperation<Void> {
+    private RollbackOperation(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected Void doExecute(Stack stack) {
+        getCloudResourceManager().rollbackResources(stack, getAzureResourceBuilderInit());
+        return null;
+    }
+
+    public static class Builder extends AzureOperation.Builder {
+        public RollbackOperation build() {
+            return new RollbackOperation(this);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/StartStopOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/StartStopOperation.java
@@ -1,0 +1,30 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class StartStopOperation extends AzureOperation<Boolean> {
+    private boolean started;
+
+    private StartStopOperation(Builder builder) {
+        super(builder);
+        this.started = builder.started;
+    }
+
+    @Override
+    protected Boolean doExecute(Stack stack) {
+        return getCloudResourceManager().startStopResources(stack, started, getAzureResourceBuilderInit());
+    }
+
+    public static class Builder extends AzureOperation.Builder {
+        private boolean started;
+
+        public Builder withStarted(boolean started) {
+            this.started = started;
+            return this;
+        }
+
+        public StartStopOperation build() {
+            return new StartStopOperation(this);
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/UpdateAllowedSubnetsOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/UpdateAllowedSubnetsOperation.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.service.stack.connector.azure;
+
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class UpdateAllowedSubnetsOperation extends AzureOperation<Void> {
+    private UpdateAllowedSubnetsOperation(Builder builder) {
+        super(builder);
+    }
+
+    @Override
+    protected Void doExecute(Stack stack) {
+        getCloudResourceManager().updateAllowedSubnets(stack, getAzureResourceBuilderInit());
+        return null;
+    }
+
+    public static class Builder extends AzureOperation.Builder {
+        public UpdateAllowedSubnetsOperation build() {
+            return new UpdateAllowedSubnetsOperation(this);
+        }
+    }
+}


### PR DESCRIPTION
AzureConnector refactor:
* azureConnector operations which belong to the same subscription cannot be executed parallel
* if an operation is in progress and an another should be started, notification will be sent about the waiting.
* all the azure operations are executed in this way
* the execution mode can be controlled with the "queued" parameter
* no state change to pending
* no retry mechanism in case of conflict error: if there are running operations started outside from the current cloudbreak conflicts with inner operations

Known bugs:
* if stack creation is in progress and the cluster will be terminated: ongoing pollings will be cancelled but termination can be failed because of conflict on azure operations. Solution: waiting for the pollings to be finsished before starting the termination.
* in case of termination during cluster installation the notifications are misleading:

```
5/19/2015 11:21:23 PM feriazur - create in progress: Creation of cluster infrastructure has started on the cloud provider.
5/19/2015 11:21:23 PM feriazur - create in progress: Started creating cluster infrastructure resources
5/19/2015 11:32:49 PM feriazur - available: Cluster infrastructure and ambari are available on the cloud. AMBARI_IP:104.47.149.26
5/19/2015 11:32:49 PM feriazur - update in progress: Building the Ambari cluster.
5/19/2015 11:34:13 PM feriazur - delete in progress: Termination of cluster infrastructure has started.
5/19/2015 11:34:13 PM feriazur - create failed: com.sequenceiq.cloudbreak.service.cluster.AmbariOperationFailedException: Cluster installation failed. Polling result: EXIT
5/19/2015 11:34:13 PM feriazur - available: Cluster installation failed. Error: com.sequenceiq.cloudbreak.service.cluster.AmbariOperationFailedException: Cluster installation failed. Polling result: EXIT
```

Jira tickets will be raised...

@akanto or @martonsereg pls review
