### PR TITLE
CLOUD-42393 some dash fs changes

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/filesystem/dash/DashFileSystemConfiguration.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/filesystem/dash/DashFileSystemConfiguration.java
@@ -1,14 +1,19 @@
 package com.sequenceiq.cloudbreak.service.cluster.flow.filesystem.dash;
 
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 import com.sequenceiq.cloudbreak.service.cluster.flow.filesystem.FileSystemConfiguration;
 
 public class DashFileSystemConfiguration extends FileSystemConfiguration {
 
     @NotNull
+    @Pattern(regexp = "^[a-z0-9]{3,24}$",
+            message = "Must contain only numbers and lowercase letters and must be between 3 and 24 characters long.")
     private String accountName;
     @NotNull
+    @Pattern(regexp = "^([A-Za-z0-9+/]{4}){21}([A-Za-z0-9+/]{4}|[A-Za-z0-9+/]{3}=|[A-Za-z0-9+/]{2}==)$",
+            message = "Must be the base64 encoded representation of 64 random bytes.")
     private String accountKey;
 
     public String getAccountName() {

--- a/core/src/main/resources/scripts/dash-hdfs.sh
+++ b/core/src/main/resources/scripts/dash-hdfs.sh
@@ -14,8 +14,10 @@ main(){
     curl "https://www.dash-update.net/client/Latest/StorageSDK2.0/$STORAGE_JAR" > "$SOURCE_JAR";
   fi
 
-  echo "Finding $MR_TAR_NAME on HDFS"
-  MR_TAR_PATH="$(hadoop fs -ls /hdp/apps | sed '1d;s/  */ /g' | cut -d\  -f8)/mapreduce/$MR_TAR_NAME"
+  hdp_version=$(ls /usr/hdp/ | head -1);
+  echo "Found HDP version: $hdp_version"
+  MR_TAR_PATH="/hdp/apps/$hdp_version/mapreduce/$MR_TAR_NAME"
+  echo "HDFS path to $MR_TAR_NAME: $MR_TAR_PATH"
 
   echo "Copying $MR_TAR_NAME from HDFS to local fs."
   [[ -f "/tmp/$MR_TAR_NAME" ]] && rm "/tmp/$MR_TAR_NAME"

--- a/core/src/main/resources/scripts/dash-local.sh
+++ b/core/src/main/resources/scripts/dash-local.sh
@@ -4,6 +4,7 @@
 
 : ${SOURCE_DIR:=/data/jars}
 : ${STORAGE_JAR:=dash-azure-storage-2.2.0.jar}
+: ${MR_TAR_NAME:=mapreduce.tar.gz}
 
 main(){
   SOURCE_JAR="$SOURCE_DIR/$STORAGE_JAR"
@@ -15,6 +16,29 @@ main(){
 
   echo "Replacing azure-storage.jar with $STORAGE_JAR"
   find / -name "azure-storage*.jar" | while read line; do echo "Replacing $line"; \cp -f "$SOURCE_JAR" "${line%azure*}"; rm -f $line; done
+
+  mapred_tars=$(find / -name "$MR_TAR_NAME")
+  for mapred_tar in $mapred_tars; do
+    if [ -f $mapred_tar ]; then
+      cd ${mapred_tar%$MR_TAR_NAME}
+
+      echo "Extracting $mapred_tar."
+      tar -xzf $mapred_tar
+
+      echo "Replacing azure-storage.jar with $STORAGE_JAR."
+      find "hadoop/" -name "azure-storage*.jar" | while read line; do echo "Replacing $line"; \cp -f $SOURCE_JAR ${line%azure*}; rm -f $line; done
+
+      echo "Removing $MR_TAR_NAME."
+      rm -f "$mapred_tar"
+
+      echo "Creating new $MR_TAR_NAME with the replaced libs."
+      tar -zcf "$mapred_tar" "hadoop/"
+
+      echo "Cleaning up extracted directory."
+      rm -rf "hadoop/"
+    fi
+  done
+
 }
 
 exec &> "$LOGFILE"


### PR DESCRIPTION
@biharitomi 
validate account name/ account key with regex,
change dash storage jars in local mapreduce.tar.gz as well because it is recopied to hdfs when some services are restarted
find mapreduce hdfs directory based on hdp version parsed from local filesystem, because the previous solution failed when a dash storage was used with another hdp version pre-installed