### PR TITLE
CLOUD-835 cleaned Azure logging

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureResourcePollerObject.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureResourcePollerObject.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import com.sequenceiq.cloud.azure.client.AzureClient;
+import com.sequenceiq.cloudbreak.domain.ResourceType;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.service.StackContext;
 
@@ -13,14 +14,20 @@ import groovyx.net.http.HttpResponseDecorator;
 public class AzureResourcePollerObject extends StackContext {
 
     private AzureClient azureClient;
+    private ResourceType resourceType;
+    private String resourceName;
     private List<HttpResponseDecorator> responses;
 
-    public AzureResourcePollerObject(AzureClient azureClient, Stack stack, HttpResponseDecorator... responses) {
-        this(azureClient, stack, Arrays.asList(responses));
+    public AzureResourcePollerObject(AzureClient azureClient, ResourceType resourceType, String resourceName,
+            Stack stack, HttpResponseDecorator... responses) {
+        this(azureClient, resourceType, resourceName, stack, Arrays.asList(responses));
     }
 
-    public AzureResourcePollerObject(AzureClient azureClient, Stack stack, List<HttpResponseDecorator> responses) {
+    public AzureResourcePollerObject(AzureClient azureClient, ResourceType resourceType, String resourceName,
+            Stack stack, List<HttpResponseDecorator> responses) {
         super(stack);
+        this.resourceType = resourceType;
+        this.resourceName = resourceName;
         this.responses = new ArrayList<>(responses);
         this.azureClient = azureClient;
     }
@@ -29,16 +36,15 @@ public class AzureResourcePollerObject extends StackContext {
         return azureClient;
     }
 
-    public void setAzureClient(AzureClient azureClient) {
-        this.azureClient = azureClient;
-    }
-
     public List<HttpResponseDecorator> getResponses() {
         return responses;
     }
 
-    public void setResponses(List<HttpResponseDecorator> responses) {
-        this.responses = responses;
+    public ResourceType getType() {
+        return resourceType;
     }
 
+    public String getName() {
+        return resourceName;
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureResourceStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureResourceStatusCheckerTask.java
@@ -29,6 +29,7 @@ public abstract class AzureResourceStatusCheckerTask extends SimpleStatusChecker
         Iterator<HttpResponseDecorator> iterator = responses.iterator();
         while (iterator.hasNext()) {
             try {
+                LOGGER.info("Checking status of Azure resource type: {} name: {}", t.getType(), t.getName());
                 HttpResponseDecorator response = iterator.next();
                 String requestId = getRequestId(response);
                 String requestStatus = String.valueOf(t.getAzureClient().getRequestStatus(requestId));
@@ -56,13 +57,14 @@ public abstract class AzureResourceStatusCheckerTask extends SimpleStatusChecker
 
     @Override
     public void handleTimeout(AzureResourcePollerObject t) {
-        throw new AzureResourceException(String.format("Operation timed out. Azure resource could not reach the desired status: %s on stack.",
-                t.getStack().getId()));
+        throw new AzureResourceException(String.format("Operation timed out. Azure resource type: %s name: %s could not reach the desired state on stack: %s",
+                t.getType(), t.getName(), t.getStack().getId()));
     }
 
     @Override
     public String successMessage(AzureResourcePollerObject t) {
-        return String.format("Azure resource successfully reached status: %s on stack.", t.getStack().getId());
+        return String.format("Azure resource type: %s name: %s successfully reached the desired state on stack: %s",
+                t.getType(), t.getName(), t.getStack().getId());
     }
 
     private String getRequestId(HttpResponseDecorator response) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/instance/AzureCloudServiceResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/instance/AzureCloudServiceResourceBuilder.java
@@ -58,8 +58,11 @@ public class AzureCloudServiceResourceBuilder extends AzureSimpleInstanceResourc
     public Boolean create(final CreateResourceRequest createResourceRequest, String region) throws Exception {
         AzureCloudServiceCreateRequest aCSCR = (AzureCloudServiceCreateRequest) createResourceRequest;
         try {
-            HttpResponseDecorator cloudServiceResponse = (HttpResponseDecorator) aCSCR.getAzureClient().createCloudService(aCSCR.getProps());
-            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(aCSCR.getAzureClient(), aCSCR.getStack(), cloudServiceResponse);
+            Map<String, String> props = aCSCR.getProps();
+            AzureClient azureClient = aCSCR.getAzureClient();
+            HttpResponseDecorator cloudServiceResponse = (HttpResponseDecorator) azureClient.createCloudService(props);
+            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                    azureClient, ResourceType.AZURE_CLOUD_SERVICE, props.get(NAME), aCSCR.getStack(), cloudServiceResponse);
             azureResourcePollerObjectPollingService.pollWithTimeout(azureCreateResourceStatusCheckerTask, azureResourcePollerObject,
                     POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
         } catch (Exception ex) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/instance/AzureServiceCertificateResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/instance/AzureServiceCertificateResourceBuilder.java
@@ -51,8 +51,11 @@ public class AzureServiceCertificateResourceBuilder extends AzureSimpleInstanceR
     public Boolean create(final CreateResourceRequest createResourceRequest, final String region) throws Exception {
         AzureServiceCertificateCreateRequest aCSCR = (AzureServiceCertificateCreateRequest) createResourceRequest;
         try {
-            HttpResponseDecorator serviceCertificate = (HttpResponseDecorator) aCSCR.getAzureClient().createServiceCertificate(aCSCR.getProps());
-            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(aCSCR.getAzureClient(), aCSCR.getStack(), serviceCertificate);
+            Map<String, String> props = aCSCR.getProps();
+            AzureClient azureClient = aCSCR.getAzureClient();
+            HttpResponseDecorator serviceCertificate = (HttpResponseDecorator) azureClient.createServiceCertificate(props);
+            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                    azureClient, ResourceType.AZURE_SERVICE_CERTIFICATE, props.get(NAME), aCSCR.getStack(), serviceCertificate);
             azureResourcePollerObjectPollingService.pollWithTimeout(azureCreateResourceStatusCheckerTask, azureResourcePollerObject,
                     POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
         } catch (Exception ex) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/instance/AzureVirtualMachineResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/instance/AzureVirtualMachineResourceBuilder.java
@@ -77,9 +77,11 @@ public class AzureVirtualMachineResourceBuilder extends AzureSimpleInstanceResou
     public Boolean create(final CreateResourceRequest createResourceRequest, final String region) throws Exception {
         AzureVirtualMachineCreateRequest aCSCR = (AzureVirtualMachineCreateRequest) createResourceRequest;
         try {
-            HttpResponseDecorator virtualMachineResponse = (HttpResponseDecorator) aCSCR.getAzureClient().createVirtualMachine(aCSCR.getProps());
-            AzureResourcePollerObject azureResourcePollerObject =
-                    new AzureResourcePollerObject(aCSCR.getAzureClient(), aCSCR.getStack(), virtualMachineResponse);
+            Map<String, Object> props = aCSCR.getProps();
+            AzureClient azureClient = aCSCR.getAzureClient();
+            HttpResponseDecorator virtualMachineResponse = (HttpResponseDecorator) azureClient.createVirtualMachine(props);
+            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                    azureClient, ResourceType.AZURE_VIRTUAL_MACHINE, String.valueOf(props.get(NAME)), aCSCR.getStack(), virtualMachineResponse);
             azureResourcePollerObjectPollingService.pollWithTimeout(azureCreateResourceStatusCheckerTask, azureResourcePollerObject,
                     POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
         } catch (Exception ex) {
@@ -178,7 +180,8 @@ public class AzureVirtualMachineResourceBuilder extends AzureSimpleInstanceResou
             props.put(NAME, resource.getResourceName());
             AzureClient azureClient = azureStackUtil.createAzureClient(credential);
             HttpResponseDecorator deleteVirtualMachineResult = (HttpResponseDecorator) azureClient.deleteVirtualMachine(props);
-            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(azureClient, stack, deleteVirtualMachineResult);
+            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                    azureClient, ResourceType.AZURE_VIRTUAL_MACHINE, props.get(NAME), stack, deleteVirtualMachineResult);
             azureResourcePollerObjectPollingService.pollWithTimeout(azureDeleteResourceStatusCheckerTask, azureResourcePollerObject,
                     POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
         } catch (HttpResponseException ex) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/network/AzureReservedIpResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/network/AzureReservedIpResourceBuilder.java
@@ -53,10 +53,11 @@ public class AzureReservedIpResourceBuilder extends AzureSimpleNetworkResourceBu
     public Boolean create(CreateResourceRequest createResourceRequest, String region) throws Exception {
         AzureReservedIpCreateRequest azureReservedIpCreateRequest = (AzureReservedIpCreateRequest) createResourceRequest;
         try {
-            HttpResponseDecorator serviceCertificate = (HttpResponseDecorator) azureReservedIpCreateRequest.getAzureClient()
-                    .createReservedIP(azureReservedIpCreateRequest.getProps());
-            AzureResourcePollerObject azureResourcePollerObject =
-                    new AzureResourcePollerObject(azureReservedIpCreateRequest.getAzureClient(), azureReservedIpCreateRequest.getStack(), serviceCertificate);
+            AzureClient azureClient = azureReservedIpCreateRequest.getAzureClient();
+            Map<String, String> props = azureReservedIpCreateRequest.getProps();
+            HttpResponseDecorator serviceCertificate = (HttpResponseDecorator) azureClient.createReservedIP(props);
+            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                    azureClient, ResourceType.AZURE_RESERVED_IP, props.get(NAME), azureReservedIpCreateRequest.getStack(), serviceCertificate);
             azureResourcePollerObjectPollingService.pollWithTimeout(azureCreateResourceStatusCheckerTask, azureResourcePollerObject,
                     POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
         } catch (Exception ex) {
@@ -74,7 +75,8 @@ public class AzureReservedIpResourceBuilder extends AzureSimpleNetworkResourceBu
             props.put(NAME, resource.getResourceName());
             AzureClient azureClient = azureStackUtil.createAzureClient(credential);
             HttpResponseDecorator deleteVirtualMachineResult = (HttpResponseDecorator) azureClient.deleteReservedIP(props);
-            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(azureClient, stack, deleteVirtualMachineResult);
+            AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                    azureClient, ResourceType.AZURE_RESERVED_IP, resource.getResourceName(), stack, deleteVirtualMachineResult);
             azureResourcePollerObjectPollingService.pollWithTimeout(azureDeleteResourceStatusCheckerTask, azureResourcePollerObject,
                     POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
         } catch (HttpResponseException ex) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/network/AzureStorageAccountResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/builders/network/AzureStorageAccountResourceBuilder.java
@@ -63,7 +63,8 @@ public class AzureStorageAccountResourceBuilder extends AzureSimpleNetworkResour
                     HttpResponseException httpResponseException = (HttpResponseException) ex;
                     if (httpResponseException.getStatusCode() == NOT_FOUND) {
                         HttpResponseDecorator storageResponse = (HttpResponseDecorator) azureClient.createStorageAccount(properties);
-                        AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(azureClient, stack, storageResponse);
+                        AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                                azureClient, ResourceType.AZURE_STORAGE, storageName, stack, storageResponse);
                         azureResourcePollerObjectPollingService.pollWithTimeout(azureCreateResourceStatusCheckerTask, azureResourcePollerObject,
                                 POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
                     } else {
@@ -88,7 +89,8 @@ public class AzureStorageAccountResourceBuilder extends AzureSimpleNetworkResour
             String osImageName = azureStackUtil.getOsImageName(stack, storageName);
             if (azureClient.isImageAvailable(osImageName)) {
                 HttpResponseDecorator imageResponse = (HttpResponseDecorator) azureClient.deleteOsImage(osImageName);
-                AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(azureClient, stack, imageResponse);
+                AzureResourcePollerObject azureResourcePollerObject = new AzureResourcePollerObject(
+                        azureClient, ResourceType.AZURE_STORAGE, storageName, stack, imageResponse);
                 azureResourcePollerObjectPollingService.pollWithTimeout(azureDeleteResourceStatusCheckerTask, azureResourcePollerObject,
                         POLLING_INTERVAL, MAX_POLLING_ATTEMPTS, MAX_FAILURE_COUNT);
             }

--- a/core/src/main/resources/logback.xml
+++ b/core/src/main/resources/logback.xml
@@ -29,6 +29,10 @@
     <root level="INFO">
         <appender-ref ref="STDOUT"/>
     </root>
+    <logger name="com.sequenceiq.cloud.azure.client">
+        <level value="INFO"/>
+    </logger>
+
 
     <appender name="OWNER_BASED" class="ch.qos.logback.classic.sift.SiftingAppender">
         <discriminator>


### PR DESCRIPTION
@martonsereg 

Log messages like this: 

ce022217551f] [type:STACK] [id:1103] [name:marciteszt3] Response code: 200; found handler: org.codehaus.groovy.runtime.MethodClosure@13cc99e3

came from the Azure rest client due to its debug logging, but it's useless so I turned it off.

