### PR TITLE
Added ability to cancel polling of SPI scheduler

### DIFF
--- a/cloud-api/build.gradle
+++ b/cloud-api/build.gradle
@@ -14,6 +14,7 @@ jar {
 
 dependencies {
 
+    compile project(':core-model')
     compile project(':cloud-common')
 
     compile group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion

--- a/cloud-api/build.gradle
+++ b/cloud-api/build.gradle
@@ -14,7 +14,7 @@ jar {
 
 dependencies {
 
-    compile project(':core-model')
+    compile project(':cloud-common')
 
     compile group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion
     compile group: 'org.springframework.boot',      name: 'spring-boot-starter',            version: springBootVersion

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudOperationNotSupportedException.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/CloudOperationNotSupportedException.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+
+public class CloudOperationNotSupportedException extends RuntimeException {
+
+    public CloudOperationNotSupportedException(String message) {
+        super(message);
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/task/CheckResult.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/task/CheckResult.java
@@ -4,4 +4,6 @@ public interface CheckResult<T> {
 
     boolean completed(T t);
 
+    boolean cancelled();
+
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTask.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTask.java
@@ -1,12 +1,11 @@
 package com.sequenceiq.cloudbreak.cloud.task;
 
-import static com.sequenceiq.cloudbreak.domain.Status.DELETE_COMPLETED;
-import static com.sequenceiq.cloudbreak.domain.Status.DELETE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup.CANCELLED;
 
 import com.sequenceiq.cloudbreak.cloud.event.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.event.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
-import com.sequenceiq.cloudbreak.domain.Status;
 
 public abstract class PollTask<T> implements FetchTask<T>, CheckResult<T> {
 
@@ -27,7 +26,7 @@ public abstract class PollTask<T> implements FetchTask<T>, CheckResult<T> {
 
     @Override
     public boolean cancelled() {
-        Status stackStatus = InMemoryStateStore.get(getCloudContext().getStackId());
-        return stackStatus != null && (DELETE_COMPLETED.equals(stackStatus) || DELETE_IN_PROGRESS.equals(stackStatus));
+        PollGroup pollGroup = InMemoryStateStore.get(getCloudContext().getStackId());
+        return pollGroup != null && CANCELLED.equals(pollGroup);
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTask.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTask.java
@@ -1,7 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.task;
 
+import static com.sequenceiq.cloudbreak.domain.Status.DELETE_COMPLETED;
+import static com.sequenceiq.cloudbreak.domain.Status.DELETE_IN_PROGRESS;
+
 import com.sequenceiq.cloudbreak.cloud.event.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.event.context.CloudContext;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.domain.Status;
 
 public abstract class PollTask<T> implements FetchTask<T>, CheckResult<T> {
 
@@ -18,5 +23,11 @@ public abstract class PollTask<T> implements FetchTask<T>, CheckResult<T> {
 
     protected AuthenticatedContext getAuthenticatedContext() {
         return authenticatedContext;
+    }
+
+    @Override
+    public boolean cancelled() {
+        Status stackStatus = InMemoryStateStore.get(getCloudContext().getStackId());
+        return stackStatus != null && (DELETE_COMPLETED.equals(stackStatus) || DELETE_IN_PROGRESS.equals(stackStatus));
     }
 }

--- a/cloud-arm/src/main/java/com/sequenceiq/cloudbreak/cloud/arm/ArmInstanceConnector.java
+++ b/cloud-arm/src/main/java/com/sequenceiq/cloudbreak/cloud/arm/ArmInstanceConnector.java
@@ -13,6 +13,7 @@ import com.sequenceiq.cloudbreak.cloud.InstanceConnector;
 import com.sequenceiq.cloudbreak.cloud.arm.status.ArmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.event.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+import com.sequenceiq.cloudbreak.cloud.model.CloudOperationNotSupportedException;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudVmInstanceStatus;
 import com.sequenceiq.cloudbreak.cloud.model.InstanceStatus;
@@ -29,8 +30,7 @@ public class ArmInstanceConnector implements InstanceConnector {
 
     @Override
     public String getConsoleOutput(AuthenticatedContext authenticatedContext, CloudInstance vm) {
-        // Currently Azure rm not supporting the get fingerprint method
-        return "-----END SSH HOST KEY FINGERPRINTS-----";
+        throw new CloudOperationNotSupportedException("Azure ARM doesn't provide access to the VM console output yet.");
     }
 
     @Override

--- a/cloud-common/build.gradle
+++ b/cloud-common/build.gradle
@@ -13,7 +13,7 @@ jar {
 }
 
 dependencies {
-  compile project(':core-model')
+//  compile project(':core-model')
   compile group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion
   compile group: 'org.springframework.boot',      name: 'spring-boot-starter',            version: springBootVersion
 

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/EnvironmentVariableConfig.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/EnvironmentVariableConfig.java
@@ -1,10 +1,5 @@
 package com.sequenceiq.cloudbreak;
 
-import java.util.Arrays;
-import java.util.List;
-
-import com.sequenceiq.cloudbreak.domain.CloudPlatform;
-
 public class EnvironmentVariableConfig {
 
     public static final String CB_THREADPOOL_CORE_SIZE = "40";
@@ -78,8 +73,6 @@ public class EnvironmentVariableConfig {
     public static final String CB_MAX_GCP_RESOURCE_NAME_LENGTH = "50";
 
     public static final String CB_ADDRESS_RESOLVING_TIMEOUT = "60000";
-
-    public static final List<String> VERBOSEDCLOUDPLATFORMS = Arrays.asList(CloudPlatform.AZURE_RM.name());
 
     private EnvironmentVariableConfig() {
 

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/CancellationException.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/CancellationException.java
@@ -1,0 +1,7 @@
+package com.sequenceiq.cloudbreak.cloud.scheduler;
+
+public class CancellationException extends RuntimeException {
+    public CancellationException(String message) {
+        super(message);
+    }
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/PollGroup.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/PollGroup.java
@@ -1,0 +1,5 @@
+package com.sequenceiq.cloudbreak.cloud.scheduler;
+
+public enum PollGroup {
+    POLLABLE, CANCELLED
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/store/InMemoryStateStore.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/store/InMemoryStateStore.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.cloud.store;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.sequenceiq.cloudbreak.domain.Status;
+
+public final class InMemoryStateStore {
+
+    private static final Map<Long, Status> STATE_STORE = new ConcurrentHashMap<>();
+
+    private InMemoryStateStore() {
+
+    }
+
+    public static Status get(Long key) {
+        return STATE_STORE.get(key);
+    }
+
+    public static void put(Long key, Status value) {
+        STATE_STORE.put(key, value);
+    }
+
+    public static void delete(Long key) {
+        STATE_STORE.remove(key);
+    }
+}

--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/store/InMemoryStateStore.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/cloud/store/InMemoryStateStore.java
@@ -3,21 +3,21 @@ package com.sequenceiq.cloudbreak.cloud.store;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import com.sequenceiq.cloudbreak.domain.Status;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 
 public final class InMemoryStateStore {
 
-    private static final Map<Long, Status> STATE_STORE = new ConcurrentHashMap<>();
+    private static final Map<Long, PollGroup> STATE_STORE = new ConcurrentHashMap<>();
 
     private InMemoryStateStore() {
 
     }
 
-    public static Status get(Long key) {
+    public static PollGroup get(Long key) {
         return STATE_STORE.get(key);
     }
 
-    public static void put(Long key, Status value) {
+    public static void put(Long key, PollGroup value) {
         STATE_STORE.put(key, value);
     }
 

--- a/cloud-reactor/build.gradle
+++ b/cloud-reactor/build.gradle
@@ -14,7 +14,6 @@ jar {
 
 dependencies {
 
-    compile project(':core-model')
     compile project(':cloud-api')
     compile project(':cloud-common')
 

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/TerminateStackHandler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/handler/TerminateStackHandler.java
@@ -56,7 +56,7 @@ public class TerminateStackHandler implements CloudPlatformEventHandler<Terminat
                     terminateStackRequest.getCloudResources());
             List<CloudResource> resources = ResourceLists.transform(resourceStatus);
             if (!resources.isEmpty()) {
-                PollTask<ResourcesStatePollerResult> task = statusCheckFactory.newPollResourcesStateTask(ac, resources);
+                PollTask<ResourcesStatePollerResult> task = statusCheckFactory.newPollResourceTerminationTask(ac, resources);
                 ResourcesStatePollerResult statePollerResult = ResourcesStatePollerResults.build(terminateStackRequest.getCloudContext(), resourceStatus);
                 if (!task.completed(statePollerResult)) {
                     statePollerResult = syncPollingScheduler.schedule(task);

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/SyncPollingScheduler.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/scheduler/SyncPollingScheduler.java
@@ -29,6 +29,9 @@ public class SyncPollingScheduler<T> {
     public T schedule(PollTask<T> task, int interval, int maxAttempt) throws ExecutionException, InterruptedException, TimeoutException {
         T result;
         for (int i = 0; i < maxAttempt; i++) {
+            if (task.cancelled()) {
+                throw new CancellationException("Task was cancelled.");
+            }
             ListenableScheduledFuture<T> ft = schedule(task, interval);
             result = ft.get();
             if (task.completed(result)) {

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollResourceTerminationTask.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollResourceTerminationTask.java
@@ -1,0 +1,19 @@
+package com.sequenceiq.cloudbreak.cloud.task;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.cloud.ResourceConnector;
+import com.sequenceiq.cloudbreak.cloud.event.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+
+public class PollResourceTerminationTask extends PollResourcesStateTask {
+
+    public PollResourceTerminationTask(AuthenticatedContext authenticatedContext, ResourceConnector connector, List<CloudResource> cloudResource) {
+        super(authenticatedContext, connector, cloudResource);
+    }
+
+    @Override
+    public boolean cancelled() {
+        return false;
+    }
+}

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTaskConfig.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTaskConfig.java
@@ -30,9 +30,17 @@ public class PollTaskConfig {
     public PollTaskFactory newFetchStateTask() {
         return new PollTaskFactory() {
             @Override
-            public PollTask<ResourcesStatePollerResult> newPollResourcesStateTask(AuthenticatedContext authenticatedContext, List<CloudResource> cloudResource) {
+            public PollTask<ResourcesStatePollerResult> newPollResourcesStateTask(AuthenticatedContext authenticatedContext,
+                    List<CloudResource> cloudResource) {
                 CloudConnector connector = cloudPlatformConnectors.get(authenticatedContext.getCloudContext().getPlatform());
                 return new PollResourcesStateTask(authenticatedContext, connector.resources(), cloudResource);
+            }
+
+            @Override
+            public PollTask<ResourcesStatePollerResult> newPollResourceTerminationTask(AuthenticatedContext authenticatedContext,
+                    List<CloudResource> cloudResource) {
+                CloudConnector connector = cloudPlatformConnectors.get(authenticatedContext.getCloudContext().getPlatform());
+                return new PollResourceTerminationTask(authenticatedContext, connector.resources(), cloudResource);
             }
 
             @Override

--- a/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTaskFactory.java
+++ b/cloud-reactor/src/main/java/com/sequenceiq/cloudbreak/cloud/task/PollTaskFactory.java
@@ -15,6 +15,8 @@ public interface PollTaskFactory {
 
     PollTask<ResourcesStatePollerResult> newPollResourcesStateTask(AuthenticatedContext authenticatedContext, List<CloudResource> cloudResource);
 
+    PollTask<ResourcesStatePollerResult> newPollResourceTerminationTask(AuthenticatedContext authenticatedContext, List<CloudResource> cloudResource);
+
     PollTask<InstancesStatusResult> newPollInstanceStateTask(AuthenticatedContext authenticatedContext, List<CloudInstance> instances);
 
     PollTask<InstanceConsoleOutputResult> newPollInstanceConsoleOutputTask(AuthenticatedContext authenticatedContext, CloudInstance instance);

--- a/core/config/checkstyle/checkstyle-suppressions.xml
+++ b/core/config/checkstyle/checkstyle-suppressions.xml
@@ -12,6 +12,7 @@
     <suppress checks="ParameterNumber|ClassFanOutComplexity|CyclomaticComplexity|JavaNCSS|NPathComplexity" files="AmbariClusterConnector.java"/>
     <suppress checks="ParameterNumber|ClassFanOutComplexity|CyclomaticComplexity|JavaNCSS|NPathComplexity" files="PublicKeyReaderUtil.java"/>
     <suppress checks="ParameterNumber|ClassFanOutComplexity|CyclomaticComplexity|JavaNCSS|NPathComplexity" files="ClusterController.java"/>
+    <suppress checks="ParameterNumber|ClassFanOutComplexity|CyclomaticComplexity|JavaNCSS|NPathComplexity" files="StatusToPollGroupConverter.java"/>
     <suppress checks="ParameterNumber" files="CloudbreakUsageController.java"/>
     <suppress checks="IllegalCatch" files="CredentialController.java"/>
     <suppress checks="IllegalCatch" files="GcpStackUtil.java"/>

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/scheduler/StatusToPollGroupConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/scheduler/StatusToPollGroupConverter.java
@@ -1,0 +1,39 @@
+package com.sequenceiq.cloudbreak.converter.scheduler;
+
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.converter.AbstractConversionServiceAwareConverter;
+import com.sequenceiq.cloudbreak.domain.Status;
+
+@Component
+public class StatusToPollGroupConverter extends AbstractConversionServiceAwareConverter<Status, PollGroup> {
+    @Override
+    public PollGroup convert(Status source) {
+        switch (source) {
+            case REQUESTED:
+            case CREATE_IN_PROGRESS:
+            case AVAILABLE:
+            case UPDATE_IN_PROGRESS:
+            case UPDATE_REQUESTED:
+            case UPDATE_FAILED:
+            case CREATE_FAILED:
+            case ENABLE_SECURITY_FAILED:
+            case STOPPED:
+            case STOP_REQUESTED:
+            case START_REQUESTED:
+            case STOP_IN_PROGRESS:
+            case START_IN_PROGRESS:
+            case START_FAILED:
+            case STOP_FAILED:
+            case DELETE_FAILED:
+                return PollGroup.POLLABLE;
+            case DELETE_IN_PROGRESS:
+            case DELETE_COMPLETED:
+                return PollGroup.CANCELLED;
+            default:
+                throw new UnsupportedOperationException(String.format("Status '%s' is not mapped to any PollGroup.", source));
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapper.java
@@ -14,8 +14,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.core.CloudbreakException;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
 import com.sequenceiq.cloudbreak.core.flow.context.BootstrapApiContext;
 import com.sequenceiq.cloudbreak.core.flow.context.ContainerOrchestratorClusterContext;
 import com.sequenceiq.cloudbreak.core.flow.context.ProvisioningContext;
@@ -113,7 +113,7 @@ public class ClusterBootstrapper {
                 clusterBootstrapperErrorHandler.terminateFailedNodes(containerOrchestrator, stack, gatewayConfig, nodes);
             }
         } catch (CloudbreakOrchestratorCancelledException e) {
-            throw new FlowCancelledException(e.getMessage());
+            throw new CancellationException(e.getMessage());
         } catch (CloudbreakOrchestratorException e) {
             throw new CloudbreakException(e);
         }
@@ -152,7 +152,7 @@ public class ClusterBootstrapper {
                 clusterBootstrapperErrorHandler.terminateFailedNodes(containerOrchestrator, stack, gatewayConfig, nodes);
             }
         } catch (CloudbreakOrchestratorCancelledException e) {
-            throw new FlowCancelledException(e.getMessage());
+            throw new CancellationException(e.getMessage());
         } catch (CloudbreakOrchestratorException e) {
             throw new CloudbreakException(e);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterContainerRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterContainerRunner.java
@@ -24,8 +24,8 @@ import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import com.google.common.base.Strings;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.core.CloudbreakException;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
 import com.sequenceiq.cloudbreak.core.flow.context.ClusterScalingContext;
 import com.sequenceiq.cloudbreak.core.flow.context.DefaultFlowContext;
 import com.sequenceiq.cloudbreak.core.flow.context.ProvisioningContext;
@@ -103,7 +103,7 @@ public class ClusterContainerRunner {
         try {
             initializeClusterContainers(context, false, Collections.<String>emptySet());
         } catch (CloudbreakOrchestratorCancelledException e) {
-            throw new FlowCancelledException(e.getMessage());
+            throw new CancellationException(e.getMessage());
         } catch (CloudbreakOrchestratorException e) {
             throw new CloudbreakException(e);
         }
@@ -113,7 +113,7 @@ public class ClusterContainerRunner {
         try {
             initializeClusterContainers(context, true, context.getUpscaleCandidateAddresses());
         } catch (CloudbreakOrchestratorCancelledException e) {
-            throw new FlowCancelledException(e.getMessage());
+            throw new CancellationException(e.getMessage());
         } catch (CloudbreakOrchestratorException e) {
             throw new CloudbreakException(e);
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteria.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteria.java
@@ -1,14 +1,13 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service;
 
-import static com.sequenceiq.cloudbreak.domain.Status.DELETE_COMPLETED;
-import static com.sequenceiq.cloudbreak.domain.Status.DELETE_IN_PROGRESS;
+import static com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup.CANCELLED;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
-import com.sequenceiq.cloudbreak.domain.Status;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteria;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 
@@ -21,8 +20,8 @@ public class StackDeletionBasedExitCriteria implements ExitCriteria {
     public boolean isExitNeeded(ExitCriteriaModel exitCriteriaModel) {
         StackDeletionBasedExitCriteriaModel model = (StackDeletionBasedExitCriteriaModel) exitCriteriaModel;
         LOGGER.debug("Check isExitNeeded for model: {}", model);
-        Status stackStatus = InMemoryStateStore.get(model.getStackId());
-        if (stackStatus != null && (DELETE_COMPLETED.equals(stackStatus) || DELETE_IN_PROGRESS.equals(stackStatus))) {
+        PollGroup pollGroup = InMemoryStateStore.get(model.getStackId());
+        if (pollGroup != null && CANCELLED.equals(pollGroup)) {
             LOGGER.warn("Stack is getting terminated, polling is cancelled.");
             return true;
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteria.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteria.java
@@ -1,43 +1,29 @@
 package com.sequenceiq.cloudbreak.core.bootstrap.service;
 
-import javax.inject.Inject;
+import static com.sequenceiq.cloudbreak.domain.Status.DELETE_COMPLETED;
+import static com.sequenceiq.cloudbreak.domain.Status.DELETE_IN_PROGRESS;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 
-import com.sequenceiq.cloudbreak.domain.Cluster;
-import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.domain.Status;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteria;
 import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 
 @Service
 public class StackDeletionBasedExitCriteria implements ExitCriteria {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(StackDeletionBasedExitCriteria.class);
 
-    @Inject
-    private StackService stackService;
-
     @Override
     public boolean isExitNeeded(ExitCriteriaModel exitCriteriaModel) {
         StackDeletionBasedExitCriteriaModel model = (StackDeletionBasedExitCriteriaModel) exitCriteriaModel;
         LOGGER.debug("Check isExitNeeded for model: {}", model);
-        try {
-            Stack stack = stackService.findLazy(model.getStackId());
-            LOGGER.debug("Stack fetched: {}, stack: {}", model.getStackId(), stack);
-            if (stack == null || stack.isDeleteInProgress() || stack.isDeleteCompleted()) {
-                LOGGER.warn("Stack is in deletion phase no need for more polling");
-                return true;
-            }
-            Cluster cluster = stack.getCluster();
-            if (cluster != null && (cluster.isDeleteInProgress() || cluster.isDeleteCompleted())) {
-                LOGGER.warn("Cluster is in deletion phase no need for more polling");
-                return true;
-            }
-        } catch (Exception ex) {
-            LOGGER.warn("Stack or cluster is in deletion phase no need for more polling");
+        Status stackStatus = InMemoryStateStore.get(model.getStackId());
+        if (stackStatus != null && (DELETE_COMPLETED.equals(stackStatus) || DELETE_IN_PROGRESS.equals(stackStatus))) {
+            LOGGER.warn("Stack is getting terminated, polling is cancelled.");
             return true;
         }
         return false;
@@ -45,6 +31,6 @@ public class StackDeletionBasedExitCriteria implements ExitCriteria {
 
     @Override
     public String exitMessage() {
-        return "Stack or cluster is in deletion phase no need for more polling";
+        return "Stack is getting terminated, polling is cancelled.";
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/AbstractFlowHandler.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/AbstractFlowHandler.java
@@ -2,9 +2,11 @@ package com.sequenceiq.cloudbreak.core.flow;
 
 import javax.inject.Inject;
 
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.core.CloudbreakException;
 import com.sequenceiq.cloudbreak.core.flow.context.DefaultFlowContext;
 import com.sequenceiq.cloudbreak.core.flow.service.FlowFacade;
@@ -48,7 +50,7 @@ public abstract class AbstractFlowHandler<T extends DefaultFlowContext> implemen
             result = execute(event);
             success = true;
         } catch (Exception t) {
-            if (t instanceof FlowCancelledException || t.getCause() instanceof FlowCancelledException) {
+            if (t instanceof CancellationException || ExceptionUtils.getRootCause(t) instanceof CancellationException) {
                 LOGGER.warn("The flow has been cancelled: {}", t.getMessage());
                 return;
             }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/FlowCancelledException.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow/FlowCancelledException.java
@@ -1,7 +1,0 @@
-package com.sequenceiq.cloudbreak.core.flow;
-
-public class FlowCancelledException extends RuntimeException {
-    public FlowCancelledException(String message) {
-        super(message);
-    }
-}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackUpdater.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.domain.Status;
@@ -56,7 +57,12 @@ public class StackUpdater {
             if (statusReason != null) {
                 stack.setStatusReason(statusReason);
             }
-            stack = stackRepository.save(stack);
+            InMemoryStateStore.put(stackId, status);
+            if (Status.DELETE_COMPLETED.equals(status)) {
+                InMemoryStateStore.delete(stackId);
+            } else {
+                stack = stackRepository.save(stack);
+            }
         }
         return stack;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackUpdater.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackUpdater.java
@@ -9,6 +9,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
+import com.sequenceiq.cloudbreak.converter.scheduler.StatusToPollGroupConverter;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.domain.Status;
@@ -25,6 +26,8 @@ public class StackUpdater {
     private CloudbreakEventService cloudbreakEventService;
     @Inject
     private ResourceRepository resourceRepository;
+    @Inject
+    private StatusToPollGroupConverter statusToPollGroupConverter;
 
     public Stack updateStackStatus(Long stackId, Status status) {
         return doUpdateStackStatus(stackId, status, "");
@@ -57,7 +60,7 @@ public class StackUpdater {
             if (statusReason != null) {
                 stack.setStatusReason(statusReason);
             }
-            InMemoryStateStore.put(stackId, status);
+            InMemoryStateStore.put(stackId, statusToPollGroupConverter.convert(status));
             if (Status.DELETE_COMPLETED.equals(status)) {
                 InMemoryStateStore.delete(stackId);
             } else {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderAdapter.java
@@ -4,8 +4,6 @@ import static com.sequenceiq.cloudbreak.service.stack.flow.ReflectionUtils.getDe
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 
-import javax.inject.Inject;
-
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -13,6 +11,13 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+
+import javax.inject.Inject;
+
+import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformRequest;
 import com.sequenceiq.cloudbreak.cloud.event.context.CloudContext;
@@ -73,10 +78,7 @@ import com.sequenceiq.cloudbreak.service.stack.event.ProvisionSetupComplete;
 import com.sequenceiq.cloudbreak.service.stack.flow.CoreInstanceMetaData;
 import com.sequenceiq.cloudbreak.service.stack.flow.InstanceSyncState;
 import com.sequenceiq.cloudbreak.service.stack.flow.ProvisioningService;
-import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+
 import reactor.bus.Event;
 import reactor.bus.EventBus;
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/ASGroupStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/ASGroupStatusCheckerTask.java
@@ -15,7 +15,7 @@ import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.DescribeInstanceStatusRequest;
 import com.amazonaws.services.ec2.model.DescribeInstanceStatusResult;
 import com.amazonaws.services.ec2.model.InstanceStatus;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.service.StackBasedStatusCheckerTask;
 
 
@@ -47,7 +47,7 @@ public class ASGroupStatusCheckerTask extends StackBasedStatusCheckerTask<AutoSc
             List<Activity> activities = amazonASClient.describeScalingActivities(describeScalingActivitiesRequest).getActivities();
             for (Activity activity : activities) {
                 if (activity.getProgress().equals(COMPLETED) && CANCELLED.equals(activity.getStatusCode())) {
-                    throw new FlowCancelledException(activity.getStatusMessage());
+                    throw new CancellationException(activity.getStatusMessage());
                 }
             }
             return false;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/aws/AwsConnector.java
@@ -85,7 +85,7 @@ import com.amazonaws.services.ec2.model.TerminateInstancesRequest;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Sets;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.domain.AwsCredential;
 import com.sequenceiq.cloudbreak.domain.AwsNetwork;
 import com.sequenceiq.cloudbreak.domain.AwsTemplate;
@@ -196,7 +196,7 @@ public class AwsConnector implements CloudPlatformConnector {
         PollingResult pollingResult = cloudFormationPollingService
                 .pollWithTimeout(cloudFormationStackStatusChecker, cfStackContext, POLLING_INTERVAL, INFINITE_ATTEMPTS);
         if (isExited(pollingResult)) {
-            throw new FlowCancelledException("Stack creation cancelled.");
+            throw new CancellationException("Stack creation cancelled.");
         } else if (isTimeout(pollingResult)) {
             throw new AwsResourceException(String.format("Failed to create CloudFormation stack: %s, polling result '%s'",
                     stackId, pollingResult));
@@ -376,7 +376,7 @@ public class AwsConnector implements CloudPlatformConnector {
         PollingResult pollingResult = consoleOutputPollingService
                 .pollWithTimeout(consoleOutputCheckerTask, consoleOutputContext, POLLING_INTERVAL, CONSOLE_OUTPUT_POLLING_ATTEMPTS);
         if (PollingResult.isExited(pollingResult)) {
-            throw new FlowCancelledException("Operation cancelled.");
+            throw new CancellationException("Operation cancelled.");
         } else if (PollingResult.isTimeout(pollingResult)) {
             throw new AwsResourceException("Operation timed out: Couldn't get console output of gateway instance.");
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/azure/AzureConnector.java
@@ -23,7 +23,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sequenceiq.cloud.azure.client.AzureClient;
 import com.sequenceiq.cloudbreak.EnvironmentVariableConfig;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.domain.AzureCredential;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.Credential;
@@ -147,9 +147,9 @@ public class AzureConnector implements CloudPlatformConnector {
             PollingResult pollingResult = azureThumbprintCheckerContextPollingService
                     .pollWithTimeout(azureThumbprintChecker, azureThumbprintCheckerContext, POLLING_INTERVAL, AZURE_THUMBPRINT_POLLING_ATTEMPTS);
             if (PollingResult.isExited(pollingResult)) {
-                throw new FlowCancelledException("Operation cancelled.");
+                throw new CancellationException("Operation cancelled.");
             } else if (PollingResult.isTimeout(pollingResult)) {
-                throw new AzureResourceException("Operation timed out: Couldn't get thumbrpint from azure on gateway instance.");
+                throw new AzureResourceException("Operation timed out: Couldn't get thumbprint from azure on gateway instance.");
             }
 
             Object virtualMachine = azureClient.getVirtualMachine(props);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/gcp/GcpConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/gcp/GcpConnector.java
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 
 import com.google.api.services.compute.Compute;
 import com.sequenceiq.cloudbreak.EnvironmentVariableConfig;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.CloudRegion;
 import com.sequenceiq.cloudbreak.domain.Credential;
@@ -115,7 +115,7 @@ public class GcpConnector implements CloudPlatformConnector {
             PollingResult pollingResult = consoleOutputPollingService
                     .pollWithTimeout(consoleOutputCheckerTask, gcpConsoleOutputContext, POLLING_INTERVAL, CONSOLE_OUTPUT_POLLING_ATTEMPTS);
             if (PollingResult.isExited(pollingResult)) {
-                throw new FlowCancelledException("Operation cancelled.");
+                throw new CancellationException("Operation cancelled.");
             } else if (PollingResult.isTimeout(pollingResult)) {
                 throw new GcpResourceException("Operation timed out: Couldn't get console output of gateway instance.");
             }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterBootstrapperTest.java
@@ -20,8 +20,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.core.CloudbreakException;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
 import com.sequenceiq.cloudbreak.core.flow.context.BootstrapApiContext;
 import com.sequenceiq.cloudbreak.core.flow.context.ContainerOrchestratorClusterContext;
 import com.sequenceiq.cloudbreak.core.flow.context.ProvisioningContext;
@@ -31,16 +31,16 @@ import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.ScalingType;
 import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.orchestrator.ContainerOrchestrator;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorCancelledException;
 import com.sequenceiq.cloudbreak.orchestrator.exception.CloudbreakOrchestratorFailedException;
-import com.sequenceiq.cloudbreak.orchestrator.ContainerOrchestrator;
-import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 import com.sequenceiq.cloudbreak.orchestrator.model.GatewayConfig;
 import com.sequenceiq.cloudbreak.orchestrator.model.Node;
 import com.sequenceiq.cloudbreak.repository.StackRepository;
 import com.sequenceiq.cloudbreak.service.PollingResult;
 import com.sequenceiq.cloudbreak.service.PollingService;
 import com.sequenceiq.cloudbreak.service.StatusCheckerTask;
+import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 import com.sequenceiq.cloudbreak.service.TlsSecurityService;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -126,7 +126,7 @@ public class ClusterBootstrapperTest {
                 any(ContainerOrchestratorClusterContext.class), anyInt(), anyInt());
     }
 
-    @Test(expected = FlowCancelledException.class)
+    @Test(expected = CancellationException.class)
     public void bootstrapClusterWhenOrchestratorDropCancelledException() throws CloudbreakException, CloudbreakOrchestratorFailedException {
         Stack stack = TestUtil.stack();
         ProvisioningContext context = new ProvisioningContext.Builder().setAmbariIp("10.0.0.1").setDefaultParams(1L, CloudPlatform.AZURE).build();
@@ -272,7 +272,7 @@ public class ClusterBootstrapperTest {
                 any(ContainerOrchestratorClusterContext.class), anyInt(), anyInt());
     }
 
-    @Test(expected = FlowCancelledException.class)
+    @Test(expected = CancellationException.class)
     public void bootstrapNewNodesInClusterWhenOrchestratorDropCancelledException() throws CloudbreakException, CloudbreakOrchestratorFailedException {
         Stack stack = TestUtil.stack();
         StackScalingContext context = new StackScalingContext(1L, CloudPlatform.AZURE, 2, "master1", new HashSet<Resource>(),

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterContainerRunnerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/ClusterContainerRunnerTest.java
@@ -21,9 +21,9 @@ import org.mockito.runners.MockitoJUnitRunner;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.cloud.scheduler.CancellationException;
 import com.sequenceiq.cloudbreak.controller.json.HostGroupAdjustmentJson;
 import com.sequenceiq.cloudbreak.core.CloudbreakException;
-import com.sequenceiq.cloudbreak.core.flow.FlowCancelledException;
 import com.sequenceiq.cloudbreak.core.flow.context.ClusterScalingContext;
 import com.sequenceiq.cloudbreak.core.flow.context.ProvisioningContext;
 import com.sequenceiq.cloudbreak.domain.CloudPlatform;
@@ -144,7 +144,7 @@ public class ClusterContainerRunnerTest {
         underTest.runClusterContainers(provisioningContext);
     }
 
-    @Test(expected = FlowCancelledException.class)
+    @Test(expected = CancellationException.class)
     public void runClusterContainersWhenContainerRunnerCancelled()
             throws CloudbreakException, CloudbreakOrchestratorFailedException, CloudbreakOrchestratorCancelledException {
         ReflectionTestUtils.setField(underTest, "baywatchEnabled", true);
@@ -271,7 +271,7 @@ public class ClusterContainerRunnerTest {
         underTest.addClusterContainers(context);
     }
 
-    @Test(expected = FlowCancelledException.class)
+    @Test(expected = CancellationException.class)
     public void runNewNodesClusterContainersWhenContainerRunnerCancelled()
             throws CloudbreakException, CloudbreakOrchestratorFailedException, CloudbreakOrchestratorCancelledException {
         ReflectionTestUtils.setField(underTest, "baywatchEnabled", true);

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteriaTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteriaTest.java
@@ -2,33 +2,23 @@ package com.sequenceiq.cloudbreak.core.bootstrap.service;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyLong;
-import static org.mockito.Mockito.when;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
-import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.cloudbreak.domain.Cluster;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.domain.Status;
-import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
-import com.sequenceiq.cloudbreak.service.stack.StackService;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StackDeletionBasedExitCriteriaTest {
 
     @InjectMocks
     private StackDeletionBasedExitCriteria underTest;
-
-    @Mock
-    private ClusterService clusterService;
-
-    @Mock
-    private StackService stackService;
 
     @Test
     public void exitNeededScenariosTest() {
@@ -37,33 +27,20 @@ public class StackDeletionBasedExitCriteriaTest {
         stack.setCluster(cluster);
         StackDeletionBasedExitCriteriaModel exitCriteriaModel = new StackDeletionBasedExitCriteriaModel(1L);
 
-        when(stackService.findLazy(anyLong())).thenReturn(stack);
-
+        InMemoryStateStore.put(1L, Status.AVAILABLE);
         assertFalse(underTest.isExitNeeded(exitCriteriaModel));
 
-        stack.setStatus(Status.DELETE_IN_PROGRESS);
+        InMemoryStateStore.put(1L, Status.DELETE_IN_PROGRESS);
         assertTrue(underTest.isExitNeeded(exitCriteriaModel));
 
-        stack.setStatus(Status.DELETE_COMPLETED);
+        InMemoryStateStore.put(1L, Status.DELETE_COMPLETED);
         assertTrue(underTest.isExitNeeded(exitCriteriaModel));
 
-        stack.setStatus(Status.AVAILABLE);
+        InMemoryStateStore.put(1L, Status.CREATE_IN_PROGRESS);
         assertFalse(underTest.isExitNeeded(exitCriteriaModel));
 
-        cluster.setStatus(Status.DELETE_COMPLETED);
-        assertTrue(underTest.isExitNeeded(exitCriteriaModel));
-
-        cluster.setStatus(Status.DELETE_IN_PROGRESS);
-        assertTrue(underTest.isExitNeeded(exitCriteriaModel));
-
-        cluster.setStatus(Status.AVAILABLE);
+        InMemoryStateStore.put(1L, Status.UPDATE_IN_PROGRESS);
         assertFalse(underTest.isExitNeeded(exitCriteriaModel));
-
-        cluster.setStatus(Status.UPDATE_IN_PROGRESS);
-        assertFalse(underTest.isExitNeeded(exitCriteriaModel));
-
-        when(stackService.findLazy(anyLong())).thenThrow(new IllegalArgumentException("test"));
-        assertTrue(underTest.isExitNeeded(exitCriteriaModel));
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteriaTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/bootstrap/service/StackDeletionBasedExitCriteriaTest.java
@@ -9,10 +9,10 @@ import org.mockito.InjectMocks;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
 import com.sequenceiq.cloudbreak.cloud.store.InMemoryStateStore;
 import com.sequenceiq.cloudbreak.domain.Cluster;
 import com.sequenceiq.cloudbreak.domain.Stack;
-import com.sequenceiq.cloudbreak.domain.Status;
 
 @RunWith(MockitoJUnitRunner.class)
 public class StackDeletionBasedExitCriteriaTest {
@@ -27,20 +27,12 @@ public class StackDeletionBasedExitCriteriaTest {
         stack.setCluster(cluster);
         StackDeletionBasedExitCriteriaModel exitCriteriaModel = new StackDeletionBasedExitCriteriaModel(1L);
 
-        InMemoryStateStore.put(1L, Status.AVAILABLE);
+        InMemoryStateStore.put(1L, PollGroup.POLLABLE);
         assertFalse(underTest.isExitNeeded(exitCriteriaModel));
 
-        InMemoryStateStore.put(1L, Status.DELETE_IN_PROGRESS);
+        InMemoryStateStore.put(1L, PollGroup.CANCELLED);
         assertTrue(underTest.isExitNeeded(exitCriteriaModel));
 
-        InMemoryStateStore.put(1L, Status.DELETE_COMPLETED);
-        assertTrue(underTest.isExitNeeded(exitCriteriaModel));
-
-        InMemoryStateStore.put(1L, Status.CREATE_IN_PROGRESS);
-        assertFalse(underTest.isExitNeeded(exitCriteriaModel));
-
-        InMemoryStateStore.put(1L, Status.UPDATE_IN_PROGRESS);
-        assertFalse(underTest.isExitNeeded(exitCriteriaModel));
     }
 
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/repository/StackUpdaterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/repository/StackUpdaterTest.java
@@ -20,6 +20,8 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import com.sequenceiq.cloudbreak.TestUtil;
+import com.sequenceiq.cloudbreak.cloud.scheduler.PollGroup;
+import com.sequenceiq.cloudbreak.converter.scheduler.StatusToPollGroupConverter;
 import com.sequenceiq.cloudbreak.domain.Resource;
 import com.sequenceiq.cloudbreak.domain.Stack;
 import com.sequenceiq.cloudbreak.domain.Status;
@@ -37,6 +39,9 @@ public class StackUpdaterTest {
     @Mock
     private ResourceRepository resourceRepository;
 
+    @Mock
+    private StatusToPollGroupConverter statusToPollGroupConverter;
+
     @InjectMocks
     private StackUpdater underTest;
 
@@ -47,6 +52,7 @@ public class StackUpdaterTest {
         when(stackRepository.findById(anyLong())).thenReturn(stack);
         when(stackRepository.save(any(Stack.class))).thenReturn(stack);
         doNothing().when(cloudbreakEventService).fireCloudbreakEvent(anyLong(), anyString(), anyString());
+        when(statusToPollGroupConverter.convert(Status.DELETE_COMPLETED)).thenReturn(PollGroup.POLLABLE);
 
         Stack newStack = underTest.updateStackStatus(1L, Status.DELETE_COMPLETED);
         assertEquals(Status.DELETE_COMPLETED, newStack.getStatus());
@@ -61,6 +67,7 @@ public class StackUpdaterTest {
         when(stackRepository.findById(anyLong())).thenReturn(stack);
         when(stackRepository.save(any(Stack.class))).thenReturn(stack);
         doNothing().when(cloudbreakEventService).fireCloudbreakEvent(anyLong(), anyString(), anyString());
+        when(statusToPollGroupConverter.convert(Status.DELETE_COMPLETED)).thenReturn(PollGroup.POLLABLE);
 
         Stack newStack = underTest.updateStackStatus(1L, Status.DELETE_COMPLETED, "test");
         assertEquals(Status.DELETE_COMPLETED, newStack.getStatus());


### PR DESCRIPTION
@akanto, @biharitomi 
this is a very simple implementation of an in-memory store that holds the current state of the stacks
- used with the SPI scheduler PollTask and with the ExitCriteria of orchestrator-api
- when a key is not found in the store, it is ignored and polling continues
- in case of cancellation an Exception is thrown that is handled in the flow handler

the implementation can be further improved later:
- move the whole syncScheduler implementation to the common module (and maybe rename it to cloud-scheduler as it doesn't really have any other purpose only the environment variable config)
- remove the exitCriteria implementation and use the scheduler there as well instead
- remove all the other poller implementations (PollingService)
- use a persistent key-value store instead of a concurrentHashMap
- change the static interface to a regular interface + implementation, but it makes it much more complicated with the service injections
