### PR TITLE
CLOUD-43441 Fix error messages

### DIFF
--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -72,7 +72,7 @@ ambari.cluster.adding.node.to.hostgroup="Adding {0} new host(s) to the host grou
 stack.instance.terminate=Terminating instance {0}
 stack.instance.delete=Deleting node {0}. Decreasing the node count on instance group {1}"
 
-ambari.cluster.could.not.sync=Cluster can't be synchronized. [ stack status: {0}, cluster status: {1} ]
+ambari.cluster.could.not.sync=Cluster can''t be synchronized. [ stack status: {0}, cluster status: {1} ]
 ambari.cluster.synchronized=Cloudbreak cluster state synchronized with Ambari: {0}
 
 stack.stop.ignored=Stop request ignored; cluster infrastructure is already stopped.
@@ -88,16 +88,16 @@ stack.scaling.terminating.host.from.hostgroup=Terminating host: {0} from host gr
 
 
 
-stack.sync.instance.status.retrieval.failed=Couldn't retrieve status of instance {0} from cloud provider
+stack.sync.instance.status.retrieval.failed=Couldn''t retrieve status of instance {0} from cloud provider
 stack.sync.instance.status.couldnt.determine=The state of one or more instances couldn't be determined. Try syncing later
 stack.sync.instance.operation.in.progress=An operation on one or more instances is in progress. Try syncing later
 stack.sync.instance.stopped.on.provider=Some instances were stopped on the cloud provider. Restart or terminate them and try syncing later
 stack.sync.instance.state.synced=Synced instance states with the cloud provider
 stack.sync.host.deleted=Deleted host {0} from Ambari as it is marked as terminated by the cloud provider.
-stack.sync.instance.removal.failed=Instance {0} is terminated but couldn't remove host from Ambari because it still reports the host as healthy. Try syncing later.
+stack.sync.instance.removal.failed=Instance {0} is terminated but couldn''t remove host from Ambari because it still reports the host as healthy. Try syncing later.
 stack.sync.host.updated=Host {0} state has been updated to: {1}
-stack.sync.instance.terminated=Instance {0} is marked as terminated by the cloud provider, but couldn't delete the host from Ambari
-stack.sync.instance.deleted.cbmetadata=Deleted instance {0} from Cloudbreak metadata because it couldn't be found on the cloud provider.
+stack.sync.instance.terminated=Instance {0} is marked as terminated by the cloud provider, but couldn''t delete the host from Ambari
+stack.sync.instance.deleted.cbmetadata=Deleted instance {0} from Cloudbreak metadata because it couldn''t be found on the cloud provider.
 stack.sync.instance.running=Updated metadata of instance {0} to running as the cloud provider reported it as running.
 
 


### PR DESCRIPTION
A single quote escaped all the parameter placeholders in some messages.