### PR TITLE
CLOUD-45712 include credential id in OpenStack credentials

### DIFF
--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/auth/OpenStackCredentialConnector.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/auth/OpenStackCredentialConnector.java
@@ -20,11 +20,8 @@ public class OpenStackCredentialConnector implements CredentialConnector {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenStackCredentialConnector.class);
 
-    private static final String CB_KEYPAIR_NAME = "cb-keypair-";
-
     @Inject
     private OpenStackClient openStackClient;
-
 
     @Override
     public CloudCredentialStatus create(AuthenticatedContext authenticatedContext) {
@@ -51,8 +48,6 @@ public class OpenStackCredentialConnector implements CredentialConnector {
     @Override
     public CloudCredentialStatus delete(AuthenticatedContext authenticatedContext) {
         LOGGER.info("Deleted credential: {}", authenticatedContext.getCloudCredential());
-
-        KeystoneCredentialView keystoneCredentialView = openStackClient.createKeystoneCredential(authenticatedContext.getCloudCredential());
 
         OSClient client = openStackClient.createOSClient(authenticatedContext);
         KeystoneCredentialView keystoneCredential = openStackClient.createKeystoneCredential(authenticatedContext.getCloudCredential());

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/compute/OpenStackInstanceBuilder.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/compute/OpenStackInstanceBuilder.java
@@ -74,7 +74,6 @@ public class OpenStackInstanceBuilder extends AbstractOpenStackComputeResourceBu
                     BlockDeviceMappingCreate blockDeviceMappingCreate = Builders.blockDeviceMapping()
                             .uuid(computeResource.getReference())
                             .deviceName(computeResource.getStringParameter(OpenStackConstants.VOLUME_MOUNT_POINT))
-//                            .deleteOnTermination(true)
                             .sourceType("volume")
                             .destinationType("volume")
                             .build();

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
@@ -14,13 +14,12 @@ public class KeystoneCredentialView {
     }
 
     public String getKeyPairName() {
-        return CB_KEYPAIR_NAME + deleteWhitespace(getName().toLowerCase());
+        return CB_KEYPAIR_NAME + cloudCredential.getId() + "-" + deleteWhitespace(getName().toLowerCase());
     }
 
     public String getName() {
         return cloudCredential.getName();
     }
-
 
     public String getPublicKey() {
         return cloudCredential.getPublicKey();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/CredentialToCloudCredentialConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/CredentialToCloudCredentialConverter.java
@@ -12,11 +12,8 @@ import com.sequenceiq.cloudbreak.domain.Credential;
 @Component
 public class CredentialToCloudCredentialConverter {
 
-    private static final String CREDENTIAL_ID = "id";
-
     public CloudCredential convert(Credential credential) {
         Map<String, Object> fields = getDeclaredFields(credential);
-        fields.put(CREDENTIAL_ID, credential.getId());
         return new CloudCredential(credential.getId(), credential.getName(), credential.getPublicKey(), credential.getLoginUserName(), fields);
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderCredentialAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/connector/adapter/ServiceProviderCredentialAdapter.java
@@ -57,15 +57,15 @@ public class ServiceProviderCredentialAdapter implements CredentialHandler<Crede
             CreateCredentialResult res = createCredentialRequest.await();
             LOGGER.info("Result: {}", res);
             if (res.getStatus() != EventStatus.OK) {
-                LOGGER.error("Failed to setup provisioning", res.getErrorDetails());
+                LOGGER.error("Failed to create the credential", res.getErrorDetails());
                 throw new OperationException(res.getErrorDetails());
             }
             if (CredentialStatus.FAILED.equals(res.getCloudCredentialStatus().getStatus())) {
-                throw new BadRequestException("Failed to setup provisioning: " + res.getCloudCredentialStatus().getStatusReason(),
+                throw new BadRequestException("Failed to create the credential: " + res.getCloudCredentialStatus().getStatusReason(),
                         res.getCloudCredentialStatus().getException());
             }
         } catch (InterruptedException e) {
-            LOGGER.error("Error while executing provisioning setup", e);
+            LOGGER.error("Error while executing credential create", e);
             throw new OperationException(e);
         }
 
@@ -84,11 +84,11 @@ public class ServiceProviderCredentialAdapter implements CredentialHandler<Crede
             DeleteCredentialResult res = deleteCredentialRequest.await();
             LOGGER.info("Result: {}", res);
             if (res.getStatus() != EventStatus.OK) {
-                LOGGER.error("Failed to setup provisioning", res.getErrorDetails());
+                LOGGER.error("Failed to delete the credential", res.getErrorDetails());
                 throw new OperationException(res.getErrorDetails());
             }
         } catch (InterruptedException e) {
-            LOGGER.error("Error while executing provisioning setup", e);
+            LOGGER.error("Error while executing credential delete", e);
             throw new OperationException(e);
         }
 


### PR DESCRIPTION
@akanto 

Credential is saved before sending the request to any provider (early duplicate key detection).
Request sent to create credential, in case of any exception the credential is removed from the db.
OpenStack keypairs have an id in it which gives some uniqueness (cannot create anymore clusters with the existing credentials)