### PR TITLE
Add thread names

### DIFF
--- a/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/conf/EventBusConfig.java
+++ b/cloud-openstack/src/test/java/com/sequenceiq/cloudbreak/cloud/conf/EventBusConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.sequenceiq.cloudbreak.cloud.handler.ConsumerNotFoundHandler;
 
 import reactor.Environment;
@@ -23,7 +24,8 @@ public class EventBusConfig {
 
     @Bean
     public ListeningScheduledExecutorService listeningScheduledExecutorService() {
-        return MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(eventBusThreadPoolSize));
+        return MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(eventBusThreadPoolSize,
+                new ThreadFactoryBuilder().setNameFormat("openstackEventBus-%d").build()));
     }
 
     @Bean

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/config/CloudReactorConfiguration.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/config/CloudReactorConfiguration.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.google.common.util.concurrent.ListeningScheduledExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 @Configuration
 public class CloudReactorConfiguration {
@@ -17,6 +18,8 @@ public class CloudReactorConfiguration {
 
     @Bean
     ListeningScheduledExecutorService listeningScheduledExecutorService() {
-        return MoreExecutors.listeningDecorator(new ScheduledThreadPoolExecutor(executorServicePoolSize));
+        return MoreExecutors
+                .listeningDecorator(new ScheduledThreadPoolExecutor(executorServicePoolSize,
+                        new ThreadFactoryBuilder().setNameFormat("reactorExecutor-%d").build()));
     }
 }

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/reactor/config/EventBusConfig.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/reactor/config/EventBusConfig.java
@@ -39,6 +39,6 @@ public class EventBusConfig {
     }
 
     private ThreadPoolExecutorDispatcher getEventBusDispatcher() {
-        return new ThreadPoolExecutorDispatcher(eventBusThreadPoolSize, eventBusThreadPoolSize);
+        return new ThreadPoolExecutorDispatcher(eventBusThreadPoolSize, eventBusThreadPoolSize, "reactorDispatcher");
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/AsyncConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/AsyncConfig.java
@@ -27,7 +27,7 @@ public class AsyncConfig implements AsyncConfigurer, SchedulingConfigurer {
         executor.setCorePoolSize(CORE_POOL_SIZE);
         executor.setMaxPoolSize(MAX_POOL_SIZE);
         executor.setQueueCapacity(QUEUE_CAPACITY);
-        executor.setThreadNamePrefix("MyExecutor-");
+        executor.setThreadNamePrefix("asyncExecutor-");
         executor.initialize();
         return executor;
     }


### PR DESCRIPTION
Added some thread names to help give us a better idea of what's going on when we take thread dumps, use monitoring tools, debug, etc. I used the camelCase naming convention since it was used on a few other threadpools in cloudbreak.