### PR TITLE
CLOUD-45185 since there is no warmup we can use that image which has Zeppelin in it

### DIFF
--- a/cloud-common/src/main/java/com/sequenceiq/cloudbreak/EnvironmentVariableConfig.java
+++ b/cloud-common/src/main/java/com/sequenceiq/cloudbreak/EnvironmentVariableConfig.java
@@ -38,7 +38,7 @@ public class EnvironmentVariableConfig {
     public static final String CB_CONTAINER_ORCHESTRATOR = "SWARM";
     public static final String CB_SUPPORTED_CONTAINER_ORCHESTRATORS = "com.sequenceiq.cloudbreak.orchestrator.swarm.SwarmContainerOrchestrator";
     public static final String CB_DOCKER_CONTAINER_AMBARI_WARMUP = "sequenceiq/ambari-warmup:2.1.0-consul";
-    public static final String CB_DOCKER_CONTAINER_AMBARI = "sequenceiq/ambari:2.1.0-consul";
+    public static final String CB_DOCKER_CONTAINER_AMBARI = "sequenceiq/ambari-warmup:2.1.0-consul";
     public static final String CB_DOCKER_CONTAINER_REGISTRATOR = "sequenceiq/registrator:v5.2";
     public static final String CB_DOCKER_CONTAINER_DOCKER_CONSUL_WATCH_PLUGN = "sequenceiq/docker-consul-watch-plugn:2.0.2-consul";
     public static final String CB_DOCKER_CONTAINER_AMBARI_DB = "postgres:9.4.1";


### PR DESCRIPTION
@akanto @martonsereg 

In docker-ambari I moved Zeppelin to the base image so the newly created cloud images will have this change, but I'm lazy to rebuild it for now.