### PR TITLE
CLOUD-823 specifying tenant_id requires admin rights, just use the au…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/HeatTemplateBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/openstack/HeatTemplateBuilder.java
@@ -101,7 +101,6 @@ public class HeatTemplateBuilder {
         parameters.put("public_net_id", publicNetId);
         parameters.put("image_id", image);
         parameters.put("key_name", openStackUtil.getKeyPairName(credential));
-        parameters.put("tenant_id", credential.getTenantName());
         parameters.put("app_net_cidr", network.getSubnetCIDR());
         return parameters;
     }

--- a/core/src/main/resources/templates/openstack-heat.ftl
+++ b/core/src/main/resources/templates/openstack-heat.ftl
@@ -9,9 +9,6 @@ parameters:
   key_name:
     type: string
     description : Name of a KeyPair to enable SSH access to the instance
-  tenant_id:
-    type: string
-    description : ID of the tenant
   image_id:
     type: string
     description: ID of the image
@@ -29,8 +26,6 @@ resources:
       properties:
         admin_state_up: true
         name: app_network
-        shared: true
-        tenant_id: { get_param: tenant_id }
 
   app_subnet:
       type: OS::Neutron::Subnet


### PR DESCRIPTION
…thenticated one instead of setting it