### PR TITLE
CLOUD-663: workaround for aws/azure, without this the /etc/sysctl.conf parameters have no effect after stop/start

### DIFF
--- a/core/src/main/resources/init/init.ftl
+++ b/core/src/main/resources/init/init.ftl
@@ -53,7 +53,13 @@ format_disks() {
 }
 </#noparse>
 
+<#-- Workaround to reload /etc/sysctl.conf parameters at first boot. Without this the parameters cannot be set properly. -->
+reload_sysconf() {
+  sysctl -p
+}
+
 main() {
+  reload_sysconf
   if [[ "$1" == "::" ]]; then
     shift
     eval "$@"

--- a/core/src/test/resources/azure-core-init.sh
+++ b/core/src/test/resources/azure-core-init.sh
@@ -44,7 +44,12 @@ format_disks() {
   cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch
 }
 
+reload_sysconf() {
+  sysctl -p
+}
+
 main() {
+  reload_sysconf
   if [[ "$1" == "::" ]]; then
     shift
     eval "$@"

--- a/core/src/test/resources/azure-gateway-init.sh
+++ b/core/src/test/resources/azure-gateway-init.sh
@@ -49,7 +49,12 @@ format_disks() {
   cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch
 }
 
+reload_sysconf() {
+  sysctl -p
+}
+
 main() {
+  reload_sysconf
   if [[ "$1" == "::" ]]; then
     shift
     eval "$@"


### PR DESCRIPTION
@akanto pls review

Was tested:
- aws, after create, after stop/start
- gcp, after create, after stop/start
- azure, after create

not tested:
- openstack
- azure stop/start
