### PR TITLE
CLOUD-880 removed superfluous saving of stack during provisioning setup

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/ProvisioningSetupService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/service/ProvisioningSetupService.java
@@ -28,7 +28,6 @@ public class ProvisioningSetupService {
 
     public ProvisionSetupComplete setup(Stack stack) throws Exception {
         ProvisionSetupComplete setupComplete = (ProvisionSetupComplete) provisionSetups.get(stack.cloudPlatform()).setupProvisioning(stack);
-        stackRepository.save(stack);
         tlsSecurityService.copyClientKeys(stack.getId());
         tlsSecurityService.setupSSHKeys(stack);
         return setupComplete;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackUpdater.java
@@ -86,6 +86,7 @@ public class StackUpdater {
         Stack stack = stackRepository.findById(stackId);
         if (statusReason != null) {
             stack.setStatusReason(statusReason);
+            cloudbreakEventService.fireCloudbreakEvent(stackId, stack.getStatus().name(), statusReason);
         }
         stack = stackRepository.save(stack);
         LOGGER.info("Updated stack: [statusReason: '{}'].", statusReason);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureProvisionSetup.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureProvisionSetup.java
@@ -48,7 +48,7 @@ public class AzureProvisionSetup implements ProvisionSetup {
     private static final String VM_COMMON_NAME = "cloudbreak";
     private static final String OS = "os";
     private static final String MEDIALINK = "mediaLink";
-    private static final int MILLIS = 5000;
+    private static final int MILLIS = 30000;
     private static final String PENDING = "pending";
     private static final String SUCCESS = "success";
     private static final int ONE_HUNDRED = 100;


### PR DESCRIPTION
* optimistic locking exception avoided by not saving the stack after (azure) provisioning setup
* events are published about the image copy status (azure)
* copy status check interval increased from 5 sec to 30 (azure)

@doktoric please review it