### PR TITLE
CLOUD-932 do not enforce precedence of versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,7 +58,8 @@ final class VersionStrategies {
     static final SemVerStrategy FINAL = Strategies.DEFAULT.copyWith(
             name: 'release',
             stages: ['final'] as SortedSet,
-            allowDirtyRepo: true
+            allowDirtyRepo: true,
+            enforcePrecedence: false
     )
 }
 


### PR DESCRIPTION
@keyki 

If rc changes are merged back to master but there were no other changes on master after the first RC, then the commits on the rc branch will be the same as the commits on master and will have both the rc tags and the new dev tags (e.g.: `0.8.0-dev.1 and 0.7.0-rc.2`), so the release (`0.7.0`) will fail if precedence is enforced (`0.7.0` cannot be preceded by `0.8.0-dev.1`).