### PR TITLE
CLOUD-873 Exceptions logged properly, with the stacktrace

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/CloudbreakErrorHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/CloudbreakErrorHandler.java
@@ -18,17 +18,17 @@ public class CloudbreakErrorHandler implements Consumer<Throwable> {
 
     @Override
     public void accept(Throwable errorData) {
-        LOGGER.debug("Consuming error:", errorData.getMessage());
+        LOGGER.debug("Applying event specific error logic on error with message: {} ", errorData.getMessage());
         errorLogic(errorData);
     }
 
     /**
-     * Place for default error consumption logic. ()
+     * Place for default event specific error consumption logic. ()
      *
      * @param errorData the exception to be consumed
      */
     protected void errorLogic(Throwable errorData) {
-        LOGGER.info("Default error consumption logic: Do nothing. Exception message: {}", errorData.getMessage());
+        LOGGER.info("Default event specific error logic - logging the received trowable: ", errorData);
     }
 
 }


### PR DESCRIPTION
* exceptions thrown from handlers are logged with the stacktrace
* the logging "logic" is moved to the CloudbreakErrorHandler
* cleaned some other log messages

@akanto please check this out 