### PR TITLE
CLOUD-898 fixed cf template for existing vpcs

### DIFF
--- a/core/src/main/resources/templates/aws-cf-stack.ftl
+++ b/core/src/main/resources/templates/aws-cf-stack.ftl
@@ -171,7 +171,11 @@
 
     "PublicRoute" : {
       "Type" : "AWS::EC2::Route",
+      <#if existingVPC>
+      "DependsOn" : "PublicRouteTable",
+      <#else>
       "DependsOn" : [ "PublicRouteTable", "AttachGateway" ],
+      </#if>
       "Properties" : {
         "RouteTableId" : { "Ref" : "PublicRouteTable" },
         "DestinationCidrBlock" : "0.0.0.0/0",


### PR DESCRIPTION
@biharitomi 

An earlier fix broke the feature to deploy clusters in an existing vpc on AWS.