### PR TITLE
Dash enhancements

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/filesystem/AbstractFileSystemConfigurator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/filesystem/AbstractFileSystemConfigurator.java
@@ -38,6 +38,7 @@ public abstract class AbstractFileSystemConfigurator<T extends FileSystemConfigu
         bpConfigs.add(new BlueprintConfigurationEntry("webhcat-site", "templeton.sqoop.archive", defaultFs + "/hdp/apps/${hdp.version}/sqoop/sqoop.tar.gz"));
         bpConfigs.add(new BlueprintConfigurationEntry(
                 "webhcat-site", "templeton.streaming.jar", defaultFs + "/hdp/apps/${hdp.version}/mapreduce/hadoop-streaming.jar"));
+        bpConfigs.add(new BlueprintConfigurationEntry("oozie-site", "oozie.service.HadoopAccessorService.supported.filesystems", "*"));
         return bpConfigs;
     }
 

--- a/core/src/main/resources/init/init.ftl
+++ b/core/src/main/resources/init/init.ftl
@@ -56,6 +56,7 @@ format_disks() {
       mkdir /hadoopfs/fs${i}
       echo $DEVICE /hadoopfs/fs${i} ext4  defaults,noatime 0 2 >> /etc/fstab
       mount /hadoopfs/fs${i}
+      chmod 777 /hadoopfs/fs${i}
     fi
   done
   cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch logs/kerberos

--- a/core/src/main/resources/scripts/dash-hdfs.sh
+++ b/core/src/main/resources/scripts/dash-hdfs.sh
@@ -5,6 +5,8 @@
 : ${SOURCE_DIR:=/data/jars}
 : ${STORAGE_JAR:=dash-azure-storage-2.2.0.jar}
 : ${MR_TAR_NAME:=mapreduce.tar.gz}
+: ${TEZ_TAR_NAME:=tez.tar.gz}
+: ${TMP_EXTRACT_DIR:=temp_extract_dir}
 
 main(){
   SOURCE_JAR="$SOURCE_DIR/$STORAGE_JAR"
@@ -16,31 +18,42 @@ main(){
 
   hdp_version=$(ls /usr/hdp/ | head -1);
   echo "Found HDP version: $hdp_version"
+
   MR_TAR_PATH="/hdp/apps/$hdp_version/mapreduce/$MR_TAR_NAME"
+  TEZ_TAR_PATH="/hdp/apps/$hdp_version/tez/$TEZ_TAR_NAME"
+
   echo "HDFS path to $MR_TAR_NAME: $MR_TAR_PATH"
+  echo "HDFS path to $TEZ_TAR_NAME: $TEZ_TAR_PATH"
 
-  echo "Copying $MR_TAR_NAME from HDFS to local fs."
-  [[ -f "/tmp/$MR_TAR_NAME" ]] && rm "/tmp/$MR_TAR_NAME"
-  hadoop fs -copyToLocal "$MR_TAR_PATH" /tmp
+  cd /tmp
+  for tar_file_path in $MR_TAR_PATH $TEZ_TAR_PATH; do
 
-  echo "Extracting $MR_TAR_NAME."
-  cd /tmp && tar -zxf $MR_TAR_NAME
+    tar_file=$(basename $tar_file_path)
 
-  echo "Replacing azure-storage.jar with $STORAGE_JAR."
-  find hadoop/ -name "azure-storage*.jar" | while read line; do echo Replace $line; \cp -f $SOURCE_JAR ${line%azure*}; rm -f $line; done
+    echo "Copying $tar_file from HDFS to local fs."
+    [[ -f "/tmp/$tar_file" ]] && rm "/tmp/$tar_file"
+    hadoop fs -copyToLocal "$tar_file_path" /tmp
 
-  echo "Removing $MR_TAR_NAME."
-  rm -f "$MR_TAR_NAME"
+    rm -rf $TMP_EXTRACT_DIR && mkdir $TMP_EXTRACT_DIR && cd $TMP_EXTRACT_DIR
+    echo "Extracting $tar_file."
+    tar -zxf ../$tar_file
 
-  echo "Creating new $MR_TAR_NAME with the replaced libs."
-  tar -zcf "$MR_TAR_NAME" hadoop
+    echo "Replacing azure-storage.jar with $STORAGE_JAR."
+    find . -name "azure-storage*.jar" | while read line; do echo Replace $line; \cp -f $SOURCE_JAR ${line%azure*}; rm -f $line; done
 
-  echo "Replacing $MR_TAR_NAME on HDFS."
-  su -c "hadoop fs -put -f $MR_TAR_NAME $MR_TAR_PATH" hdfs
+    echo "Removing $tar_file."
+    rm -f "../$tar_file"
 
-  echo "Cleaning up local fs."
-  rm -f "$MR_TAR_NAME"
-  rm -rf hadoop
+    echo "Creating new $tar_file with the replaced libs."
+    tar -zcf "../$tar_file" $(ls)
+
+    echo "Replacing $tar_file on HDFS."
+    su -c "hadoop fs -put -f ../$tar_file $tar_file_path" hdfs
+
+    echo "Cleaning up local fs."
+    rm -f "../$tar_file"
+    cd .. && rm -rf $TM_EXTRACT_DIR
+  done
 }
 
 exec &>> "$LOGFILE"

--- a/core/src/main/resources/scripts/dash-local.sh
+++ b/core/src/main/resources/scripts/dash-local.sh
@@ -8,6 +8,13 @@
 : ${TEZ_TAR_NAME:=tez.tar.gz}
 : ${TMP_EXTRACT_DIR:=temp_extract_dir}
 
+restart_services(){
+  if curl -s http://localhost:11000/oozie; then
+    /usr/hdp/current/oozie-server/bin/oozie-stop.sh
+    /usr/hdp/current/oozie-server/bin/oozie-start.sh
+  fi
+}
+
 main(){
   SOURCE_JAR="$SOURCE_DIR/$STORAGE_JAR"
   if [ ! -f "$SOURCE_JAR" ]; then
@@ -42,6 +49,8 @@ main(){
       cd .. && rm -rf $TMP_EXTRACT_DIR
     fi
   done
+
+  restart_services
 }
 
 exec &>> "$LOGFILE"

--- a/core/src/test/resources/azure-core-init.sh
+++ b/core/src/test/resources/azure-core-init.sh
@@ -48,6 +48,7 @@ format_disks() {
       mkdir /hadoopfs/fs${i}
       echo $DEVICE /hadoopfs/fs${i} ext4  defaults,noatime 0 2 >> /etc/fstab
       mount /hadoopfs/fs${i}
+      chmod 777 /hadoopfs/fs${i}
     fi
   done
   cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch logs/kerberos

--- a/core/src/test/resources/azure-gateway-init.sh
+++ b/core/src/test/resources/azure-gateway-init.sh
@@ -53,6 +53,7 @@ format_disks() {
       mkdir /hadoopfs/fs${i}
       echo $DEVICE /hadoopfs/fs${i} ext4  defaults,noatime 0 2 >> /etc/fstab
       mount /hadoopfs/fs${i}
+      chmod 777 /hadoopfs/fs${i}
     fi
   done
   cd /hadoopfs/fs1 && mkdir logs logs/ambari-server logs/ambari-agent logs/consul-watch logs/kerberos


### PR DESCRIPTION
@keyki 

- tez.tar.gz contains an azure-storage jar as well, I've modified the dash scripts to change it there as well
- the `oozie.service.HadoopAccessorService.supported.filesystems` configuration's default value is `hdfs` so if it's not set then wasb is not working with oozie
- oozie server must be restarted after the azure jars are changed
- /hadoopfs/fs directories' permission is set to 777 so default ssh user is able to scp files there
- oozie sharelib creation on hdfs is not done via cloudbreak, it is the responsibility of the oozie user by executing `oozie-setup.sh sharelib create -fs <fs.defaultFs>`