### PR TITLE
CLOUD-48869 ability to run hdfs-home multiple times successfully

### DIFF
--- a/core/src/main/resources/scripts/dash-hdfs.sh
+++ b/core/src/main/resources/scripts/dash-hdfs.sh
@@ -43,5 +43,5 @@ main(){
   rm -rf hadoop
 }
 
-exec &> "$LOGFILE"
+exec &>> "$LOGFILE"
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/core/src/main/resources/scripts/dash-local.sh
+++ b/core/src/main/resources/scripts/dash-local.sh
@@ -41,5 +41,5 @@ main(){
 
 }
 
-exec &> "$LOGFILE"
+exec &>> "$LOGFILE"
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/core/src/main/resources/scripts/gcs-connector.sh
+++ b/core/src/main/resources/scripts/gcs-connector.sh
@@ -18,5 +18,5 @@ main(){
   mv "$SOURCE_JAR" "$TARGET_DIR"
 }
 
-exec &> "$LOGFILE"
+exec &>> "$LOGFILE"
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/core/src/main/resources/scripts/gcs-p12.sh
+++ b/core/src/main/resources/scripts/gcs-p12.sh
@@ -8,5 +8,5 @@ main(){
   echo "p12 file successfully downloaded from key-value store."
 }
 
-exec &> "$LOGFILE"
+exec &>> "$LOGFILE"
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"

--- a/core/src/main/resources/scripts/hdfs-home.sh
+++ b/core/src/main/resources/scripts/hdfs-home.sh
@@ -3,8 +3,13 @@
 : ${LOGFILE:=/var/log/consul-watch/consul_handler.log}
 
 create_user_home(){
-  su hdfs -c "hadoop fs -mkdir /user/$1" 2> /dev/null
-  su hdfs -c "hadoop fs -chown $1:hadoop /user/$1" 2> /dev/null
+  if ! su hdfs -c "hadoop fs -ls /user/$1" 2> /dev/null; then
+    su hdfs -c "hadoop fs -mkdir /user/$1" 2> /dev/null
+    su hdfs -c "hadoop fs -chown $1:hadoop /user/$1" 2> /dev/null
+    echo "created /user/$1"
+  else
+    echo "/user/$1 already exists, skipping..."
+  fi
 }
 
 main(){
@@ -12,5 +17,5 @@ main(){
   create_user_home $USER
 }
 
-exec &> "$LOGFILE"
+exec &>> "$LOGFILE"
 [[ "$0" == "$BASH_SOURCE" ]] && main "$@"


### PR DESCRIPTION
@keyki 
If some recipes fail but this script runs first and creates the directories it will fail after a cluster reinstall when all the recipes run again.
Also do not truncate the consul-handler log file with `exec &>` in the scripts