### PR TITLE
cleaned up stack and cluster layers in start/stop implementation

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/AbstractFlowHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/AbstractFlowHandler.java
@@ -46,6 +46,10 @@ public abstract class AbstractFlowHandler<T extends DefaultFlowContext> implemen
             result = execute(event);
             success = true;
         } catch (Exception t) {
+            if (t instanceof FlowCancelledException || t.getCause() instanceof FlowCancelledException) {
+                LOGGER.warn("Flow was cancelled: {}", t.getMessage());
+                return;
+            }
             consumeError(event, t);
             try {
                 result = handleErrorFlow(t, event.getData());

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/FlowCancelledException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/FlowCancelledException.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.core.flow;
+
+public class FlowCancelledException extends RuntimeException {
+    public FlowCancelledException(String message) {
+        super(message);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/context/StackStatusUpdateContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/context/StackStatusUpdateContext.java
@@ -4,7 +4,6 @@ import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 
 public class StackStatusUpdateContext extends DefaultFlowContext implements FlowContext {
     private boolean start;
-    private boolean pollingError;
 
     public StackStatusUpdateContext(Long stackId, CloudPlatform cloudPlatform, boolean start) {
         super(stackId, cloudPlatform);
@@ -20,11 +19,4 @@ public class StackStatusUpdateContext extends DefaultFlowContext implements Flow
         return start;
     }
 
-    public boolean isPollingError() {
-        return pollingError;
-    }
-
-    public void setPollingError(boolean pollingError) {
-        this.pollingError = pollingError;
-    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/handlers/ClusterStartHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/handlers/ClusterStartHandler.java
@@ -21,4 +21,10 @@ public class ClusterStartHandler extends AbstractFlowHandler<StackStatusUpdateCo
         StackStatusUpdateContext context = event.getData();
         return getFlowFacade().startCluster(context);
     }
+
+
+    @Override
+    protected Object handleErrorFlow(Throwable throwable, StackStatusUpdateContext data) throws Exception {
+        return super.handleErrorFlow(throwable, data);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/SimpleFlowFacade.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/SimpleFlowFacade.java
@@ -120,7 +120,7 @@ public class SimpleFlowFacade implements FlowFacade {
         try {
             return clusterFacade.runClusterContainers(context);
         } catch (Exception e) {
-            LOGGER.error("Exception during Ambari role allocation.", e);
+            LOGGER.error("Exception while setting up cluster containers.", e);
             throw new CloudbreakException(e);
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/SimpleStackFacade.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/SimpleStackFacade.java
@@ -150,6 +150,7 @@ public class SimpleStackFacade implements StackFacade {
             MDCBuilder.buildMdcContext(stackService.getById(stackStatusUpdateContext.getStackId()));
             LOGGER.debug("Starting stack. Context: {}", stackStatusUpdateContext);
             context = stackStartService.start(stackStatusUpdateContext);
+            stackUpdater.updateStackStatus(stackStatusUpdateContext.getStackId(), Status.AVAILABLE, "Instances were started.");
             LOGGER.debug("Starting stack is DONE.");
             return context;
         } catch (Exception e) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/PollingResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/PollingResult.java
@@ -10,4 +10,9 @@ public enum PollingResult {
     public static boolean isExited(PollingResult pollingResult) {
         return PollingResult.EXIT.equals(pollingResult);
     }
+
+    public static boolean isTimeout(PollingResult pollingResult) {
+        return PollingResult.TIMEOUT.equals(pollingResult);
+    }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariHealthCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariHealthCheckerTask.java
@@ -21,7 +21,7 @@ public class AmbariHealthCheckerTask extends StackBasedStatusCheckerTask<AmbariC
             }
             return false;
         } catch (Exception e) {
-            LOGGER.info("Ambari is not running yet, polling");
+            LOGGER.info("Ambari is not running yet: {}", e.getMessage());
             return false;
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariHostsJoinStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariHostsJoinStatusCheckerTask.java
@@ -8,7 +8,6 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.cloudbreak.service.StackBasedStatusCheckerTask;
-import com.sequenceiq.cloudbreak.service.cluster.AmbariHostsUnavailableException;
 
 @Component
 public class AmbariHostsJoinStatusCheckerTask extends StackBasedStatusCheckerTask<AmbariHosts> {
@@ -35,8 +34,7 @@ public class AmbariHostsJoinStatusCheckerTask extends StackBasedStatusCheckerTas
 
     @Override
     public void handleTimeout(AmbariHosts t) {
-        throw new AmbariHostsUnavailableException(String.format("Operation timed out. Failed to find all '%s' Ambari hosts. Stack: '%s'",
-                t.getHostCount(), t.getStack().getId()));
+        LOGGER.error("Operation timed out. Failed to find all '{}' Ambari hosts. Stack: '{}'", t.getHostCount(), t.getStack().getId());
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackFailureHandlerService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackFailureHandlerService.java
@@ -60,8 +60,6 @@ public class StackFailureHandlerService implements FailureHandlerService {
                 throwError(localStack, failedResourceRequestResults);
             }
         } else {
-            eventService.fireCloudbreakEvent(stack.getId(), Status.UPDATE_IN_PROGRESS.name(),
-                    "Error occurred during the provisioning so some resource will be rolled back");
             switch (localStack.getFailurePolicy().getAdjustmentType()) {
             case EXACT:
                 if (localStack.getFailurePolicy().getThreshold() > localStack.getFullNodeCount() - failedResourceRequestResults.size()) {


### PR DESCRIPTION
@doktoric please check this

Main goal was to separate logic in cluster and stack layers. 
When starting a cluster, checking the Ambari server and starting the agents are part of the cluster layer. When stopping a cluster, stopping the agents are again part of the cluster layer.
I've also cleaned up the code in some classes.