### PR TITLE
CLOUD-872 fix default security rules and groups description and migration scripts

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/network/ExposedService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/network/ExposedService.java
@@ -16,8 +16,8 @@ public enum ExposedService {
     OOZIE("Oozie", "OOZIE_SERVER", "/oozie"),
     SPARK_HISTORY_SERVER("Spark History server", "SPARK_JOBHISTORYSERVER"),
     CONTAINER_LOGS("Container logs"),
-    ZEPPELI_WEB_SOCKET("Zeppelin web socket"),
-    ZEPPELI_UI("Zeppelin ui", "ZEPPELIN_MASTER"),
+    ZEPPELIN_WEB_SOCKET("Zeppelin web socket"),
+    ZEPPELIN_UI("Zeppelin ui", "ZEPPELIN_MASTER"),
     KIBANA("Kibana", "KIBANA"),
     ELASTIC_SEARCH("Elastic Search", "ELASTIC_SEARCH");
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/network/NetworkUtils.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/network/NetworkUtils.java
@@ -17,8 +17,8 @@ import static com.sequenceiq.cloudbreak.service.network.ExposedService.RESOURCEM
 import static com.sequenceiq.cloudbreak.service.network.ExposedService.SPARK_HISTORY_SERVER;
 import static com.sequenceiq.cloudbreak.service.network.ExposedService.SSH;
 import static com.sequenceiq.cloudbreak.service.network.ExposedService.STORM;
-import static com.sequenceiq.cloudbreak.service.network.ExposedService.ZEPPELI_UI;
-import static com.sequenceiq.cloudbreak.service.network.ExposedService.ZEPPELI_WEB_SOCKET;
+import static com.sequenceiq.cloudbreak.service.network.ExposedService.ZEPPELIN_UI;
+import static com.sequenceiq.cloudbreak.service.network.ExposedService.ZEPPELIN_WEB_SOCKET;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
@@ -48,8 +48,8 @@ public final class NetworkUtils {
         ports.add(new Port(OOZIE, "11000", "tcp"));
         ports.add(new Port(SPARK_HISTORY_SERVER, "18080", "tcp"));
         ports.add(new Port(CONTAINER_LOGS, "8042", "tcp"));
-        ports.add(new Port(ZEPPELI_WEB_SOCKET, "9996", "tcp"));
-        ports.add(new Port(ZEPPELI_UI, "9995", "tcp"));
+        ports.add(new Port(ZEPPELIN_WEB_SOCKET, "9996", "tcp"));
+        ports.add(new Port(ZEPPELIN_UI, "9995", "tcp"));
         ports.add(new Port(KIBANA, "3080", "tcp"));
         ports.add(new Port(ELASTIC_SEARCH, "9200", "tcp"));
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/securitygroup/DefaultSecurityGroupCreator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/securitygroup/DefaultSecurityGroupCreator.java
@@ -47,7 +47,7 @@ public class DefaultSecurityGroupCreator {
         Set<SecurityGroup> securityGroups = new HashSet<>();
 
         //create default strict security group
-        SecurityGroup onlySshAndSsl = createSecurityGroup(user, "only-ssh-and-ssl", "Only the 22 and 443 ports could be reached from any IP.");
+        SecurityGroup onlySshAndSsl = createSecurityGroup(user, "only-ssh-and-ssl", "Open ports: 22 (SSH) 443 (HTTPS)");
         SecurityRule sshAndSslRule = createSecurityRule("22,443", onlySshAndSsl);
         onlySshAndSsl.setSecurityRules(new HashSet<>(Arrays.asList(sshAndSslRule)));
         groupRepository.save(onlySshAndSsl);
@@ -55,7 +55,10 @@ public class DefaultSecurityGroupCreator {
         securityGroups.add(onlySshAndSsl);
 
         //create default security group which opens all of the known services' ports
-        SecurityGroup allServicesPort = createSecurityGroup(user, "all-services-port", "All the known services' ports could be reached from any IP.");
+        String allPortsOpenDesc = "Open ports: 8080 (Ambari) 8500 (Consul) 50070 (NN) 8088 (RM Web) 8030(RM Scheduler) 8050(RM IPC) "
+                + "19888(Job history server) 60010(HBase master) 15000(Falcon) 8744(Storm) 11000(Oozie) 18080(Spark HS) 8042(NM Web) "
+                + "9996(Zeppelin WebSocket) 9995(Zeppelin UI) 3080(Kibana) 9200(Elasticsearch)";
+        SecurityGroup allServicesPort = createSecurityGroup(user, "all-services-port", allPortsOpenDesc);
         SecurityRule allPortsRule = createSecurityRule(concatenateAllPortsKnownByCloudbreak(), allServicesPort);
         allServicesPort.setSecurityRules(new HashSet<>(Arrays.asList(allPortsRule)));
         groupRepository.save(allServicesPort);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/TerminationService.java
@@ -69,6 +69,7 @@ public class TerminationService {
             }
             stack.setCredential(null);
             stack.setNetwork(null);
+            stack.setSecurityGroup(null);
             stack.setName(terminatedName);
             terminateMetaDataInstances(stack);
             stackRepository.save(stack);

--- a/core/src/main/resources/schema/20150623133213_CLOUD-872_create_default_security_groups_and_rules.sql
+++ b/core/src/main/resources/schema/20150623133213_CLOUD-872_create_default_security_groups_and_rules.sql
@@ -1,0 +1,75 @@
+-- // CLOUD-872 create default security groups and rules
+-- Migration SQL that makes the change goes here.
+
+-- create temporary table for storing accounts that does not have default securitygroup and
+-- the created id of the default security groups for them
+CREATE TABLE create_security_groups_temp(
+  account         CHARACTER VARYING (255),
+  owner           CHARACTER VARYING (255),
+  securitygroup_id  bigint
+);
+
+
+WITH insert_temp AS (
+  INSERT INTO securitygroup (
+      name,
+      description,
+      account,
+      owner,
+      publicinaccount,
+      status
+  )
+    SELECT
+      'all-services-port' AS name,
+      'Open ports: 8080 (Ambari) 8500 (Consul) 50070 (NN) 8088 (RM Web) 8030(RM Scheduler) 8050(RM IPC) 19888(Job history server) 60010(HBase master) 15000(Falcon) 8744(Storm) 11000(Oozie) 18080(Spark HS) 8042(NM Web) 9996(Zeppelin WebSocket) 9995(Zeppelin UI) 3080(Kibana) 9200(Elasticsearch)' AS description,
+      csgt.account AS account,
+      csgt.owner AS owner,
+      true AS publicinaccount,
+      'DEFAULT' AS status
+    FROM (  SELECT
+              s.account AS account,
+              max(s.owner) AS owner
+            FROM stack s
+              where s.account NOT IN (select sg.account from securitygroup sg) AND s.status <> 'DELETE_COMPLETED'
+              group by s.account) csgt
+  RETURNING id AS securitygroup_id, account AS account, owner AS owner
+)
+INSERT INTO create_security_groups_temp(
+    securitygroup_id,
+    account,
+    owner
+  ) SELECT securitygroup_id,account,owner from insert_temp;
+
+
+-- insert default security rules for the newly created security groups
+INSERT INTO securityrule (
+  securitygroup_id,
+  cidr,
+  ports,
+  protocol,
+  modifiable
+)
+SELECT
+  s.id AS securitygroup_id,
+  '0.0.0.0/0' AS cidr,
+  '22,443,8080,8500,50070,8088,8030,8050,19888,60010,15000,8744,11000,18080,8042,9996,9995,3080,9200' AS ports,
+  'tcp' AS protocol,
+  false AS modifiable
+FROM securitygroup s
+  where s.account IN (SELECT account FROM create_security_groups_temp);
+
+
+UPDATE stack SET securitygroup_id = subquery.id
+  FROM (SELECT id, account FROM securitygroup) AS subquery
+  WHERE
+      stack.account=subquery.account AND
+      stack.securitygroup_id IS NULL AND
+      stack.status <> 'DELETE_COMPLETED';
+
+-- drop the temporary table
+DROP TABLE IF EXISTS create_security_groups_temp;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+


### PR DESCRIPTION
@keyki or @martonsereg please review it!

Changes:
 - detach security group form stack at termination
 - update default security groups description
 - create a migration script that creates default security groups and rules for existing stacks (it is tested on a production like database)