### PR TITLE
CLOUD-811 Eliminate swarm compile time dependency from core

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -58,7 +58,7 @@ dependencies {
     compile ("com.sequenceiq:azure-rest-client:${azureRestClientVersion}")                                          { exclude group: 'log4j' }
     compile (group: 'com.amazonaws',                name: 'aws-java-sdk',                   version: '1.9.35')      { exclude group: 'commons-logging' }
 
-    compile project(':orchestrator-swarm')
+    runtime project(':orchestrator-swarm')
     compile project(':orchestrator-api')
 
     runtime     group: 'activation',                name: 'activation',                     version: '1.0.2'

--- a/core/src/main/java/com/sequenceiq/cloudbreak/EnvironmentVariableConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/EnvironmentVariableConfig.java
@@ -38,6 +38,7 @@ public class EnvironmentVariableConfig {
     public static final String CB_FAILED_CLUSTER_INSTALLER_MAIL_TEMPLATE_PATH = "templates/cluster-installer-mail-fail.ftl";
 
     public static final String CB_CONTAINER_ORCHESTRATOR = "SWARM";
+    public static final String CB_SUPPORTED_CONTAINER_ORCHESTRATORS = "com.sequenceiq.cloudbreak.orchestrator.swarm.SwarmContainerOrchestrator";
     public static final String CB_DOCKER_CONTAINER_AMBARI_WARMUP = "sequenceiq/ambari-warmup:2.0.0-consul";
     public static final String CB_DOCKER_CONTAINER_AMBARI = "sequenceiq/ambari:2.0.0-consul";
     public static final String CB_DOCKER_CONTAINER_REGISTRATOR = "sequenceiq/registrator:v5.2";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ContainerOrchestratorResolver.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ContainerOrchestratorResolver.java
@@ -1,0 +1,35 @@
+package com.sequenceiq.cloudbreak.core.bootstrap.service;
+
+import static com.sequenceiq.cloudbreak.EnvironmentVariableConfig.CB_CONTAINER_ORCHESTRATOR;
+
+import java.util.Map;
+import javax.annotation.Resource;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.core.CloudbreakException;
+import com.sequenceiq.cloudbreak.orchestrator.ContainerOrchestrator;
+
+@Component
+public class ContainerOrchestratorResolver {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ContainerOrchestratorResolver.class);
+
+    @Value("${cb.container.orchestrator:" + CB_CONTAINER_ORCHESTRATOR + "}")
+    private String containerOrchestratorName;
+
+    @Resource
+    private Map<String, ContainerOrchestrator> containerOrchestrators;
+
+    public ContainerOrchestrator get() throws CloudbreakException {
+        ContainerOrchestrator co = containerOrchestrators.get(containerOrchestratorName);
+        if (co == null) {
+            LOGGER.error("ContainerOrchestrator not found: {}, supported ContainerOrchestrators: {}", containerOrchestratorName, containerOrchestrators);
+            throw new CloudbreakException("ContainerOrchestrator not found: " + containerOrchestratorName);
+        }
+        return containerOrchestrators.get(containerOrchestratorName);
+    }
+}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/ContainerOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/ContainerOrchestrator.java
@@ -5,20 +5,29 @@ import java.util.Set;
 
 public interface ContainerOrchestrator {
 
+    String name();
+
+    void init(ParallelContainerRunner parallelContainerRunner);
+
     void bootstrap(String gatewayAddress, Set<Node> nodes, int consulServerCount) throws CloudbreakOrchestratorException;
+
     void bootstrapNewNodes(String gatewayAddress, Set<Node> nodes) throws CloudbreakOrchestratorException;
+
     void startRegistrator(ContainerOrchestratorCluster cluster, String imageName) throws CloudbreakOrchestratorException;
+
     void startAmbariServer(ContainerOrchestratorCluster cluster, String dbImageName,
             String serverImageName, String platform) throws CloudbreakOrchestratorException;
+
     void startAmbariAgents(ContainerOrchestratorCluster cluster, String imageName, int count, String platform) throws CloudbreakOrchestratorException;
+
     void startConsulWatches(ContainerOrchestratorCluster cluster, String imageName, int count) throws CloudbreakOrchestratorException;
 
     boolean areAllNodesAvailable(String gatewayAddress, Set<Node> nodes);
+
     List<String> getAvailableNodes(String gatewayAddress, Set<Node> nodes);
+
     boolean isBootstrapApiAvailable(String gatewayAddress);
 
     int getMaxBootstrapNodes();
-
-    ContainerOrchestratorTool type();
 
 }

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/ContainerOrchestratorTool.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/ContainerOrchestratorTool.java
@@ -1,5 +1,0 @@
-package com.sequenceiq.cloudbreak.orchestrator;
-
-public enum ContainerOrchestratorTool {
-    SWARM
-}

--- a/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/SimpleContainerOrchestrator.java
+++ b/orchestrator-api/src/main/java/com/sequenceiq/cloudbreak/orchestrator/SimpleContainerOrchestrator.java
@@ -4,11 +4,12 @@ public abstract class SimpleContainerOrchestrator implements ContainerOrchestrat
 
     private ParallelContainerRunner parallelContainerRunner;
 
-    public SimpleContainerOrchestrator(ParallelContainerRunner parallelContainerRunner) {
+    @Override
+    public void init(ParallelContainerRunner parallelContainerRunner) {
         this.parallelContainerRunner = parallelContainerRunner;
     }
 
-    public ParallelContainerRunner getParallelContainerRunner() {
+    protected ParallelContainerRunner getParallelContainerRunner() {
         return parallelContainerRunner;
     }
 }

--- a/orchestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orchestrator/swarm/SwarmContainerOrchestrator.java
+++ b/orchestrator-swarm/src/main/java/com/sequenceiq/cloudbreak/orchestrator/swarm/SwarmContainerOrchestrator.java
@@ -1,6 +1,6 @@
 package com.sequenceiq.cloudbreak.orchestrator.swarm;
 
-import static com.sequenceiq.cloudbreak.orchestrator.ContainerOrchestratorTool.SWARM;
+
 import static com.sequenceiq.cloudbreak.orchestrator.SimpleContainerBootstrapRunner.simpleContainerBootstrapRunner;
 
 import java.util.ArrayList;
@@ -23,9 +23,7 @@ import com.github.dockerjava.jaxrs.DockerCmdExecFactoryImpl;
 import com.google.common.annotations.VisibleForTesting;
 import com.sequenceiq.cloudbreak.orchestrator.CloudbreakOrchestratorException;
 import com.sequenceiq.cloudbreak.orchestrator.ContainerOrchestratorCluster;
-import com.sequenceiq.cloudbreak.orchestrator.ContainerOrchestratorTool;
 import com.sequenceiq.cloudbreak.orchestrator.Node;
-import com.sequenceiq.cloudbreak.orchestrator.ParallelContainerRunner;
 import com.sequenceiq.cloudbreak.orchestrator.SimpleContainerBootstrapRunner;
 import com.sequenceiq.cloudbreak.orchestrator.SimpleContainerOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.swarm.containers.AmbariAgentBootstrap;
@@ -42,9 +40,6 @@ public class SwarmContainerOrchestrator extends SimpleContainerOrchestrator {
     private static final String MUNCHAUSEN_DOCKER_IMAGE = "sequenceiq/munchausen:0.3";
     private static final int MAX_IP_FOR_ONE_REQUEST = 600;
 
-    public SwarmContainerOrchestrator(ParallelContainerRunner parallelContainerRunner) {
-        super(parallelContainerRunner);
-    }
 
     /**
      * Bootstraps a Swarm based container orchestration cluster with a Consul discovery backend with the Munchausen tool.
@@ -235,8 +230,8 @@ public class SwarmContainerOrchestrator extends SimpleContainerOrchestrator {
     }
 
     @Override
-    public ContainerOrchestratorTool type() {
-        return SWARM;
+    public String name() {
+        return "SWARM";
     }
 
     private Set<String> selectConsulServers(String gatewayAddress, Set<String> privateAddresses, int consulServerCount) {


### PR DESCRIPTION
@martonsereg please check

- core has only runtime dependency on swarm
- eliminate the ContainerOrchestratorTool enum to make the plugin mechanism more dynamic
- delete code duplication by introducing ContainerOrchestratorResolver
- some code formatting