### PR TITLE
CLOUD-959 stop Ambari agents before deleting them

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -105,6 +105,8 @@ public class AmbariClusterConnector {
     @Inject
     private AmbariHostsStatusCheckerTask ambariHostsStatusCheckerTask;
     @Inject
+    private AmbariHostsLeaveStatusCheckerTask hostsLeaveStatusCheckerTask;
+    @Inject
     private DNDecommissionStatusCheckerTask dnDecommissionStatusCheckerTask;
     @Inject
     private RSDecommissionStatusCheckerTask rsDecommissionStatusCheckerTask;
@@ -116,6 +118,8 @@ public class AmbariClusterConnector {
     private AmbariHostsRemover ambariHostsRemover;
     @Inject
     private PollingService<AmbariHostsCheckerContext> ambariHostJoin;
+    @Inject
+    private PollingService<AmbariHostsWithNames> ambariHostLeave;
     @Inject
     private PollingService<AmbariClientPollerObject> ambariHealthChecker;
     @Inject
@@ -220,7 +224,7 @@ public class AmbariClusterConnector {
         }
         HostGroup hostGroup = hostGroupRepository.findHostGroupInClusterByName(cluster.getId(), hostGroupAdjustment.getHostGroup());
         List<String> hostList = new ArrayList<>(hostsToRemove.keySet());
-        ambariHostsRemover.deleteHosts(stack, hostList, new ArrayList<>(components));
+        deleteHosts(stack, hostList, components);
         PollingResult pollingResult = restartHadoopServices(stack, ambariClient, true);
         if (isSuccess(pollingResult)) {
             hostGroup.getHostMetadata().removeAll(hostsToRemove.values());
@@ -282,7 +286,7 @@ public class AmbariClusterConnector {
                     if (isSuccess(pollingResult)) {
                         pollingResult = stopHadoopComponents(stack, ambariClient, hostList);
                         if (isSuccess(pollingResult)) {
-                            ambariHostsRemover.deleteHosts(stack, hostList, new ArrayList<>(components));
+                            stopAndDeleteHosts(stack, ambariClient, hostList, components);
                             pollingResult = restartHadoopServices(stack, ambariClient, true);
                             if (isSuccess(pollingResult)) {
                                 cluster = clusterRepository.findOneWithLists(stack.getCluster().getId());
@@ -307,7 +311,7 @@ public class AmbariClusterConnector {
             if (!allServiceStopped(ambariClient.getHostComponentsStates())) {
                 stopAllServices(stack, ambariClient);
             }
-            stopAmbariAgents(stack);
+            stopAmbariAgents(stack, null);
         } catch (AmbariConnectionException ex) {
             LOGGER.debug("Ambari not running on the gateway machine, no need to stop it.");
         }
@@ -347,7 +351,7 @@ public class AmbariClusterConnector {
         if (ambariClient.getClusterHosts().contains(data.getHostName())) {
             String hostState = ambariClient.getHostState(data.getHostName());
             if ("UNKNOWN".equals(hostState)) {
-                ambariHostsRemover.deleteHosts(stack, Arrays.asList(data.getHostName()), new ArrayList<>(components));
+                deleteHosts(stack, Arrays.asList(data.getHostName()), components);
                 PollingResult result = restartHadoopServices(stack, ambariClient, true);
                 if (isTimeout(result)) {
                     throw new AmbariOperationFailedException("Timeout while restarting Hadoop services.");
@@ -361,6 +365,21 @@ public class AmbariClusterConnector {
             hostDeleted = true;
         }
         return hostDeleted;
+    }
+
+    private void stopAndDeleteHosts(Stack stack, AmbariClient ambariClient, List<String> hostList, Set<String> components) throws CloudbreakException {
+        stopAmbariAgents(stack, new HashSet<>(hostList));
+        PollingResult pollingResult = waitForHostsToLeave(stack, ambariClient, hostList);
+        if (isTimeout(pollingResult)) {
+            LOGGER.warn("Ambari agent stop timed out, delete the hosts anyway, hosts: {}", hostList);
+        }
+        if (!isExited(pollingResult)) {
+            deleteHosts(stack, hostList, components);
+        }
+    }
+
+    private void deleteHosts(Stack stack, List<String> hostList, Set<String> components) throws CloudbreakSecuritySetupException {
+        ambariHostsRemover.deleteHosts(stack, hostList, new ArrayList<>(components));
     }
 
     private void stopAllServices(Stack stack, AmbariClient ambariClient) throws CloudbreakException {
@@ -527,10 +546,10 @@ public class AmbariClusterConnector {
                         } else if ("HBASE_REGIONSERVER".equals(componentStateEntry.getKey())) {
                             services.add("HBASE_REGIONSERVER");
                         } else {
-                            LOGGER.warn("No need to restart ambari service: {}", componentStateEntry.getKey());
+                            LOGGER.info("No need to restart ambari service: {}", componentStateEntry.getKey());
                         }
                     } else {
-                        LOGGER.warn("Ambari service already running: {}", componentStateEntry.getKey());
+                        LOGGER.info("Ambari service already running: {}", componentStateEntry.getKey());
                     }
                 }
             }
@@ -570,9 +589,10 @@ public class AmbariClusterConnector {
         }
     }
 
-    private void stopAmbariAgents(Stack stack) throws CloudbreakException {
-        LOGGER.info("Stopping Ambari agents on the hosts.");
-        pluginManager.triggerAndWaitForPlugins(stack, ConsulPluginEvent.STOP_AMBARI_EVENT, DEFAULT_RECIPE_TIMEOUT, AMBARI_AGENT);
+    private void stopAmbariAgents(Stack stack, Set<String> hosts) throws CloudbreakException {
+        LOGGER.info("Stopping Ambari agents on hosts: {}", hosts == null || hosts.isEmpty() ? "all" : hosts);
+        pluginManager.triggerAndWaitForPlugins(stack, ConsulPluginEvent.STOP_AMBARI_EVENT,
+                DEFAULT_RECIPE_TIMEOUT, AMBARI_AGENT, Collections.<String>emptyList(), hosts);
     }
 
     private void startAmbariAgents(Stack stack) throws CloudbreakException {
@@ -755,13 +775,9 @@ public class AmbariClusterConnector {
         }
     }
 
-    private PollingResult startComponents(Stack stack, Cluster cluster, AmbariClient ambariClient, HostGroup hostGroup) {
-        try {
-            int id = ambariClient.startAllComponents(cluster.getBlueprint().getBlueprintName(), hostGroup.getName());
-            return waitForAmbariOperations(stack, ambariClient, singletonMap("START_SERVICES on new hosts", id));
-        } catch (HttpResponseException e) {
-            throw new BadRequestException("Failed to start the components on the new hosts", e);
-        }
+    private PollingResult waitForHostsToLeave(Stack stack, AmbariClient ambariClient, List<String> hostNames) throws CloudbreakSecuritySetupException {
+        return ambariHostLeave.pollWithTimeout(hostsLeaveStatusCheckerTask, new AmbariHostsWithNames(stack, ambariClient, hostNames),
+                AMBARI_POLLING_INTERVAL, MAX_ATTEMPTS_FOR_HOSTS, AmbariOperationService.MAX_FAILURE_COUNT);
     }
 
     private PollingResult waitForAmbariOperations(Stack stack, AmbariClient ambariClient, Map<String, Integer> operationRequests) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariHostsLeaveStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariHostsLeaveStatusCheckerTask.java
@@ -1,0 +1,49 @@
+package com.sequenceiq.cloudbreak.service.cluster.flow;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.ambari.client.AmbariClient;
+import com.sequenceiq.cloudbreak.service.StackBasedStatusCheckerTask;
+
+@Component
+public class AmbariHostsLeaveStatusCheckerTask extends StackBasedStatusCheckerTask<AmbariHostsWithNames> {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AmbariHostsLeaveStatusCheckerTask.class);
+    private static final String LEFT_STATE = "UNKNOWN";
+
+    @Override
+    public boolean checkStatus(AmbariHostsWithNames hosts) {
+        try {
+            AmbariClient ambariClient = hosts.getAmbariClient();
+            List<String> hostNames = hosts.getHostNames();
+            Map<String, String> hostStatuses = ambariClient.getHostStatuses();
+            for (String hostName : hostNames) {
+                String status = hostStatuses.get(hostName);
+                if (!LEFT_STATE.equals(status)) {
+                    LOGGER.info("{} didn't leave the cluster yet", hostName);
+                    return false;
+                }
+            }
+        } catch (Exception e) {
+            LOGGER.error("Failed to check the left hosts", e);
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void handleTimeout(AmbariHostsWithNames t) {
+        LOGGER.error("Operation timed out. Hosts didn't leave in time, hosts: '{}' stack: '{}'", t.getHostNames(), t.getStack().getId());
+    }
+
+    @Override
+    public String successMessage(AmbariHostsWithNames t) {
+        return String.format("Hosts left the cluster, hosts: '%s' stack '%s'", t.getHostNames(), t.getStack().getId());
+    }
+
+}


### PR DESCRIPTION
Stop the ambari agents before deleting them during downscale. Unfortunately it does not solve the dead node issue.

@biharitomi @akanto @doktoric 