### PR TITLE
CLOUD-46378 GCP stop/start after CB update from 1.0.x

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpMetadataCollector.java
@@ -64,9 +64,9 @@ public class GcpMetadataCollector implements MetadataCollector {
         for (CloudResource resource : resources) {
             if (ResourceType.GCP_INSTANCE == resource.getType()) {
                 String resourceName = resource.getName();
-                long privateId = GcpStackUtil.getPrivateId(resourceName);
+                Long privateId = GcpStackUtil.getPrivateId(resourceName);
                 for (InstanceTemplate vm : vms) {
-                    if (vm.getPrivateId() == privateId) {
+                    if (privateId == null || vm.getPrivateId().equals(privateId)) {
                         templateMap.put(resourceName, vm);
                         break;
                     }

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpStackUtil.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/util/GcpStackUtil.java
@@ -36,6 +36,7 @@ public final class GcpStackUtil {
     private static final String GCP_IMAGE_TYPE_PREFIX = "https://www.googleapis.com/compute/v1/projects/%s/global/images/";
     private static final String EMPTY_BUCKET = "";
     private static final int FINISHED = 100;
+    private static final int PRIVATE_ID_PART = 2;
     private static final String SERVICE_ACCOUNT = "serviceAccountId";
     private static final String PRIVATE_KEY = "serviceAccountPrivateKey";
     private static final String PROJECT_ID = "projectId";
@@ -167,8 +168,16 @@ public final class GcpStackUtil {
         return String.format(GCP_IMAGE_TYPE_PREFIX + getImageName(image), projectId);
     }
 
-    public static long getPrivateId(String resourceName) {
-        return Long.valueOf(resourceName.split("-")[2]);
+    public static Long getPrivateId(String resourceName) {
+        try {
+            return Long.valueOf(resourceName.split("-")[PRIVATE_ID_PART]);
+        } catch (NumberFormatException nfe) {
+            LOGGER.warn("Cannot determine the private id of GCP instance, name: " + resourceName);
+            return null;
+        } catch (Exception e) {
+            LOGGER.warn("Cannot determine the private id of GCP instance, name: " + resourceName, e);
+            return null;
+        }
     }
 
     private static String[] createParts(String splittable) {


### PR DESCRIPTION
@akanto 

Due to resource name change we cannot determine the instances instance group thus we rely on the existing information. In case of GCP every instance will come back from the metadata collection as gw node, but that's incorrect so we use the original one.