### PR TITLE
DEV-45 propagate exceptions on start-stop

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/HostMetadata.java
@@ -36,6 +36,10 @@ public class HostMetadata {
 
     }
 
+    public Long getId() {
+        return id;
+    }
+
     public String getHostName() {
         return hostName;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/StackStartService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/StackStartService.java
@@ -30,10 +30,7 @@ public class StackStartService {
     public FlowContext start(FlowContext context) throws CloudbreakException {
         StackStatusUpdateContext stackStatusUpdateContext = (StackStatusUpdateContext) context;
         Stack stack = stackRepository.findOneWithLists(stackStatusUpdateContext.getStackId());
-        CloudPlatformConnector connector = cloudPlatformConnectors.get(stack.cloudPlatform());
-        if (!connector.startAll(stack)) {
-            throw new CloudbreakException("The cluster infrastructure cannot be started.");
-        }
+        cloudPlatformConnectors.get(stack.cloudPlatform()).startAll(stack);
         return stackStatusUpdateContext;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/StackStopService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/StackStopService.java
@@ -47,12 +47,8 @@ public class StackStopService {
         StackStatusUpdateContext stackStatusUpdateContext = (StackStatusUpdateContext) context;
         long stackId = stackStatusUpdateContext.getStackId();
         Stack stack = stackRepository.findOneWithLists(stackId);
-        CloudPlatformConnector connector = cloudPlatformConnectors.get(stack.cloudPlatform());
-        if (connector.stopAll(stack)) {
-            return stackStatusUpdateContext;
-        } else {
-            throw new CloudbreakException("The cluster infrastructure could not be stopped.");
-        }
+        cloudPlatformConnectors.get(stack.cloudPlatform()).stopAll(stack);
+        return stackStatusUpdateContext;
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/CloudPlatformConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/CloudPlatformConnector.java
@@ -20,9 +20,9 @@ public interface CloudPlatformConnector {
 
     void rollback(Stack stack, Set<Resource> resourceSet);
 
-    boolean startAll(Stack stack);
+    void startAll(Stack stack);
 
-    boolean stopAll(Stack stack);
+    void stopAll(Stack stack);
 
     CloudPlatform getCloudPlatform();
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
@@ -360,13 +360,13 @@ public class AwsConnector implements CloudPlatformConnector {
     }
 
     @Override
-    public boolean startAll(Stack stack) {
-        return setStackState(stack, false);
+    public void startAll(Stack stack) {
+        setStackState(stack, false);
     }
 
     @Override
-    public boolean stopAll(Stack stack) {
-        return setStackState(stack, true);
+    public void stopAll(Stack stack) {
+        setStackState(stack, true);
     }
 
     /**
@@ -467,8 +467,7 @@ public class AwsConnector implements CloudPlatformConnector {
         return image.getRootDeviceName();
     }
 
-    private boolean setStackState(Stack stack, boolean stopped) {
-        boolean result = true;
+    private void setStackState(Stack stack, boolean stopped) {
         Regions region = Regions.valueOf(stack.getRegion());
         AwsCredential credential = (AwsCredential) stack.getCredential();
         AmazonAutoScalingClient amazonASClient = awsStackUtil.createAutoScalingClient(region, credential);
@@ -507,11 +506,9 @@ public class AwsConnector implements CloudPlatformConnector {
                     updateInstanceMetadata(stack, amazonEC2Client, stack.getRunningInstanceMetaData(), instances);
                 }
             } catch (Exception e) {
-                LOGGER.error(String.format("Failed to %s AWS instances on stack: %s", stopped ? "stop" : "start", stack.getId()), e);
-                result = false;
+                throw new AwsResourceException(String.format("Failed to %s AWS instances on stack: %s", stopped ? "stop" : "start", stack.getId()), e);
             }
         }
-        return result;
     }
 
     private Collection<String> removeInstanceIdsWhichAreNotInCorrectState(Collection<String> instances, AmazonEC2Client amazonEC2Client, String state) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureConnector.java
@@ -107,17 +107,17 @@ public class AzureConnector implements CloudPlatformConnector {
     }
 
     @Override
-    public boolean startAll(Stack stack) {
+    public void startAll(Stack stack) {
         StartStopOperation startOperation = buildAzureOperation(new StartStopOperation.Builder(), stack)
                 .withStarted(true).build();
-        return startOperation.execute();
+        startOperation.execute();
     }
 
     @Override
-    public boolean stopAll(Stack stack) {
+    public void stopAll(Stack stack) {
         StartStopOperation stopOperation = buildAzureOperation(new StartStopOperation.Builder(), stack)
                 .withStarted(false).build();
-        return stopOperation.execute();
+        stopOperation.execute();
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureResourceException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureResourceException.java
@@ -10,4 +10,8 @@ public class AzureResourceException extends CloudConnectorException {
     public AzureResourceException(Throwable cause) {
         super(cause);
     }
+
+    public AzureResourceException(String message, Throwable cause) {
+        super(message, cause);
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/StartStopOperation.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/StartStopOperation.java
@@ -2,7 +2,7 @@ package com.sequenceiq.cloudbreak.service.stack.connector.azure;
 
 import com.sequenceiq.cloudbreak.domain.Stack;
 
-public class StartStopOperation extends AzureOperation<Boolean> {
+public class StartStopOperation extends AzureOperation<Void> {
     private boolean started;
 
     private StartStopOperation(Builder builder) {
@@ -11,8 +11,9 @@ public class StartStopOperation extends AzureOperation<Boolean> {
     }
 
     @Override
-    protected Boolean doExecute(Stack stack) {
-        return getCloudResourceManager().startStopResources(stack, started, getAzureResourceBuilderInit());
+    protected Void doExecute(Stack stack) {
+        getCloudResourceManager().startStopResources(stack, started, getAzureResourceBuilderInit());
+        return null;
     }
 
     public static class Builder extends AzureOperation.Builder {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/gcp/GcpConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/gcp/GcpConnector.java
@@ -78,13 +78,13 @@ public class GcpConnector implements CloudPlatformConnector {
     }
 
     @Override
-    public boolean startAll(Stack stack) {
-        return cloudResourceManager.startStopResources(stack, true, gcpResourceBuilderInit);
+    public void startAll(Stack stack) {
+        cloudResourceManager.startStopResources(stack, true, gcpResourceBuilderInit);
     }
 
     @Override
-    public boolean stopAll(Stack stack) {
-        return cloudResourceManager.startStopResources(stack, false, gcpResourceBuilderInit);
+    public void stopAll(Stack stack) {
+        cloudResourceManager.startStopResources(stack, false, gcpResourceBuilderInit);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/ResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/ResourceBuilder.java
@@ -21,9 +21,9 @@ public interface ResourceBuilder<P extends ProvisionContextObject,
 
     ResourceBuilderType resourceBuilderType();
 
-    Boolean start(SSCO startStopContextObject, Resource resource, String region);
+    void start(SSCO startStopContextObject, Resource resource, String region);
 
-    Boolean stop(SSCO startStopContextObject, Resource resource, String region);
+    void stop(SSCO startStopContextObject, Resource resource, String region);
 
     List<Resource> buildResources(P provisionContextObject, int index, List<Resource> resources,
             Optional<InstanceGroup> instanceGroup);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureSimpleInstanceResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureSimpleInstanceResourceBuilder.java
@@ -91,13 +91,13 @@ public abstract class AzureSimpleInstanceResourceBuilder implements
     }
 
     @Override
-    public Boolean start(AzureStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(AzureStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Instance start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(AzureStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(AzureStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Instance stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureSimpleNetworkResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/azure/AzureSimpleNetworkResourceBuilder.java
@@ -75,13 +75,13 @@ public abstract class AzureSimpleNetworkResourceBuilder implements
     }
 
     @Override
-    public Boolean start(AzureStartStopContextObject aSSCO, Resource resource, String region) {
-        return true;
+    public void start(AzureStartStopContextObject aSSCO, Resource resource, String region) {
+        LOGGER.debug("Network start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(AzureStartStopContextObject aSSCO, Resource resource, String region) {
-        return true;
+    public void stop(AzureStartStopContextObject aSSCO, Resource resource, String region) {
+        LOGGER.debug("Network stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/gcp/GcpSimpleInstanceResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/gcp/GcpSimpleInstanceResourceBuilder.java
@@ -48,7 +48,7 @@ public abstract class GcpSimpleInstanceResourceBuilder implements
 
     protected void exceptionHandler(GoogleJsonResponseException ex, String name, Stack stack) {
         if (ex.getDetails().get("code").equals(NOT_FOUND)) {
-            LOGGER.info(String.format("Resource was delete with name: %s", name));
+            LOGGER.info(String.format("Resource was deleted with name: %s", name));
         } else {
             throw new GcpResourceException("Error while creating instances", ex);
         }
@@ -69,13 +69,13 @@ public abstract class GcpSimpleInstanceResourceBuilder implements
     }
 
     @Override
-    public Boolean start(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Instance start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Instance stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/gcp/GcpSimpleNetworkResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/gcp/GcpSimpleNetworkResourceBuilder.java
@@ -70,13 +70,13 @@ public abstract class GcpSimpleNetworkResourceBuilder implements
     }
 
     @Override
-    public Boolean start(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/gcp/builders/network/GcpNetworkResourceBuilder.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/gcp/builders/network/GcpNetworkResourceBuilder.java
@@ -88,13 +88,13 @@ public class GcpNetworkResourceBuilder extends GcpSimpleNetworkResourceBuilder {
     }
 
     @Override
-    public Boolean start(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(GcpStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/instance/DummyAttachedDiskResourceBuilder.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/instance/DummyAttachedDiskResourceBuilder.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
@@ -20,6 +23,8 @@ import com.sequenceiq.cloudbreak.service.stack.resource.UpdateContextObject;
 
 public class DummyAttachedDiskResourceBuilder
         implements ResourceBuilder<DummyProvisionContextObject, DummyDeleteContextObject, DummyStartStopContextObject, UpdateContextObject> {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DummyAttachedDiskResourceBuilder.class);
 
     @Override
     public Boolean create(CreateResourceRequest createResourceRequest, String region) throws Exception {
@@ -46,13 +51,13 @@ public class DummyAttachedDiskResourceBuilder
     }
 
     @Override
-    public Boolean start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Disk start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Disk stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/instance/DummyExVirtualMachineResourceBuilder.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/instance/DummyExVirtualMachineResourceBuilder.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
@@ -21,6 +24,8 @@ import com.sequenceiq.cloudbreak.service.stack.resource.UpdateContextObject;
 
 public class DummyExVirtualMachineResourceBuilder
         implements ResourceBuilder<DummyProvisionContextObject, DummyDeleteContextObject, DummyStartStopContextObject, UpdateContextObject> {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DummyExVirtualMachineResourceBuilder.class);
 
     @Override
     public Boolean create(CreateResourceRequest createResourceRequest, String region) throws Exception {
@@ -47,13 +52,13 @@ public class DummyExVirtualMachineResourceBuilder
     }
 
     @Override
-    public Boolean start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("VM start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("VM stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/instance/DummyVirtualMachineResourceBuilder.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/instance/DummyVirtualMachineResourceBuilder.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
@@ -20,6 +23,8 @@ import com.sequenceiq.cloudbreak.service.stack.resource.UpdateContextObject;
 
 public class DummyVirtualMachineResourceBuilder
         implements ResourceBuilder<DummyProvisionContextObject, DummyDeleteContextObject, DummyStartStopContextObject, UpdateContextObject> {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DummyVirtualMachineResourceBuilder.class);
 
     @Override
     public Boolean create(CreateResourceRequest createResourceRequest, String region) throws Exception {
@@ -46,13 +51,13 @@ public class DummyVirtualMachineResourceBuilder
     }
 
     @Override
-    public Boolean start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("VM stop requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("VM stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/network/DummyExNetworkResourceBuilder.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/network/DummyExNetworkResourceBuilder.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
@@ -21,6 +24,8 @@ import com.sequenceiq.cloudbreak.service.stack.resource.UpdateContextObject;
 
 public class DummyExNetworkResourceBuilder
         implements ResourceBuilder<DummyProvisionContextObject, DummyDeleteContextObject, DummyStartStopContextObject, UpdateContextObject> {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DummyExNetworkResourceBuilder.class);
 
     @Override
     public Boolean create(CreateResourceRequest createResourceRequest, String region) throws Exception {
@@ -47,13 +52,13 @@ public class DummyExNetworkResourceBuilder
     }
 
     @Override
-    public Boolean start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network stop requested - nothing to do.");
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/network/DummyNetworkResourceBuilder.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/dummy/network/DummyNetworkResourceBuilder.java
@@ -4,6 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.InstanceGroup;
@@ -20,6 +23,8 @@ import com.sequenceiq.cloudbreak.service.stack.resource.UpdateContextObject;
 
 public class DummyNetworkResourceBuilder
         implements ResourceBuilder<DummyProvisionContextObject, DummyDeleteContextObject, DummyStartStopContextObject, UpdateContextObject> {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(DummyNetworkResourceBuilder.class);
 
     @Override
     public Boolean create(CreateResourceRequest createResourceRequest, String region) throws Exception {
@@ -46,13 +51,13 @@ public class DummyNetworkResourceBuilder
     }
 
     @Override
-    public Boolean start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void start(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network start requested - nothing to do.");
     }
 
     @Override
-    public Boolean stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
-        return true;
+    public void stop(DummyStartStopContextObject startStopContextObject, Resource resource, String region) {
+        LOGGER.debug("Network stop requested - nothing to do.");
     }
 
     @Override


### PR DESCRIPTION
@doktoric 
removed boolean return values from start-stop related calls, because we should keep the error context as well to provide some information on failures. When something fails, an exception is thrown like in other cases.