### PR TITLE
Configurable account preferences

### DIFF
--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/AccountPreferences.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/AccountPreferences.java
@@ -1,0 +1,100 @@
+package com.sequenceiq.cloudbreak.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.NamedQueries;
+import javax.persistence.NamedQuery;
+import javax.persistence.Table;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+@Entity
+@Table(name = "account_preferences")
+@NamedQueries({
+        @NamedQuery(
+                name = "AccountPreferences.findByAccount",
+                query = "SELECT ap FROM AccountPreferences ap "
+                        + "WHERE ap.account= :account")
+})
+public class AccountPreferences {
+    private static final String INSTANCE_TYPE_SEPARATOR = ",";
+
+    @Id
+    private String account;
+    private Long maxNumberOfClusters;
+    private Long maxNumberOfNodesPerCluster;
+    private Long maxNumberOfClustersPerUser;
+    private String allowedInstanceTypes;
+    private Long clusterTimeToLive;
+    private Long userTimeToLive;
+
+    public String getAccount() {
+        return account;
+    }
+
+    public void setAccount(String account) {
+        this.account = account;
+    }
+
+    public Long getMaxNumberOfClusters() {
+        return maxNumberOfClusters;
+    }
+
+    public void setMaxNumberOfClusters(Long maxNumberOfClusters) {
+        this.maxNumberOfClusters = maxNumberOfClusters;
+    }
+
+    public Long getMaxNumberOfNodesPerCluster() {
+        return maxNumberOfNodesPerCluster;
+    }
+
+    public void setMaxNumberOfNodesPerCluster(Long maxNumberOfNodesPerCluster) {
+        this.maxNumberOfNodesPerCluster = maxNumberOfNodesPerCluster;
+    }
+
+    public List<String> getAllowedInstanceTypes() {
+        return StringUtils.isEmpty(allowedInstanceTypes) ? new ArrayList<String>() : Arrays.asList(allowedInstanceTypes.split(INSTANCE_TYPE_SEPARATOR));
+    }
+
+    public void setAllowedInstanceTypes(Iterable<String> allowedInstanceTypes) {
+        StringBuilder builder = new StringBuilder();
+        Iterator<String> it = allowedInstanceTypes.iterator();
+        while (it.hasNext()) {
+            String instanceType = it.next();
+            builder.append(instanceType);
+            if (it.hasNext()) {
+                builder.append(INSTANCE_TYPE_SEPARATOR);
+            }
+        }
+        this.allowedInstanceTypes = builder.toString();
+    }
+
+    public Long getClusterTimeToLive() {
+        return clusterTimeToLive;
+    }
+
+    public void setClusterTimeToLive(Long clusterTimeToLive) {
+        this.clusterTimeToLive = clusterTimeToLive;
+    }
+
+    public Long getUserTimeToLive() {
+        return userTimeToLive;
+    }
+
+    public void setUserTimeToLive(Long userTimeToLive) {
+        this.userTimeToLive = userTimeToLive;
+    }
+
+    public Long getMaxNumberOfClustersPerUser() {
+        return maxNumberOfClustersPerUser;
+    }
+
+    public void setMaxNumberOfClustersPerUser(Long maxNumberOfClustersPerUser) {
+        this.maxNumberOfClustersPerUser = maxNumberOfClustersPerUser;
+    }
+}

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/CbUser.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/CbUser.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.domain;
 
+import java.util.Date;
 import java.util.List;
 
 public class CbUser {
@@ -10,14 +11,16 @@ public class CbUser {
     private List<CbUserRole> roles;
     private String givenName;
     private String familyName;
+    private Date created;
 
-    public CbUser(String userId, String username, String account, List<CbUserRole> roles, String givenName, String familyName) {
+    public CbUser(String userId, String username, String account, List<CbUserRole> roles, String givenName, String familyName, Date created) {
         this.userId = userId;
         this.username = username;
         this.account = account;
         this.roles = roles;
         this.givenName = givenName;
         this.familyName = familyName;
+        this.created = created;
     }
 
     public String getUserId() {
@@ -46,5 +49,9 @@ public class CbUser {
 
     public String getFamilyName() {
         return familyName;
+    }
+
+    public Date getCreated() {
+        return created;
     }
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/Stack.java
@@ -14,12 +14,6 @@ import static com.sequenceiq.cloudbreak.domain.Status.STOP_IN_PROGRESS;
 import static com.sequenceiq.cloudbreak.domain.Status.STOP_REQUESTED;
 import static com.sequenceiq.cloudbreak.domain.Status.UPDATE_IN_PROGRESS;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -40,6 +34,12 @@ import javax.persistence.SequenceGenerator;
 import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 import javax.persistence.Version;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 @Entity
 @Table(name = "Stack", uniqueConstraints = {
@@ -188,7 +188,11 @@ import javax.persistence.Version;
                         + "LEFT JOIN FETCH t.resources "
                         + "LEFT JOIN FETCH t.instanceGroups ig "
                         + "LEFT JOIN FETCH ig.instanceMetaData "
-                        + "WHERE t.securityGroup.id= :securityGroupId ")
+                        + "WHERE t.securityGroup.id= :securityGroupId "),
+        @NamedQuery(
+                name = "Stack.findAllAlive",
+                query = "SELECT s FROM Stack s "
+                        + "WHERE s.status <> 'DELETE_COMPLETED' ")
 })
 public class Stack implements ProvisionEntity {
 
@@ -234,6 +238,7 @@ public class Stack implements ProvisionEntity {
     private Network network;
     @ManyToOne
     private SecurityGroup securityGroup;
+    private Long created;
 
     public Set<InstanceGroup> getInstanceGroups() {
         return instanceGroups;
@@ -575,5 +580,13 @@ public class Stack implements ProvisionEntity {
             }
         }
         return ephemeral;
+    }
+
+    public Long getCreated() {
+        return created;
+    }
+
+    public void setCreated(Long created) {
+        this.created = created;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/OwnerBasedPermissionEvaluator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/OwnerBasedPermissionEvaluator.java
@@ -3,17 +3,16 @@ package com.sequenceiq.cloudbreak.conf;
 import java.io.Serializable;
 import java.lang.reflect.Field;
 
-import org.springframework.security.access.PermissionEvaluator;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.oauth2.provider.OAuth2Authentication;
-import org.springframework.stereotype.Component;
-import org.springframework.util.ReflectionUtils;
-
 import com.sequenceiq.cloudbreak.controller.NotFoundException;
 import com.sequenceiq.cloudbreak.domain.CbUser;
 import com.sequenceiq.cloudbreak.domain.CbUserRole;
 import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
 import com.sequenceiq.cloudbreak.service.user.UserFilterField;
+import org.springframework.security.access.PermissionEvaluator;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.stereotype.Component;
+import org.springframework.util.ReflectionUtils;
 
 @Component
 public class OwnerBasedPermissionEvaluator implements PermissionEvaluator {
@@ -56,20 +55,32 @@ public class OwnerBasedPermissionEvaluator implements PermissionEvaluator {
     }
 
     private String getAccount(Object targetDomainObject) throws IllegalAccessException {
+        String result = "";
         Field accountField = ReflectionUtils.findField(targetDomainObject.getClass(), "account");
-        accountField.setAccessible(true);
-        return (String) accountField.get(targetDomainObject);
+        if (accountField != null) {
+            accountField.setAccessible(true);
+            result = (String) accountField.get(targetDomainObject);
+        }
+        return result;
     }
 
     private Boolean isPublicInAccount(Object targetDomainObject) throws IllegalAccessException {
+        Boolean result = false;
         Field publicInAccountField = ReflectionUtils.findField(targetDomainObject.getClass(), "publicInAccount");
-        publicInAccountField.setAccessible(true);
-        return (Boolean) publicInAccountField.get(targetDomainObject);
+        if (publicInAccountField != null) {
+            publicInAccountField.setAccessible(true);
+            result = (Boolean) publicInAccountField.get(targetDomainObject);
+        }
+        return result;
     }
 
     private String getOwner(Object targetDomainObject) throws IllegalAccessException {
+        String result = "";
         Field ownerField = ReflectionUtils.findField(targetDomainObject.getClass(), "owner");
-        ownerField.setAccessible(true);
-        return (String) ownerField.get(targetDomainObject);
+        if (ownerField != null) {
+            ownerField.setAccessible(true);
+            result = (String) ownerField.get(targetDomainObject);
+        }
+        return result;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/conf/SecurityConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/conf/SecurityConfig.java
@@ -1,7 +1,5 @@
 package com.sequenceiq.cloudbreak.conf;
 
-import java.io.IOException;
-
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.servlet.FilterChain;
@@ -9,6 +7,11 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import java.io.IOException;
+
+import com.sequenceiq.cloudbreak.domain.CbUser;
+import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
+import com.sequenceiq.cloudbreak.service.user.UserFilterField;
 import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.slf4j.Logger;
@@ -30,10 +33,6 @@ import org.springframework.security.oauth2.provider.OAuth2Authentication;
 import org.springframework.security.oauth2.provider.token.RemoteTokenServices;
 import org.springframework.security.web.authentication.preauth.AbstractPreAuthenticatedProcessingFilter;
 import org.springframework.web.filter.OncePerRequestFilter;
-
-import com.sequenceiq.cloudbreak.domain.CbUser;
-import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
-import com.sequenceiq.cloudbreak.service.user.UserFilterField;
 
 @Configuration
 public class SecurityConfig {
@@ -135,7 +134,8 @@ public class SecurityConfig {
                     .antMatchers("/recipes").access("#oauth2.hasScope('cloudbreak.recipes')")
                     .antMatchers("/user/networks").access("#oauth2.hasScope('cloudbreak.templates')")
                     .antMatchers("/account/networks").access("#oauth2.hasScope('cloudbreak.templates')")
-                    .antMatchers("/networks/**").access("#oauth2.hasScope('cloudbreak.templates')");
+                    .antMatchers("/networks/**").access("#oauth2.hasScope('cloudbreak.templates')")
+                    .antMatchers("/accountpreferences").access("#oauth2.hasScope('cloudbreak.templates')");
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/AccountPreferencesController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/AccountPreferencesController.java
@@ -1,0 +1,64 @@
+package com.sequenceiq.cloudbreak.controller;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+
+import com.sequenceiq.cloudbreak.controller.doc.ContentType;
+import com.sequenceiq.cloudbreak.controller.doc.ControllerDescription;
+import com.sequenceiq.cloudbreak.controller.doc.Notes;
+import com.sequenceiq.cloudbreak.controller.doc.OperationDescriptions;
+import com.sequenceiq.cloudbreak.controller.json.AccountPreferencesJson;
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import com.sequenceiq.cloudbreak.domain.CbUser;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.service.account.AccountPreferencesService;
+import com.wordnik.swagger.annotations.Api;
+import com.wordnik.swagger.annotations.ApiOperation;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.core.convert.ConversionService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@Api(value = "/accountpreferences", description = ControllerDescription.ACCOUNT_PREFERENCES_DESCRIPTION)
+public class AccountPreferencesController {
+
+    @Inject
+    private AccountPreferencesService service;
+
+    @Inject
+    @Qualifier("conversionService")
+    private ConversionService conversionService;
+
+    @ApiOperation(value = OperationDescriptions.AccountPreferencesDescription.GET_PRIVATE, produces = ContentType.JSON, notes = Notes.ACCOUNT_PREFERENCES_NOTES)
+    @RequestMapping(value = "accountpreferences", method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<AccountPreferencesJson> getAccountPreferencesForUser(@ModelAttribute("user") CbUser user) {
+        MDCBuilder.buildUserMdcContext(user);
+        AccountPreferences preferences = service.getOneByAccount(user);
+        return new ResponseEntity<>(convert(preferences), HttpStatus.OK);
+    }
+
+    @ApiOperation(value = OperationDescriptions.AccountPreferencesDescription.PUT_PRIVATE, produces = ContentType.JSON, notes = Notes.ACCOUNT_PREFERENCES_NOTES)
+    @RequestMapping(value = "accountpreferences", method = RequestMethod.PUT)
+    @ResponseBody
+    public ResponseEntity<String> updateAccountPreferences(@ModelAttribute("user") CbUser user, @Valid @RequestBody AccountPreferencesJson updateRequest) {
+        MDCBuilder.buildUserMdcContext(user);
+        service.saveOne(user, convert(updateRequest));
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    private AccountPreferencesJson convert(AccountPreferences preferences) {
+        return conversionService.convert(preferences, AccountPreferencesJson.class);
+    }
+
+    private AccountPreferences convert(AccountPreferencesJson preferences) {
+        return conversionService.convert(preferences, AccountPreferences.class);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/AccountPreferencesController.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/AccountPreferencesController.java
@@ -10,8 +10,10 @@ import com.sequenceiq.cloudbreak.controller.doc.OperationDescriptions;
 import com.sequenceiq.cloudbreak.controller.json.AccountPreferencesJson;
 import com.sequenceiq.cloudbreak.domain.AccountPreferences;
 import com.sequenceiq.cloudbreak.domain.CbUser;
+import com.sequenceiq.cloudbreak.domain.CbUserRole;
 import com.sequenceiq.cloudbreak.logger.MDCBuilder;
 import com.sequenceiq.cloudbreak.service.account.AccountPreferencesService;
+import com.sequenceiq.cloudbreak.service.account.ScheduledAccountPreferencesValidator;
 import com.wordnik.swagger.annotations.Api;
 import com.wordnik.swagger.annotations.ApiOperation;
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -33,6 +35,9 @@ public class AccountPreferencesController {
     private AccountPreferencesService service;
 
     @Inject
+    private ScheduledAccountPreferencesValidator validator;
+
+    @Inject
     @Qualifier("conversionService")
     private ConversionService conversionService;
 
@@ -51,6 +56,17 @@ public class AccountPreferencesController {
     public ResponseEntity<String> updateAccountPreferences(@ModelAttribute("user") CbUser user, @Valid @RequestBody AccountPreferencesJson updateRequest) {
         MDCBuilder.buildUserMdcContext(user);
         service.saveOne(user, convert(updateRequest));
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @ApiOperation(value = OperationDescriptions.AccountPreferencesDescription.VALIDATE, produces = ContentType.JSON, notes = Notes.ACCOUNT_PREFERENCES_NOTES)
+    @RequestMapping(value = "accountpreferences/validate", method = RequestMethod.GET)
+    @ResponseBody
+    public ResponseEntity<String> validate(@ModelAttribute("user") CbUser user) {
+        MDCBuilder.buildUserMdcContext(user);
+        if (user.getRoles().contains(CbUserRole.ADMIN)) {
+            validator.validate();
+        }
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/ControllerDescription.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/ControllerDescription.java
@@ -11,6 +11,7 @@ public class ControllerDescription {
     public static final String USAGES_DESCRIPTION = "Operations on usages";
     public static final String EVENT_DESCRIPTION = "Operations on events";
     public static final String NETWORK_DESCRIPTION = "Operations on networks";
+    public static final String ACCOUNT_PREFERENCES_DESCRIPTION = "Operations on account preferences";
     public static final String USER_DESCRIPTION = "Operations on users";
     public static final String SECURITY_GROUPS_DESCRIPTION = "Operations on security group resources";
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/ModelDescriptions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/ModelDescriptions.java
@@ -161,4 +161,13 @@ public class ModelDescriptions {
         public static final String PROTOCOL = "protocol of the rule";
         public static final String MODIFIABLE = "flag for making the rule modifiable";
     }
+
+    public static class AccountPreferencesModelDescription {
+        public static final String MAX_NO_CLUSTERS = "max number of clusters in the account (0 when unlimited)";
+        public static final String MAX_NO_NODES_PER_CLUSTER = "max number of vms in a cluster of account (0 when unlimited)";
+        public static final String MAX_NO_CLUSTERS_PER_USER = "max number of clusters for user within the account (0 when unlimited)";
+        public static final String ALLOWED_INSTANCE_TYPES = "allowed instance types in the account (empty list for no restriction)";
+        public static final String CLUSTER_TIME_TO_LIVE = "lifecycle of the cluster in ms (0 for immortal clusters)";
+        public static final String ACCOUNT_TIME_TO_LIVE = "lifecycle of the account and its clusters in ms (0 for immortal account)";
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/ModelDescriptions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/ModelDescriptions.java
@@ -167,7 +167,7 @@ public class ModelDescriptions {
         public static final String MAX_NO_NODES_PER_CLUSTER = "max number of vms in a cluster of account (0 when unlimited)";
         public static final String MAX_NO_CLUSTERS_PER_USER = "max number of clusters for user within the account (0 when unlimited)";
         public static final String ALLOWED_INSTANCE_TYPES = "allowed instance types in the account (empty list for no restriction)";
-        public static final String CLUSTER_TIME_TO_LIVE = "lifecycle of the cluster in ms (0 for immortal clusters)";
-        public static final String ACCOUNT_TIME_TO_LIVE = "lifecycle of the account and its clusters in ms (0 for immortal account)";
+        public static final String CLUSTER_TIME_TO_LIVE = "lifecycle of the cluster in hours (0 for immortal clusters)";
+        public static final String ACCOUNT_TIME_TO_LIVE = "lifecycle of the account and its clusters in hours (0 for immortal account)";
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/Notes.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/Notes.java
@@ -37,6 +37,8 @@ public class Notes {
     public static final String NETWORK_NOTES = "Provider specific network settings could be configured by using Network resources.";
     public static final String SECURITY_GROUP_NOTES = "Different inbound security rules(group) could be configured by using SecurityGroup resources "
             + "and a group could be assigned to any Stack(cluster).";
+    public static final String ACCOUNT_PREFERENCES_NOTES = "Account related preferences that could be managed by the account admins and different "
+            + "restrictions could be added to Cloudbreak resources.";
 
     public static final String USER_NOTES = "Users can be invited under an account by the administrator, and all resources "
             + "(e.g. resources, networks, blueprints, credentials, clusters) can be shared across account users";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/OperationDescriptions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/OperationDescriptions.java
@@ -125,4 +125,9 @@ public class OperationDescriptions {
         public static final String DELETE_PUBLIC_BY_NAME = "delete public (owned) or private security group by name";
         public static final String DELETE_BY_ID = "delete security group by id";
     }
+
+    public static class AccountPreferencesDescription {
+        public static final String GET_PRIVATE = "retrieve account preferences for admin user";
+        public static final String PUT_PRIVATE = "update account preferences of admin user";
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/OperationDescriptions.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/doc/OperationDescriptions.java
@@ -129,5 +129,6 @@ public class OperationDescriptions {
     public static class AccountPreferencesDescription {
         public static final String GET_PRIVATE = "retrieve account preferences for admin user";
         public static final String PUT_PRIVATE = "update account preferences of admin user";
+        public static final String VALIDATE = "validate account preferences of all stacks";
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/AccountPreferencesJson.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/json/AccountPreferencesJson.java
@@ -1,0 +1,95 @@
+package com.sequenceiq.cloudbreak.controller.json;
+
+import static com.sequenceiq.cloudbreak.controller.doc.ModelDescriptions.AccountPreferencesModelDescription;
+
+import javax.validation.constraints.Digits;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
+import java.util.List;
+
+import com.wordnik.swagger.annotations.ApiModel;
+import com.wordnik.swagger.annotations.ApiModelProperty;
+
+@ApiModel("AccountPreferences")
+public class AccountPreferencesJson implements JsonEntity {
+
+    @NotNull
+    @Min(value = 0, message = "The maximum number of clusters has to be greater than '-1'")
+    @Digits(fraction = 0, integer = 10, message = "The maximum number of clusters has to be a number")
+    @ApiModelProperty(AccountPreferencesModelDescription.MAX_NO_CLUSTERS)
+    private Long maxNumberOfClusters;
+
+    @NotNull
+    @Min(value = 0, message = "The maximum number of vms per cluster has to be greater than '-1'")
+    @Digits(fraction = 0, integer = 10, message = "The maximum number of vms per cluster has to be a number")
+    @ApiModelProperty(AccountPreferencesModelDescription.MAX_NO_NODES_PER_CLUSTER)
+    private Long maxNumberOfNodesPerCluster;
+
+    @NotNull
+    @Min(value = 0, message = "The maximum number of clusters per user has to be greater than '-1'")
+    @Digits(fraction = 0, integer = 10, message = "The maximum number of clusters per user has to be a number")
+    @ApiModelProperty(AccountPreferencesModelDescription.MAX_NO_CLUSTERS_PER_USER)
+    private Long maxNumberOfClustersPerUser;
+
+    @ApiModelProperty(AccountPreferencesModelDescription.ALLOWED_INSTANCE_TYPES)
+    private List<String> allowedInstanceTypes;
+
+    @NotNull
+    @Min(value = 0, message = "The cluster time to live has to be greater than '-1'")
+    @ApiModelProperty(AccountPreferencesModelDescription.CLUSTER_TIME_TO_LIVE)
+    private Long clusterTimeToLive;
+
+    @NotNull
+    @Min(value = 0, message = "The account time to live has to be greater than '-1'")
+    @ApiModelProperty(AccountPreferencesModelDescription.ACCOUNT_TIME_TO_LIVE)
+    private Long userTimeToLive;
+
+    public Long getMaxNumberOfClusters() {
+        return maxNumberOfClusters;
+    }
+
+    public void setMaxNumberOfClusters(Long maxNumberOfClusters) {
+        this.maxNumberOfClusters = maxNumberOfClusters;
+    }
+
+    public Long getMaxNumberOfNodesPerCluster() {
+        return maxNumberOfNodesPerCluster;
+    }
+
+    public void setMaxNumberOfNodesPerCluster(Long maxNumberOfNodesPerCluster) {
+        this.maxNumberOfNodesPerCluster = maxNumberOfNodesPerCluster;
+    }
+
+    public List<String> getAllowedInstanceTypes() {
+        return allowedInstanceTypes;
+    }
+
+    public void setAllowedInstanceTypes(List<String> allowedInstanceTypes) {
+        this.allowedInstanceTypes = allowedInstanceTypes;
+    }
+
+    public Long getClusterTimeToLive() {
+        return clusterTimeToLive;
+    }
+
+    public void setClusterTimeToLive(Long clusterTimeToLive) {
+        this.clusterTimeToLive = clusterTimeToLive;
+    }
+
+    public Long getUserTimeToLive() {
+        return userTimeToLive;
+    }
+
+    public void setUserTimeToLive(Long userTimeToLive) {
+        this.userTimeToLive = userTimeToLive;
+    }
+
+    public Long getMaxNumberOfClustersPerUser() {
+        return maxNumberOfClustersPerUser;
+    }
+
+    public void setMaxNumberOfClustersPerUser(Long maxNumberOfClustersPerUser) {
+        this.maxNumberOfClustersPerUser = maxNumberOfClustersPerUser;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/AccountPreferencesToJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/AccountPreferencesToJsonConverter.java
@@ -1,0 +1,21 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import com.sequenceiq.cloudbreak.controller.json.AccountPreferencesJson;
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccountPreferencesToJsonConverter extends AbstractConversionServiceAwareConverter<AccountPreferences, AccountPreferencesJson> {
+
+    @Override
+    public AccountPreferencesJson convert(AccountPreferences source) {
+        AccountPreferencesJson json = new AccountPreferencesJson();
+        json.setMaxNumberOfClusters(source.getMaxNumberOfClusters());
+        json.setMaxNumberOfNodesPerCluster(source.getMaxNumberOfNodesPerCluster());
+        json.setAllowedInstanceTypes(source.getAllowedInstanceTypes());
+        json.setClusterTimeToLive(source.getClusterTimeToLive());
+        json.setUserTimeToLive(source.getUserTimeToLive());
+        json.setMaxNumberOfClustersPerUser(source.getMaxNumberOfClustersPerUser());
+        return json;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/AccountPreferencesToJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/AccountPreferencesToJsonConverter.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AccountPreferencesToJsonConverter extends AbstractConversionServiceAwareConverter<AccountPreferences, AccountPreferencesJson> {
+    private static final long HOUR_IN_MS = 3600000L;
+    private static final long ZERO = 0L;
 
     @Override
     public AccountPreferencesJson convert(AccountPreferences source) {
@@ -13,8 +15,10 @@ public class AccountPreferencesToJsonConverter extends AbstractConversionService
         json.setMaxNumberOfClusters(source.getMaxNumberOfClusters());
         json.setMaxNumberOfNodesPerCluster(source.getMaxNumberOfNodesPerCluster());
         json.setAllowedInstanceTypes(source.getAllowedInstanceTypes());
-        json.setClusterTimeToLive(source.getClusterTimeToLive());
-        json.setUserTimeToLive(source.getUserTimeToLive());
+        long clusterTimeToLive = source.getClusterTimeToLive() == ZERO ? ZERO : source.getClusterTimeToLive() / HOUR_IN_MS;
+        json.setClusterTimeToLive(clusterTimeToLive);
+        long userTimeToLive = source.getUserTimeToLive() == ZERO ? ZERO : source.getUserTimeToLive() / HOUR_IN_MS;
+        json.setUserTimeToLive(userTimeToLive);
         json.setMaxNumberOfClustersPerUser(source.getMaxNumberOfClustersPerUser());
         return json;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToAccountPreferencesConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToAccountPreferencesConverter.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class JsonToAccountPreferencesConverter extends AbstractConversionServiceAwareConverter<AccountPreferencesJson, AccountPreferences> {
+    private static final long HOUR_IN_MS = 3600000L;
 
     @Override
     public AccountPreferences convert(AccountPreferencesJson source) {
@@ -18,8 +19,8 @@ public class JsonToAccountPreferencesConverter extends AbstractConversionService
         if (allowedInstanceTypes != null && !allowedInstanceTypes.isEmpty()) {
             target.setAllowedInstanceTypes(allowedInstanceTypes);
         }
-        target.setClusterTimeToLive(source.getClusterTimeToLive());
-        target.setUserTimeToLive(source.getUserTimeToLive());
+        target.setClusterTimeToLive(source.getClusterTimeToLive() * HOUR_IN_MS);
+        target.setUserTimeToLive(source.getUserTimeToLive() * HOUR_IN_MS);
         target.setMaxNumberOfClustersPerUser(source.getMaxNumberOfClustersPerUser());
         return target;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToAccountPreferencesConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToAccountPreferencesConverter.java
@@ -1,0 +1,27 @@
+package com.sequenceiq.cloudbreak.converter;
+
+import java.util.List;
+
+import com.sequenceiq.cloudbreak.controller.json.AccountPreferencesJson;
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonToAccountPreferencesConverter extends AbstractConversionServiceAwareConverter<AccountPreferencesJson, AccountPreferences> {
+
+    @Override
+    public AccountPreferences convert(AccountPreferencesJson source) {
+        AccountPreferences target = new AccountPreferences();
+        target.setMaxNumberOfClusters(source.getMaxNumberOfClusters());
+        target.setMaxNumberOfNodesPerCluster(source.getMaxNumberOfNodesPerCluster());
+        List<String> allowedInstanceTypes = source.getAllowedInstanceTypes();
+        if (allowedInstanceTypes != null && !allowedInstanceTypes.isEmpty()) {
+            target.setAllowedInstanceTypes(allowedInstanceTypes);
+        }
+        target.setClusterTimeToLive(source.getClusterTimeToLive());
+        target.setUserTimeToLive(source.getUserTimeToLive());
+        target.setMaxNumberOfClustersPerUser(source.getMaxNumberOfClustersPerUser());
+        return target;
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToStackConverter.java
@@ -1,5 +1,6 @@
 package com.sequenceiq.cloudbreak.converter;
 
+import java.util.Calendar;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -32,6 +33,7 @@ public class JsonToStackConverter extends AbstractConversionServiceAwareConverte
         }
         stack.setFailurePolicy(getConversionService().convert(source.getFailurePolicy(), FailurePolicy.class));
         stack.setParameters(getValidParameters(source));
+        stack.setCreated(Calendar.getInstance().getTimeInMillis());
         return stack;
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/AccountPreferencesRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/AccountPreferencesRepository.java
@@ -1,0 +1,12 @@
+package com.sequenceiq.cloudbreak.repository;
+
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import org.springframework.data.repository.CrudRepository;
+import org.springframework.data.repository.query.Param;
+
+@EntityType(entityClass = AccountPreferences.class)
+public interface AccountPreferencesRepository extends CrudRepository<AccountPreferences, Long> {
+
+    AccountPreferences findByAccount(@Param("account") String account);
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/repository/StackRepository.java
@@ -48,4 +48,6 @@ public interface StackRepository extends CrudRepository<Stack, Long> {
     Stack findByIdWithSecurityGroup(@Param("id") Long id);
 
     List<Stack> findAllBySecurityGroup(@Param("securityGroupId") Long securityGroupId);
+
+    List<Stack> findAllAlive();
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesService.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import com.sequenceiq.cloudbreak.domain.CbUser;
+
+public interface AccountPreferencesService {
+
+    AccountPreferences save(AccountPreferences accountPreferences);
+
+    AccountPreferences saveOne(CbUser user, AccountPreferences accountPreferences);
+
+    AccountPreferences get(Long id);
+
+    AccountPreferences getByAccount(String account);
+
+    AccountPreferences getOneById(Long id, CbUser user);
+
+    AccountPreferences getOneByAccount(CbUser user);
+
+    void delete(CbUser user);
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidationFailed.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidationFailed.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+
+public class AccountPreferencesValidationFailed extends Exception {
+
+    public AccountPreferencesValidationFailed(String message) {
+        super(message);
+    }
+
+    public AccountPreferencesValidationFailed(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AccountPreferencesValidationFailed(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidator.java
@@ -50,7 +50,7 @@ public class AccountPreferencesValidator {
     private void validateNumberOfNodesPerCluster(Integer nodeCount, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
         Long maxNodeNumberPerCluster = preferences.getMaxNumberOfNodesPerCluster();
         if (needToValidateField(maxNodeNumberPerCluster) && nodeCount > maxNodeNumberPerCluster) {
-            throw new AccountPreferencesValidationFailed(String.format("Error: Cluster with maximum '%s' instances could be created within this account!",
+            throw new AccountPreferencesValidationFailed(String.format("Cluster with maximum '%s' instances could be created within this account!",
                     maxNodeNumberPerCluster));
         }
     }
@@ -73,7 +73,7 @@ public class AccountPreferencesValidator {
                 String instanceTypeName = ig.getTemplate().getInstanceTypeName();
                 if (!allowedInstanceTypes.contains(instanceTypeName)) {
                     throw new AccountPreferencesValidationFailed(
-                            String.format("Error: The '%s' instance type isn't allowed within the account!", instanceTypeName));
+                            String.format("The '%s' instance type isn't allowed within the account!", instanceTypeName));
                 }
             }
         }
@@ -90,14 +90,25 @@ public class AccountPreferencesValidator {
         }
     }
 
-    private void validateUserTimeToLive(String owner, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+    public void validateUserTimeToLive(String owner, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
         Long userTimeToLive = preferences.getUserTimeToLive();
         if (needToValidateField(userTimeToLive)) {
             CbUser cbUser = userDetailsService.getDetails(owner, UserFilterField.USERID);
             long now = Calendar.getInstance().getTimeInMillis();
             long userActiveTime = now - cbUser.getCreated().getTime();
             if (userActiveTime > userTimeToLive) {
-                throw new AccountPreferencesValidationFailed("Cluster could no be created, the user demo time is expired!");
+                throw new AccountPreferencesValidationFailed("The user demo time is expired!");
+            }
+        }
+    }
+
+    public void validateClusterTimeToLive(Long created, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+        Long clusterTimeToLive = preferences.getClusterTimeToLive();
+        if (needToValidateField(clusterTimeToLive)) {
+            long now = Calendar.getInstance().getTimeInMillis();
+            long clusterRunningTime = now - created;
+            if (clusterRunningTime > clusterTimeToLive) {
+                throw new AccountPreferencesValidationFailed("The maximum running time that is configured for the account is exceeded by the cluster!");
             }
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidator.java
@@ -1,0 +1,112 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+import javax.inject.Inject;
+
+import java.util.Calendar;
+import java.util.List;
+import java.util.Set;
+
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import com.sequenceiq.cloudbreak.domain.CbUser;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
+import com.sequenceiq.cloudbreak.service.user.UserFilterField;
+import org.springframework.stereotype.Component;
+
+@Component
+public class AccountPreferencesValidator {
+    private static final Long EXTREMAL_VALUE = 0L;
+
+    @Inject
+    private AccountPreferencesService accountPreferencesService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private UserDetailsService userDetailsService;
+
+    public void validate(Stack stack, String account, String owner) throws AccountPreferencesValidationFailed {
+        validate(stack.getInstanceGroups(), stack.getFullNodeCount(), account, owner);
+    }
+
+    public void validate(Long stackId, Integer scalingAdjustment, String account, String owner) throws AccountPreferencesValidationFailed {
+        Stack stack = stackService.getById(stackId);
+        Integer newNodeCount = stack.getFullNodeCount() + scalingAdjustment;
+        validate(stack.getInstanceGroups(), newNodeCount, account, owner);
+    }
+
+    private void validate(Set<InstanceGroup> instanceGroups, Integer nodeCount, String account, String owner) throws AccountPreferencesValidationFailed {
+        AccountPreferences preferences = accountPreferencesService.getByAccount(account);
+        validateNumberOfNodesPerCluster(nodeCount, preferences);
+        validateNumberOfClusters(account, preferences);
+        validateAllowedInstanceTypes(instanceGroups, preferences);
+        validateNumberOfClustersPerUser(owner, preferences);
+        validateUserTimeToLive(owner, preferences);
+    }
+
+    private void validateNumberOfNodesPerCluster(Integer nodeCount, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+        Long maxNodeNumberPerCluster = preferences.getMaxNumberOfNodesPerCluster();
+        if (needToValidateField(maxNodeNumberPerCluster) && nodeCount > maxNodeNumberPerCluster) {
+            throw new AccountPreferencesValidationFailed(String.format("Error: Cluster with maximum '%s' instances could be created within this account!",
+                    maxNodeNumberPerCluster));
+        }
+    }
+
+    private void validateNumberOfClusters(String account, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+        Long maxNumberOfClusters = preferences.getMaxNumberOfClusters();
+        if (needToValidateField(maxNumberOfClusters)) {
+            Set<Stack> stacks = stackService.retrieveAccountStacks(account);
+            if (stacks.size() >= maxNumberOfClusters) {
+                throw new AccountPreferencesValidationFailed(
+                        String.format("No more cluster could be created! The number of clusters exceeded the account's limit(%s)!", maxNumberOfClusters));
+            }
+        }
+    }
+
+    private void validateAllowedInstanceTypes(Set<InstanceGroup> instanceGroups, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+        List<String> allowedInstanceTypes = preferences.getAllowedInstanceTypes();
+        if (needToValidateField(allowedInstanceTypes)) {
+            for (InstanceGroup ig : instanceGroups) {
+                String instanceTypeName = ig.getTemplate().getInstanceTypeName();
+                if (!allowedInstanceTypes.contains(instanceTypeName)) {
+                    throw new AccountPreferencesValidationFailed(
+                            String.format("Error: The '%s' instance type isn't allowed within the account!", instanceTypeName));
+                }
+            }
+        }
+    }
+
+    private void validateNumberOfClustersPerUser(String owner, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+        Long maxClustersPerUser = preferences.getMaxNumberOfClustersPerUser();
+        if (needToValidateField(maxClustersPerUser)) {
+            Set<Stack> stacks = stackService.retrieveOwnerStacks(owner);
+            if (stacks.size() >= maxClustersPerUser) {
+                throw new AccountPreferencesValidationFailed(
+                        String.format("No more cluster could be created! The number of clusters exceeded the user's limit(%s)!", maxClustersPerUser));
+            }
+        }
+    }
+
+    private void validateUserTimeToLive(String owner, AccountPreferences preferences) throws AccountPreferencesValidationFailed {
+        Long userTimeToLive = preferences.getUserTimeToLive();
+        if (needToValidateField(userTimeToLive)) {
+            CbUser cbUser = userDetailsService.getDetails(owner, UserFilterField.USERID);
+            long now = Calendar.getInstance().getTimeInMillis();
+            long userActiveTime = now - cbUser.getCreated().getTime();
+            if (userActiveTime > userTimeToLive) {
+                throw new AccountPreferencesValidationFailed("Cluster could no be created, the user demo time is expired!");
+            }
+        }
+    }
+
+    private boolean needToValidateField(long field) {
+        return !EXTREMAL_VALUE.equals(field);
+    }
+
+    private boolean needToValidateField(List<String> field) {
+        return !field.isEmpty();
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/ScheduledAccountPreferencesValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/ScheduledAccountPreferencesValidator.java
@@ -1,0 +1,69 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+import javax.inject.Inject;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.sequenceiq.cloudbreak.core.flow.FlowManager;
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.stack.event.StackDeleteRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ScheduledAccountPreferencesValidator {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScheduledAccountPreferencesValidator.class);
+    private static final String EVERY_HOUR_0MIN_0SEC = "0 0 * * * *";
+
+    @Inject
+    private AccountPreferencesService accountPreferencesService;
+
+    @Inject
+    private StackService stackService;
+
+    @Inject
+    private AccountPreferencesValidator preferencesValidator;
+
+    @Inject
+    private FlowManager flowManager;
+
+    @Scheduled(cron = EVERY_HOUR_0MIN_0SEC)
+    public void validate() {
+        LOGGER.info("Validate account preferences for all 'running' stack.");
+        Map<String, AccountPreferences> accountPreferences = new HashMap<>();
+        List<Stack> allAlive = stackService.getAllAlive();
+
+        for (Stack stack : allAlive) {
+            AccountPreferences preferences = getAccountPreferences(stack.getAccount(), accountPreferences);
+            try {
+                preferencesValidator.validateClusterTimeToLive(stack.getCreated(), preferences);
+                preferencesValidator.validateUserTimeToLive(stack.getOwner(), preferences);
+            } catch (AccountPreferencesValidationFailed e) {
+                terminateStack(stack);
+            }
+        }
+    }
+
+    private AccountPreferences getAccountPreferences(String account, Map<String, AccountPreferences> accountPreferences) {
+        if (accountPreferences.containsKey(account)) {
+            return accountPreferences.get(account);
+        } else {
+            AccountPreferences preferences = accountPreferencesService.getByAccount(account);
+            accountPreferences.put(account, preferences);
+            return preferences;
+        }
+    }
+
+    private void terminateStack(Stack stack) {
+        if (!stack.isDeleteCompleted()) {
+            LOGGER.info("Trigger termination of stack: '{}', owner: '{}', account: '{}'.", stack.getName(), stack.getOwner(), stack.getAccount());
+            flowManager.triggerTermination(new StackDeleteRequest(stack.cloudPlatform(), stack.getId()));
+        }
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/account/SimpleAccountPreferencesService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/account/SimpleAccountPreferencesService.java
@@ -1,0 +1,98 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+import javax.inject.Inject;
+
+import java.util.Collections;
+
+import com.sequenceiq.cloudbreak.controller.BadRequestException;
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import com.sequenceiq.cloudbreak.domain.CbUser;
+import com.sequenceiq.cloudbreak.domain.CbUserRole;
+import com.sequenceiq.cloudbreak.repository.AccountPreferencesRepository;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.stereotype.Service;
+
+@Service
+public class SimpleAccountPreferencesService implements AccountPreferencesService {
+    private static final long ZERO = 0L;
+
+    @Inject
+    private AccountPreferencesRepository repository;
+
+    @Override
+    public AccountPreferences save(AccountPreferences accountPreferences) {
+        return repository.save(accountPreferences);
+    }
+
+    @Override
+    @PostAuthorize("hasPermission(returnObject,'read')")
+    public AccountPreferences saveOne(CbUser user, AccountPreferences accountPreferences) {
+        accountPreferences.setAccount(user.getAccount());
+        return repository.save(accountPreferences);
+    }
+
+    @Override
+    public AccountPreferences get(Long id) {
+        return repository.findOne(id);
+    }
+
+    @Override
+    public AccountPreferences getByAccount(String account) {
+        AccountPreferences accountPreferences = repository.findByAccount(account);
+        if (accountPreferences == null) {
+            accountPreferences = createDefaultAccountPreferences(account);
+        }
+        return accountPreferences;
+    }
+
+    @Override
+    @PostAuthorize("hasPermission(returnObject,'read')")
+    public AccountPreferences getOneById(Long id, CbUser user) {
+        AccountPreferences accountPreferences = repository.findOne(id);
+        if (!user.getRoles().contains(CbUserRole.ADMIN)) {
+            throw new BadRequestException("AccountPreferences are only available for admin users!");
+        } else if (accountPreferences == null) {
+            throw new BadRequestException(String.format("AccountPreferences could not find with id: %s", id));
+        } else if (!accountPreferences.getAccount().equals(user.getAccount())) {
+            throw new BadRequestException("AccountPreferences are only available for the owner admin user!");
+        } else {
+            return accountPreferences;
+        }
+    }
+
+    @Override
+    @PostAuthorize("hasPermission(returnObject,'read')")
+    public AccountPreferences getOneByAccount(CbUser user) {
+        String account = user.getAccount();
+        AccountPreferences accountPreferences = repository.findByAccount(account);
+
+        if (accountPreferences == null) {
+            accountPreferences = createDefaultAccountPreferences(account);
+        }
+
+        if (!user.getRoles().contains(CbUserRole.ADMIN)) {
+            throw new BadRequestException("AccountPreferences are only available for admin users!");
+        } else {
+            return accountPreferences;
+        }
+    }
+
+    @Override
+    public void delete(CbUser user) {
+        AccountPreferences preferences = getOneByAccount(user);
+        repository.delete(preferences);
+    }
+
+    private AccountPreferences createDefaultAccountPreferences(String account) {
+        AccountPreferences defaultPreferences = new AccountPreferences();
+        defaultPreferences.setAccount(account);
+        defaultPreferences.setMaxNumberOfClusters(ZERO);
+        defaultPreferences.setMaxNumberOfNodesPerCluster(ZERO);
+        defaultPreferences.setMaxNumberOfClustersPerUser(ZERO);
+        defaultPreferences.setAllowedInstanceTypes(Collections.<String>emptyList());
+        defaultPreferences.setClusterTimeToLive(ZERO);
+        defaultPreferences.setUserTimeToLive(ZERO);
+        return repository.save(defaultPreferences);
+    }
+
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/StackDecorator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/decorator/StackDecorator.java
@@ -6,15 +6,10 @@ import static com.sequenceiq.cloudbreak.EnvironmentVariableConfig.CB_AZURE_RM_IM
 import static com.sequenceiq.cloudbreak.EnvironmentVariableConfig.CB_GCP_SOURCE_IMAGE_PATH;
 import static com.sequenceiq.cloudbreak.EnvironmentVariableConfig.CB_OPENSTACK_IMAGE;
 
-import java.util.HashMap;
-import java.util.Map;
-
 import javax.inject.Inject;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.stereotype.Service;
+import java.util.HashMap;
+import java.util.Map;
 
 import com.amazonaws.regions.Regions;
 import com.google.common.base.Strings;
@@ -28,6 +23,10 @@ import com.sequenceiq.cloudbreak.service.credential.CredentialService;
 import com.sequenceiq.cloudbreak.service.network.NetworkService;
 import com.sequenceiq.cloudbreak.service.securitygroup.SecurityGroupService;
 import com.sequenceiq.cloudbreak.service.stack.flow.ConsulUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
 
 @Service
 public class StackDecorator implements Decorator<Stack> {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackService.java
@@ -358,6 +358,11 @@ public class DefaultStackService implements StackService {
         return stackRepository.save(stack);
     }
 
+    @Override
+    public List<Stack> getAllAlive() {
+        return stackRepository.findAllAlive();
+    }
+
     private void validateScalingAdjustment(InstanceGroupAdjustmentJson instanceGroupAdjustmentJson, Stack stack) {
         if (0 == instanceGroupAdjustmentJson.getScalingAdjustment()) {
             throw new BadRequestException(String.format("Requested scaling adjustment on stack '%s' is 0. Nothing to do.", stack.getId()));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackService.java
@@ -7,19 +7,10 @@ import static com.sequenceiq.cloudbreak.domain.Status.STOPPED;
 import static com.sequenceiq.cloudbreak.domain.Status.STOP_REQUESTED;
 import static com.sequenceiq.cloudbreak.domain.Status.UPDATE_REQUESTED;
 
-import java.util.List;
-import java.util.Set;
-
 import javax.inject.Inject;
 
-import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang3.builder.HashCodeBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.dao.DataIntegrityViolationException;
-import org.springframework.security.access.prepost.PostAuthorize;
-import org.springframework.stereotype.Service;
-import org.springframework.util.DigestUtils;
+import java.util.List;
+import java.util.Set;
 
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.NotFoundException;
@@ -57,6 +48,14 @@ import com.sequenceiq.cloudbreak.service.stack.event.StackDeleteRequest;
 import com.sequenceiq.cloudbreak.service.stack.event.StackStatusUpdateRequest;
 import com.sequenceiq.cloudbreak.service.stack.event.UpdateAllowedSubnetsRequest;
 import com.sequenceiq.cloudbreak.service.stack.event.UpdateInstancesRequest;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.security.access.prepost.PostAuthorize;
+import org.springframework.stereotype.Service;
+import org.springframework.util.DigestUtils;
 
 @Service
 public class DefaultStackService implements StackService {
@@ -117,6 +116,16 @@ public class DefaultStackService implements StackService {
         } else {
             return stackRepository.findPublicInAccountForUser(user.getUserId(), user.getAccount());
         }
+    }
+
+    @Override
+    public Set<Stack> retrieveAccountStacks(String account) {
+        return stackRepository.findAllInAccount(account);
+    }
+
+    @Override
+    public Set<Stack> retrieveOwnerStacks(String owner) {
+        return stackRepository.findForUser(owner);
     }
 
     @Override

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -55,4 +55,6 @@ public interface StackService {
     void validateStack(StackValidation stackValidation);
 
     Stack save(Stack stack);
+
+    List<Stack> getAllAlive();
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/StackService.java
@@ -18,6 +18,10 @@ public interface StackService {
 
     Set<Stack> retrieveAccountStacks(CbUser user);
 
+    Set<Stack> retrieveAccountStacks(String account);
+
+    Set<Stack> retrieveOwnerStacks(String owner);
+
     Stack get(Long id);
 
     Stack findLazy(Long id);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/usages/StackUsageGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/usages/StackUsageGenerator.java
@@ -82,7 +82,7 @@ public class StackUsageGenerator {
             Calendar start = Calendar.getInstance();
             start.setTime(startEvent.getEventTimestamp());
             cal.set(MINUTE, start.get(MINUTE));
-            //save billing start event for daily usage generation
+            //saveOne billing start event for daily usage generation
             CloudbreakEvent newBillingStart = createBillingStarterCloudbreakEvent(startEvent, cal);
             eventRepository.save(newBillingStart);
             LOGGER.debug("BILLING_STARTED is created with date:{} for running stack {}.", cal.getTime(), newBillingStart.getStackId());

--- a/core/src/main/resources/schema/20150826154556_CLOUD-42526_create_account_preferences.sql
+++ b/core/src/main/resources/schema/20150826154556_CLOUD-42526_create_account_preferences.sql
@@ -1,0 +1,21 @@
+-- // CLOUD-42526 create account preferences
+-- Migration SQL that makes the change goes here.
+
+CREATE TABLE IF NOT EXISTS account_preferences
+(
+    account CHARACTER VARYING (255) NOT NULL,
+    maxNumberOfClusters BIGINT NOT NULL,
+    maxNumberOfNodesPerCluster BIGINT NOT NULL,
+    maxNumberOfClustersPerUser BIGINT NOT NULL,
+    clusterTimeToLive BIGINT NOT NULL,
+    userTimeToLive BIGINT NOT NULL,
+    allowedInstanceTypes TEXT,
+   PRIMARY KEY (account)
+);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+DROP TABLE IF EXISTS account_preferences;
+
+

--- a/core/src/main/resources/schema/20150828142440_CLOUD-42526_store_creation_time_of_stack.sql
+++ b/core/src/main/resources/schema/20150828142440_CLOUD-42526_store_creation_time_of_stack.sql
@@ -1,0 +1,9 @@
+-- // CLOUD-42526 store creation time of stack
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE stack ADD COLUMN created BIGINT NOT NULL DEFAULT (EXTRACT(EPOCH FROM now()) * 1000);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE stack DROP COLUMN created;

--- a/core/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -127,7 +127,7 @@ public class TestUtil {
     }
 
     public static CbUser cbUser() {
-        return new CbUser("userid", "testuser", "testaccount", Arrays.asList(CbUserRole.ADMIN, CbUserRole.USER), "givenname", "familyname");
+        return new CbUser("userid", "testuser", "testaccount", Arrays.asList(CbUserRole.ADMIN, CbUserRole.USER), "givenname", "familyname", new Date());
     }
 
     public static Credential azureCredential() {

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/CloudbreakUsageToJsonConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/CloudbreakUsageToJsonConverterTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
 
 import java.util.Arrays;
+import java.util.Date;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -86,6 +87,6 @@ public class CloudbreakUsageToJsonConverterTest extends AbstractEntityConverterT
 
     private CbUser createCbUser() {
         return new CbUser("dummyUserId", "john.smith@example.com", "dummyAccount",
-                Arrays.asList(CbUserRole.ADMIN, CbUserRole.USER), "John", "Smith");
+                Arrays.asList(CbUserRole.ADMIN, CbUserRole.USER), "John", "Smith", new Date());
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/converter/JsonToStackConverterTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/converter/JsonToStackConverterTest.java
@@ -45,7 +45,7 @@ public class JsonToStackConverterTest extends AbstractJsonConverterTest<StackReq
         Stack stack = underTest.convert(getRequest("stack/stack.json"));
         // THEN
         assertAllFieldsNotNull(stack, Arrays.asList("description", "statusReason", "cluster", "credential",
-                "template", "network", "securityConfig", "securityGroup", "version"));
+                "template", "network", "securityConfig", "securityGroup", "version", "created"));
     }
 
     @Override

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidatorTest.java
@@ -1,0 +1,180 @@
+package com.sequenceiq.cloudbreak.service.account;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Sets;
+import com.sequenceiq.cloudbreak.domain.AccountPreferences;
+import com.sequenceiq.cloudbreak.domain.CbUser;
+import com.sequenceiq.cloudbreak.domain.InstanceGroup;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+import com.sequenceiq.cloudbreak.service.user.UserDetailsService;
+import com.sequenceiq.cloudbreak.service.user.UserFilterField;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AccountPreferencesValidatorTest {
+
+    public static final String EMPTY_STRING = "";
+    @Mock
+    private Stack stack;
+
+    @Mock
+    private AccountPreferences preferences;
+
+    @Mock
+    private AccountPreferencesService accountPreferencesService;
+
+    @Mock
+    private StackService stackService;
+
+    @Mock
+    private UserDetailsService userDetailsService;
+
+    @InjectMocks
+    private AccountPreferencesValidator underTest;
+
+    @Before
+    public void setUp() throws Exception {
+        when(stack.getAccount()).thenReturn("");
+        when(accountPreferencesService.getByAccount("")).thenReturn(preferences);
+        when(preferences.getMaxNumberOfNodesPerCluster()).thenReturn(0L);
+        when(preferences.getMaxNumberOfClusters()).thenReturn(0L);
+        when(preferences.getMaxNumberOfClustersPerUser()).thenReturn(0L);
+        when(preferences.getClusterTimeToLive()).thenReturn(0L);
+        when(preferences.getUserTimeToLive()).thenReturn(0L);
+        when(preferences.getAllowedInstanceTypes()).thenReturn(new ArrayList<String>());
+    }
+
+    @Test
+    public void testValidateShouldNotThrowExceptionWhenPreferencesShouldNotBeValidated() throws Exception {
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test(expected = AccountPreferencesValidationFailed.class)
+    public void testValidateShouldThrowExceptionWhenTheStackNodeCountIsGreaterThanTheAccountMaximum() throws Exception {
+        when(preferences.getMaxNumberOfNodesPerCluster()).thenReturn(4L);
+        when(stack.getFullNodeCount()).thenReturn(5);
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test
+    public void testValidateShouldNotThrowExceptionWhenTheStackNodeCountIsLessThanTheAccountMaximum() throws Exception {
+        when(preferences.getMaxNumberOfNodesPerCluster()).thenReturn(4L);
+        when(stack.getFullNodeCount()).thenReturn(3);
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test(expected = AccountPreferencesValidationFailed.class)
+    public void testValidateShouldThrowExceptionWhenTheNumberOfClusterInAccountIsGreaterOrEqualThanTheAccountMaximum() throws Exception {
+        when(preferences.getMaxNumberOfClusters()).thenReturn(400L);
+        Set stacks = Mockito.mock(Set.class);
+        when(stackService.retrieveAccountStacks(anyString())).thenReturn(stacks);
+        when(stacks.size()).thenReturn(400);
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test
+    public void testValidateShouldNotThrowExceptionWhenTheNumberOfClusterInAccountIsLessThanTheAccountMaximum() throws Exception {
+        when(preferences.getMaxNumberOfClusters()).thenReturn(400L);
+        Set stacks = Mockito.mock(Set.class);
+        when(stackService.retrieveAccountStacks(anyString())).thenReturn(stacks);
+        when(stacks.size()).thenReturn(200);
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test(expected = AccountPreferencesValidationFailed.class)
+    public void testValidateShouldThrowExceptionWhenTheNumberOfClusterInAccountForAUserIsGreaterOrEqualThanTheAccountMaximum() throws Exception {
+        when(preferences.getMaxNumberOfClustersPerUser()).thenReturn(4L);
+        Set stacks = Mockito.mock(Set.class);
+        when(stackService.retrieveOwnerStacks(anyString())).thenReturn(stacks);
+        when(stacks.size()).thenReturn(4);
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test
+    public void testValidateShouldNotThrowExceptionWhenTheNumberOfClusterInAccountForAUserIsLessThanTheAccountMaximum() throws Exception {
+        when(preferences.getMaxNumberOfClustersPerUser()).thenReturn(4L);
+        Set stacks = Mockito.mock(Set.class);
+        when(stackService.retrieveOwnerStacks(anyString())).thenReturn(stacks);
+        when(stacks.size()).thenReturn(2);
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test(expected = AccountPreferencesValidationFailed.class)
+    public void testValidateShouldThrowExceptionWhenTheUserDemoTimeExpired() throws Exception {
+        Calendar calendar = Calendar.getInstance();
+        calendar.roll(Calendar.HOUR_OF_DAY, -1);
+        when(preferences.getUserTimeToLive()).thenReturn(40000L);
+        CbUser cbUser = Mockito.mock(CbUser.class);
+        when(userDetailsService.getDetails(anyString(), any(UserFilterField.class))).thenReturn(cbUser);
+        when(cbUser.getCreated()).thenReturn(calendar.getTime());
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test
+    public void testValidateShouldNotThrowExceptionWhenTheUserDemoTimeHasNotExpiredYet() throws Exception {
+        Calendar calendar = Calendar.getInstance();
+        calendar.roll(Calendar.MINUTE, -1);
+        when(preferences.getUserTimeToLive()).thenReturn(65000L);
+        CbUser cbUser = Mockito.mock(CbUser.class);
+        when(userDetailsService.getDetails(anyString(), any(UserFilterField.class))).thenReturn(cbUser);
+        when(cbUser.getCreated()).thenReturn(calendar.getTime());
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test(expected = AccountPreferencesValidationFailed.class)
+    public void testValidateShouldThrowExceptionWhenTheStackContainsNotAllowedInstanceTypes() throws Exception {
+        String n1St4Type = "N1_STANDARD_4";
+        List<String> allowedInstanceTypes = Arrays.asList(n1St4Type, "N1_STANDARD_8", "N1_STANDARD_16");
+        when(preferences.getAllowedInstanceTypes()).thenReturn(allowedInstanceTypes);
+        InstanceGroup cbgateway = Mockito.mock(InstanceGroup.class, Mockito.RETURNS_DEEP_STUBS);
+        InstanceGroup master = Mockito.mock(InstanceGroup.class, Mockito.RETURNS_DEEP_STUBS);
+        InstanceGroup slave = Mockito.mock(InstanceGroup.class, Mockito.RETURNS_DEEP_STUBS);
+        when(cbgateway.getTemplate().getInstanceTypeName()).thenReturn(n1St4Type);
+        when(master.getTemplate().getInstanceTypeName()).thenReturn(n1St4Type);
+        when(slave.getTemplate().getInstanceTypeName()).thenReturn("N1_STANDARD_32");
+        when(stack.getInstanceGroups()).thenReturn(Sets.newHashSet(cbgateway, master, slave));
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+
+    @Test
+    public void testValidateShouldNotThrowExceptionWhenTheStackContainsOnlyAllowedInstanceTypes() throws Exception {
+        String n1St4Type = "N1_STANDARD_4";
+        String n1St6Type = "N1_STANDARD_8";
+        List<String> allowedInstanceTypes = Arrays.asList(n1St4Type, n1St6Type, "N1_STANDARD_16");
+        when(preferences.getAllowedInstanceTypes()).thenReturn(allowedInstanceTypes);
+        InstanceGroup cbgateway = Mockito.mock(InstanceGroup.class, Mockito.RETURNS_DEEP_STUBS);
+        InstanceGroup master = Mockito.mock(InstanceGroup.class, Mockito.RETURNS_DEEP_STUBS);
+        InstanceGroup slave = Mockito.mock(InstanceGroup.class, Mockito.RETURNS_DEEP_STUBS);
+        when(cbgateway.getTemplate().getInstanceTypeName()).thenReturn(n1St4Type);
+        when(master.getTemplate().getInstanceTypeName()).thenReturn(n1St4Type);
+        when(slave.getTemplate().getInstanceTypeName()).thenReturn(n1St6Type);
+        when(stack.getInstanceGroups()).thenReturn(Sets.newHashSet(cbgateway, master, slave));
+
+        underTest.validate(stack, EMPTY_STRING, EMPTY_STRING);
+    }
+}

--- a/core/src/test/resources/com/sequenceiq/cloudbreak/converter/stack/stack.json
+++ b/core/src/test/resources/com/sequenceiq/cloudbreak/converter/stack/stack.json
@@ -38,5 +38,6 @@
   "parameters": {
     "dedicatedInstances" : true
   },
-  "consulServerCount": 1
+  "consulServerCount": 1,
+  "created": 8000000
 }


### PR DESCRIPTION
Please review it @akanto, @matyix or @keyki !

Ability to account admins could configure the following restrictions to their accounts:
 - max number of clusters
 - max number of nodes per cluster
 - max number of clusters per user
 - instance types
 - max running time of clusters
 - time period for user to be able to create clusters

@matyix please check the error messages in [AccountPreferencesValidator.java](https://github.com/sequenceiq/cloudbreak/blob/account-config/core/src/main/java/com/sequenceiq/cloudbreak/service/account/AccountPreferencesValidator.java)