### PR TITLE
Removed conf directory which appears to be a duplicate of /config

### DIFF
--- a/conf/README.md
+++ b/conf/README.md
@@ -1,2 +1,0 @@
-This folder contains:
-  * idea/idea_settings.jar contains the idea specific settings like code formatting.


### PR DESCRIPTION
It looks like /conf was an accidentally created dupe of /config (the commit refers to a file that does not exist)? Assuming it's a dupe, this deletes it.