### PR TITLE
CLOUD-44576 smoke test failure sends warning

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/PollingResult.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/PollingResult.java
@@ -1,7 +1,7 @@
 package com.sequenceiq.cloudbreak.service;
 
 public enum PollingResult {
-    TIMEOUT, EXIT, SUCCESS;
+    TIMEOUT, EXIT, SUCCESS, FAILURE;
 
     public static boolean isSuccess(PollingResult pollingResult) {
         return PollingResult.SUCCESS.equals(pollingResult);
@@ -13,6 +13,10 @@ public enum PollingResult {
 
     public static boolean isTimeout(PollingResult pollingResult) {
         return PollingResult.TIMEOUT.equals(pollingResult);
+    }
+
+    public static boolean isFailure(PollingResult pollingResult) {
+        return PollingResult.FAILURE.equals(pollingResult);
     }
 
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/PollingService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/PollingService.java
@@ -38,6 +38,7 @@ public class PollingService<T> {
             if (failures >= maxFailure) {
                 LOGGER.info("Polling failure reached the limit which was {}, poller will drop the last exception.", maxFailure);
                 statusCheckerTask.handleException(actual);
+                return PollingResult.FAILURE;
             }
             if (success) {
                 LOGGER.info(statusCheckerTask.successMessage(t));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/SimpleStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/SimpleStatusCheckerTask.java
@@ -3,7 +3,7 @@ package com.sequenceiq.cloudbreak.service;
 public abstract class SimpleStatusCheckerTask<T> implements StatusCheckerTask<T> {
 
     @Override
-    public boolean handleException(Exception e) {
+    public void handleException(Exception e) {
         throw new CloudbreakServiceException(e);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/StatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/StatusCheckerTask.java
@@ -10,5 +10,5 @@ public interface StatusCheckerTask<T> {
 
     boolean exitPolling(T t);
 
-    boolean handleException(Exception e);
+    void handleException(Exception e);
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariOperationsStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariOperationsStatusCheckerTask.java
@@ -58,4 +58,9 @@ public class AmbariOperationsStatusCheckerTask extends StackBasedStatusCheckerTa
         return String.format("Requested Ambari operations completed: %s", t.getRequests().toString());
     }
 
+    @Override
+    public void handleException(Exception e) {
+        LOGGER.error("Ambari operation failed.", e);
+    }
+
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/filesystem/wasbintegrated/StorageAccountStatusCheckerTask.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/filesystem/wasbintegrated/StorageAccountStatusCheckerTask.java
@@ -44,7 +44,7 @@ public class StorageAccountStatusCheckerTask implements StatusCheckerTask<Storag
     }
 
     @Override
-    public boolean handleException(Exception e) {
+    public void handleException(Exception e) {
         throw new FileSystemConfigException("Exception occurred while creating Azure storage account for the WASB filesystem.", e);
     }
 }

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -55,6 +55,9 @@ ambari.cluster.stop.failed=Ambari cluster could not be stopped. Reason: {0}
 ambari.cluster.create.failed=Ambari cluster could not be created. Reason: {0}
 ambari.cluster.configure.security.failed=Failed to enable security on Ambari cluster. Reason: {0}
 ambari.cluster.scaling.failed=New node(s) could not be {0} to the cluster. Reason {1}
+ambari.cluster.mr.smoke.failed=Warning: MapReduce smoke test failed, check your cluster's configurations!
+ambari.cluster.install.failed=Cluster installation failed to complete, please check the Ambari UI for more details. You can try to reinstall the cluster with a different blueprint or fix the failures in Ambari and sync the cluster with Cloudbreak later.
+ambari.cluster.host.join.failed=Error while waiting for hosts to connect.
 
 bootstrapper.error.nodes.failed=Bootstrap failed on {0} nodes. These nodes will be terminated
 bootstrapper.error.invalide.nodecount=Invalid node count on instance group {0}; Cluster creation failed

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnectorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnectorTest.java
@@ -48,6 +48,7 @@ import com.sequenceiq.cloudbreak.service.TlsSecurityService;
 import com.sequenceiq.cloudbreak.service.cluster.AmbariClientProvider;
 import com.sequenceiq.cloudbreak.service.cluster.AmbariOperationFailedException;
 import com.sequenceiq.cloudbreak.service.cluster.HadoopConfigurationService;
+import com.sequenceiq.cloudbreak.service.messages.CloudbreakMessagesService;
 import com.sequenceiq.cloudbreak.service.stack.flow.TLSClientConfig;
 
 import groovyx.net.http.HttpResponseException;
@@ -100,6 +101,9 @@ public class AmbariClusterConnectorTest {
 
     @Mock
     private HostGroup hostGroup;
+
+    @Mock
+    private CloudbreakMessagesService messagesService;
 
     @InjectMocks
     @Spy


### PR DESCRIPTION
@biharitomi 

If MR Smoke test fails, it should not cause a failure in the cloudbreak cluster creation, it sends a Warning event instead.