### PR TITLE
Keystone v3 implementation for Openstack credential management

### DIFF
--- a/cloud-openstack/build.gradle
+++ b/cloud-openstack/build.gradle
@@ -13,15 +13,19 @@ jar {
 
 dependencies {
 
-    compile project(':cloud-api')
     compile project(':cloud-common')
     compile project(':cloud-template')
-    testCompile project(':cloud-reactor')
 
     compile group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion
+    compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: '3.3.2'
     compile group: 'org.springframework',           name: 'spring-context-support',         version: '4.0.3.RELEASE'
     compile group: 'org.springframework.boot',      name: 'spring-boot-starter',            version: springBootVersion
     compile group: 'org.pacesys',                   name: 'openstack4j',                    version: '2.0.6'
     compile group: 'org.freemarker',                name: 'freemarker',                     version: freemarkerVersion
     compile group: 'commons-codec',                 name: 'commons-codec',                  version: '1.10'
+
+    testCompile project(':cloud-reactor')
+    testCompile group: 'org.mockito',               name: 'mockito-all',                    version: '1.10.19'
+    testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: '1.1.8.RELEASE'
+    testCompile group: 'junit',                     name: 'junit',                          version: '4.12'
 }

--- a/cloud-openstack/build.gradle
+++ b/cloud-openstack/build.gradle
@@ -13,19 +13,15 @@ jar {
 
 dependencies {
 
+    compile project(':cloud-api')
     compile project(':cloud-common')
     compile project(':cloud-template')
+    testCompile project(':cloud-reactor')
 
     compile group: 'org.slf4j',                     name: 'slf4j-api',                      version: slf4jApiVersion
-    compile group: 'org.apache.commons',            name: 'commons-lang3',                  version: '3.3.2'
     compile group: 'org.springframework',           name: 'spring-context-support',         version: '4.0.3.RELEASE'
     compile group: 'org.springframework.boot',      name: 'spring-boot-starter',            version: springBootVersion
-    compile group: 'org.pacesys',                   name: 'openstack4j',                    version: '2.0.3'
+    compile group: 'org.pacesys',                   name: 'openstack4j',                    version: '2.0.6'
     compile group: 'org.freemarker',                name: 'freemarker',                     version: freemarkerVersion
     compile group: 'commons-codec',                 name: 'commons-codec',                  version: '1.10'
-
-    testCompile project(':cloud-reactor')
-    testCompile group: 'org.mockito',               name: 'mockito-all',                    version: '1.10.19'
-    testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: '1.1.8.RELEASE'
-    testCompile group: 'junit',                     name: 'junit',                          version: '4.12'
 }

--- a/cloud-openstack/build.gradle
+++ b/cloud-openstack/build.gradle
@@ -29,3 +29,4 @@ dependencies {
     testCompile group: 'org.springframework.boot',  name: 'spring-boot-starter-test',       version: '1.1.8.RELEASE'
     testCompile group: 'junit',                     name: 'junit',                          version: '4.12'
 }
+

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/auth/OpenStackClient.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/auth/OpenStackClient.java
@@ -52,19 +52,19 @@ public class OpenStackClient {
 
         if ( osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_DEFAULT_SCOPE) )
             return OSFactory.builderV3().endpoint(osCredential.getEndpoint())
-                    .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()/*"DEV"*/))
+                    .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()))
                     .authenticate()
                     .getAccess();
         else if ( osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_DOMAIN_SCOPE) )
             return OSFactory.builderV3().endpoint(osCredential.getEndpoint())
-                    .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()/*"DEV"*/))
+                    .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()))
                     .scopeToDomain(Identifier.byName(osCredential.getDomainName()))
                     .authenticate()
                     .getAccess();
         else
             return OSFactory.builderV3().endpoint(osCredential.getEndpoint())
-                    .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()/*"DEV"*/))
-                    .scopeToProject(Identifier.byName(osCredential.getProjectName()/*"vivek-madani"*/), Identifier.byName(osCredential.getProjectDomain()/*"DEV"*/))
+                    .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()))
+                    .scopeToProject(Identifier.byName(osCredential.getProjectName()), Identifier.byName(osCredential.getProjectDomain()))
                     .authenticate()
                     .getAccess();
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/auth/OpenStackClient.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/auth/OpenStackClient.java
@@ -9,11 +9,12 @@ import org.openstack4j.model.identity.Access;
 import org.openstack4j.openstack.OSFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
+import org.openstack4j.model.common.Identifier;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.openstack.view.KeystoneCredentialView;
+import com.sequenceiq.cloudbreak.cloud.exception.CloudConnectorException;
 
 @Component
 public class OpenStackClient {
@@ -44,29 +45,31 @@ public class OpenStackClient {
 
     public Access createAccess(AuthenticatedContext authenticatedContext) {
         KeystoneCredentialView osCredential = createKeystoneCredential(authenticatedContext);
-        if ( osCredential.getVersion().equals(KeystoneCredentialView.CB_KEYSTONE_V2) )
+        if (osCredential.getVersion().equals(KeystoneCredentialView.CB_KEYSTONE_V2)) {
             return OSFactory.builder().endpoint(osCredential.getEndpoint())
                     .credentials(osCredential.getUserName(), osCredential.getPassword())
                     .tenantName(osCredential.getTenantName())
                     .authenticate().getAccess();
-
-        if ( osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_DEFAULT_SCOPE) )
+        } else if (osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_DEFAULT_SCOPE)) {
             return OSFactory.builderV3().endpoint(osCredential.getEndpoint())
                     .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()))
                     .authenticate()
                     .getAccess();
-        else if ( osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_DOMAIN_SCOPE) )
+        } else if (osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_DOMAIN_SCOPE)) {
             return OSFactory.builderV3().endpoint(osCredential.getEndpoint())
                     .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()))
                     .scopeToDomain(Identifier.byName(osCredential.getDomainName()))
                     .authenticate()
                     .getAccess();
-        else
+        } else if (osCredential.getScope().equals(KeystoneCredentialView.CB_KEYSTONE_V3_PROJECT_SCOPE)) {
             return OSFactory.builderV3().endpoint(osCredential.getEndpoint())
                     .credentials(osCredential.getUserName(), osCredential.getPassword(), Identifier.byName(osCredential.getUserDomain()))
                     .scopeToProject(Identifier.byName(osCredential.getProjectName()), Identifier.byName(osCredential.getProjectDomain()))
                     .authenticate()
                     .getAccess();
+        } else {
+            throw new CloudConnectorException("Unsupported keystone version");
+        }
     }
 
     public OSClient createOSClient(Access access) {

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
@@ -6,13 +6,13 @@ import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
 public class KeystoneCredentialView {
-    private static final String CB_KEYPAIR_NAME = "cb";
     public static final String CB_KEYSTONE_V2 = "cb-keystone-v2";
     public static final String CB_KEYSTONE_V3 = "cb-keystone-v3";
     public static final String CB_KEYSTONE_V3_DEFAULT_SCOPE = "cb-keystone-v3-default-scope";
     public static final String CB_KEYSTONE_V3_PROJECT_SCOPE = "cb-keystone-v3-project-scope";
     public static final String CB_KEYSTONE_V3_DOMAIN_SCOPE = "cb-keystone-v3-domain-scope";
 
+    private static final String CB_KEYPAIR_NAME = "cb";
     private CloudCredential cloudCredential;
     private String stackName;
 
@@ -69,11 +69,11 @@ public class KeystoneCredentialView {
         return cloudCredential.getParameter("domainName", String.class);
     }
 
-    public String getScope() { 
-		return cloudCredential.getParameter("keystoneAuthScope", String.class); 
-	}
+    public String getScope() {
+        return cloudCredential.getParameter("keystoneAuthScope", String.class);
+    }
 
-    public String getVersion() { 
-		return cloudCredential.getParameter("keystoneVersion", String.class); 
-	}
+    public String getVersion() {
+        return cloudCredential.getParameter("keystoneVersion", String.class);
+    }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
@@ -1,32 +1,31 @@
 package com.sequenceiq.cloudbreak.cloud.openstack.view;
 
-import static org.apache.commons.lang3.StringUtils.deleteWhitespace;
-
-import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 
+import static org.apache.commons.lang3.StringUtils.deleteWhitespace;
+
 public class KeystoneCredentialView {
-    private static final String CB_KEYPAIR_NAME = "cb";
+    private static final String CB_KEYPAIR_NAME = "cb-keypair-";
+    public static final String CB_KEYSTONE_V2 = "cb-keystone-v2";
+    public static final String CB_KEYSTONE_V3 = "cb-keystone-v3";
+    public static final String CB_KEYSTONE_V3_DEFAULT_SCOPE = "cb-keystone-v3-default-scope";
+    public static final String CB_KEYSTONE_V3_PROJECT_SCOPE = "cb-keystone-v3-project-scope";
+    public static final String CB_KEYSTONE_V3_DOMAIN_SCOPE = "cb-keystone-v3-domain-scope";
 
     private CloudCredential cloudCredential;
-    private String stackName;
 
-    public KeystoneCredentialView(AuthenticatedContext authenticatedContext) {
-        this.stackName = authenticatedContext.getCloudContext().getName();
-        this.cloudCredential = authenticatedContext.getCloudCredential();
+    public KeystoneCredentialView(CloudCredential cloudCredential) {
+        this.cloudCredential = cloudCredential;
     }
 
     public String getKeyPairName() {
-        return String.format("%s-%s-%s-%s", CB_KEYPAIR_NAME, getStackName(), deleteWhitespace(getName().toLowerCase()), cloudCredential.getId());
+        return CB_KEYPAIR_NAME + deleteWhitespace(getName().toLowerCase());
     }
 
     public String getName() {
         return cloudCredential.getName();
     }
 
-    public String getStackName() {
-        return stackName;
-    }
 
     public String getPublicKey() {
         return cloudCredential.getPublicKey();
@@ -48,4 +47,23 @@ public class KeystoneCredentialView {
         return cloudCredential.getParameter("endpoint", String.class);
     }
 
+    public String getUserDomain() {
+        return cloudCredential.getParameter("userDomain", String.class);
+    }
+
+    public String getProjectName() {
+        return cloudCredential.getParameter("projectName", String.class);
+    }
+
+    public String getProjectDomain() {
+        return cloudCredential.getParameter("projectDomainName", String.class);
+    }
+
+    public String getDomainName() {
+        return cloudCredential.getParameter("domainName", String.class);
+    }
+
+    public String getScope() { return cloudCredential.getParameter("keystoneAuthScope", String.class); }
+
+    public String getVersion() { return cloudCredential.getParameter("keystoneVersion", String.class); }
 }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/KeystoneCredentialView.java
@@ -1,11 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.openstack.view;
 
-import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
-
 import static org.apache.commons.lang3.StringUtils.deleteWhitespace;
 
+import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
+import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
+
 public class KeystoneCredentialView {
-    private static final String CB_KEYPAIR_NAME = "cb-keypair-";
+    private static final String CB_KEYPAIR_NAME = "cb";
     public static final String CB_KEYSTONE_V2 = "cb-keystone-v2";
     public static final String CB_KEYSTONE_V3 = "cb-keystone-v3";
     public static final String CB_KEYSTONE_V3_DEFAULT_SCOPE = "cb-keystone-v3-default-scope";
@@ -13,19 +14,24 @@ public class KeystoneCredentialView {
     public static final String CB_KEYSTONE_V3_DOMAIN_SCOPE = "cb-keystone-v3-domain-scope";
 
     private CloudCredential cloudCredential;
+    private String stackName;
 
-    public KeystoneCredentialView(CloudCredential cloudCredential) {
-        this.cloudCredential = cloudCredential;
+    public KeystoneCredentialView(AuthenticatedContext authenticatedContext) {
+        this.stackName = authenticatedContext.getCloudContext().getName();
+        this.cloudCredential = authenticatedContext.getCloudCredential();
     }
 
     public String getKeyPairName() {
-        return CB_KEYPAIR_NAME + deleteWhitespace(getName().toLowerCase());
+        return String.format("%s-%s-%s-%s", CB_KEYPAIR_NAME, getStackName(), deleteWhitespace(getName().toLowerCase()), cloudCredential.getId());
     }
 
     public String getName() {
         return cloudCredential.getName();
     }
 
+    public String getStackName() {
+        return stackName;
+    }
 
     public String getPublicKey() {
         return cloudCredential.getPublicKey();
@@ -63,7 +69,11 @@ public class KeystoneCredentialView {
         return cloudCredential.getParameter("domainName", String.class);
     }
 
-    public String getScope() { return cloudCredential.getParameter("keystoneAuthScope", String.class); }
+    public String getScope() { 
+		return cloudCredential.getParameter("keystoneAuthScope", String.class); 
+	}
 
-    public String getVersion() { return cloudCredential.getParameter("keystoneVersion", String.class); }
+    public String getVersion() { 
+		return cloudCredential.getParameter("keystoneVersion", String.class); 
+	}
 }

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/OpenStackCredential.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/OpenStackCredential.java
@@ -2,8 +2,6 @@ package com.sequenceiq.cloudbreak.domain;
 
 import javax.persistence.Entity;
 
-import com.sequenceiq.cloudbreak.common.type.CloudPlatform;
-
 @Entity
 public class OpenStackCredential extends Credential implements ProvisionEntity {
 
@@ -13,6 +11,12 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
     private String password;
     private String tenantName;
     private String endpoint;
+    private String userDomain;
+    private String keystoneVersion;
+    private String keystoneAuthScope;
+    private String projectName;
+    private String projectDomainName;
+    private String domainName;
 
     public OpenStackCredential() {
     }
@@ -33,6 +37,10 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
         this.tenantName = tenantName;
     }
 
+    public String getUserDomain() { return userDomain; }
+
+    public void setUserDomain(String userDomain) { this.userDomain = userDomain; }
+
     public String getEndpoint() {
         return endpoint;
     }
@@ -48,6 +56,26 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
     public void setUserName(String userName) {
         this.userName = userName;
     }
+
+    public String getKeystoneVersion() { return keystoneVersion; }
+
+    public void setKeystoneVersion(String keystoneVersion) { this.keystoneVersion = keystoneVersion; }
+
+    public String getKeystoneAuthScope() { return keystoneAuthScope; }
+
+    public void setKeystoneAuthScope(String keystoneAuthScope) { this.keystoneAuthScope = keystoneAuthScope; }
+
+    public String getProjectName() { return projectName; }
+
+    public void setProjectName(String projectName) { this.projectName = projectName; }
+
+    public String getProjectDomainName() { return projectDomainName; }
+
+    public void setProjectDomainName(String projectDomainName) { this.projectDomainName = projectDomainName; }
+
+    public String getDomainName() { return domainName; }
+
+    public void setDomainName(String domainName) { this.domainName = domainName; }
 
     @Override
     public CloudPlatform cloudPlatform() {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/OpenStackCredential.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/OpenStackCredential.java
@@ -2,6 +2,8 @@ package com.sequenceiq.cloudbreak.domain;
 
 import javax.persistence.Entity;
 
+import com.sequenceiq.cloudbreak.common.type.CloudPlatform;
+
 @Entity
 public class OpenStackCredential extends Credential implements ProvisionEntity {
 
@@ -37,9 +39,13 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
         this.tenantName = tenantName;
     }
 
-    public String getUserDomain() { return userDomain; }
+    public String getUserDomain() { 
+		return userDomain; 
+	}
 
-    public void setUserDomain(String userDomain) { this.userDomain = userDomain; }
+    public void setUserDomain(String userDomain) { 
+		this.userDomain = userDomain; 
+	}
 
     public String getEndpoint() {
         return endpoint;
@@ -57,25 +63,45 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
         this.userName = userName;
     }
 
-    public String getKeystoneVersion() { return keystoneVersion; }
+    public String getKeystoneVersion() { 
+		return keystoneVersion; 
+	}
 
-    public void setKeystoneVersion(String keystoneVersion) { this.keystoneVersion = keystoneVersion; }
+    public void setKeystoneVersion(String keystoneVersion) { 
+		this.keystoneVersion = keystoneVersion; 
+	}
 
-    public String getKeystoneAuthScope() { return keystoneAuthScope; }
+    public String getKeystoneAuthScope() { 
+		return keystoneAuthScope; 
+	}
 
-    public void setKeystoneAuthScope(String keystoneAuthScope) { this.keystoneAuthScope = keystoneAuthScope; }
+    public void setKeystoneAuthScope(String keystoneAuthScope) { 
+		this.keystoneAuthScope = keystoneAuthScope; 
+	}
 
-    public String getProjectName() { return projectName; }
+    public String getProjectName() { 
+		return projectName; 
+	}
 
-    public void setProjectName(String projectName) { this.projectName = projectName; }
+    public void setProjectName(String projectName) { 
+		this.projectName = projectName; 
+	}
 
-    public String getProjectDomainName() { return projectDomainName; }
+    public String getProjectDomainName() { 
+		return projectDomainName; 
+	}
 
-    public void setProjectDomainName(String projectDomainName) { this.projectDomainName = projectDomainName; }
+    public void setProjectDomainName(String projectDomainName) { 
+		this.projectDomainName = projectDomainName; 
+	}
 
-    public String getDomainName() { return domainName; }
+    public String getDomainName() { 
+		return domainName; 
+	}
 
-    public void setDomainName(String domainName) { this.domainName = domainName; }
+    public void setDomainName(String domainName) { 
+		this.domainName = domainName; 
+	}
 
     @Override
     public CloudPlatform cloudPlatform() {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/OpenStackCredential.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/OpenStackCredential.java
@@ -39,13 +39,13 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
         this.tenantName = tenantName;
     }
 
-    public String getUserDomain() { 
-		return userDomain; 
-	}
+    public String getUserDomain() {
+        return userDomain;
+    }
 
-    public void setUserDomain(String userDomain) { 
-		this.userDomain = userDomain; 
-	}
+    public void setUserDomain(String userDomain) {
+        this.userDomain = userDomain;
+    }
 
     public String getEndpoint() {
         return endpoint;
@@ -63,45 +63,45 @@ public class OpenStackCredential extends Credential implements ProvisionEntity {
         this.userName = userName;
     }
 
-    public String getKeystoneVersion() { 
-		return keystoneVersion; 
-	}
+    public String getKeystoneVersion() {
+        return keystoneVersion;
+    }
 
-    public void setKeystoneVersion(String keystoneVersion) { 
-		this.keystoneVersion = keystoneVersion; 
-	}
+    public void setKeystoneVersion(String keystoneVersion) {
+        this.keystoneVersion = keystoneVersion;
+    }
 
-    public String getKeystoneAuthScope() { 
-		return keystoneAuthScope; 
-	}
+    public String getKeystoneAuthScope() {
+        return keystoneAuthScope;
+    }
 
-    public void setKeystoneAuthScope(String keystoneAuthScope) { 
-		this.keystoneAuthScope = keystoneAuthScope; 
-	}
+    public void setKeystoneAuthScope(String keystoneAuthScope) {
+        this.keystoneAuthScope = keystoneAuthScope;
+    }
 
-    public String getProjectName() { 
-		return projectName; 
-	}
+    public String getProjectName() {
+        return projectName;
+    }
 
-    public void setProjectName(String projectName) { 
-		this.projectName = projectName; 
-	}
+    public void setProjectName(String projectName) {
+        this.projectName = projectName;
+    }
 
-    public String getProjectDomainName() { 
-		return projectDomainName; 
-	}
+    public String getProjectDomainName() {
+        return projectDomainName;
+    }
 
-    public void setProjectDomainName(String projectDomainName) { 
-		this.projectDomainName = projectDomainName; 
-	}
+    public void setProjectDomainName(String projectDomainName) {
+        this.projectDomainName = projectDomainName;
+    }
 
-    public String getDomainName() { 
-		return domainName; 
-	}
+    public String getDomainName() {
+        return domainName;
+    }
 
-    public void setDomainName(String domainName) { 
-		this.domainName = domainName; 
-	}
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
 
     @Override
     public CloudPlatform cloudPlatform() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidator.java
@@ -12,6 +12,12 @@ import com.sequenceiq.cloudbreak.controller.json.CredentialRequest;
 
 public class CredentialParametersValidator implements ConstraintValidator<ValidCredentialRequest, CredentialRequest> {
 
+    private static final String KEYSTONE_VERSION_V2 = "cb-keystone-v2";
+    private static final String KEYSTONE_VERSION_V3 = "cb-keystone-v3";
+    private static final String KEYSTONE_V3_DEFAULT_SCOPE = "cb-keystone-v3-default-scope";
+    private static final String KEYSTONE_V3_DOMAIN_SCOPE = "cb-keystone-v3-domain-scope";
+    private static final String KEYSTONE_V3_PROJECT_SCOPE = "cb-keystone-v3-project-scope";
+
     @Inject
     private List<ParameterValidator> parameterValidators;
 
@@ -50,7 +56,7 @@ public class CredentialParametersValidator implements ConstraintValidator<ValidC
                 valid = validateParams(request.getParameters(), context, requiredGcpParams);
                 break;
             case OPENSTACK:
-                valid = validateParams(request.getParameters(), context, requiredOpenStackParams);
+                valid = validateOpenStackParams(request.getParameters(), context, requiredOpenStackParams);
                 break;
             default:
                 break;
@@ -67,4 +73,85 @@ public class CredentialParametersValidator implements ConstraintValidator<ValidC
         return true;
     }
 
+    private boolean validateOpenStackParams(Map<String, Object> params, ConstraintValidatorContext context, List<TemplateParam> paramConstraints) {
+        boolean valid = true;
+        String keystoneVersion = String.valueOf(params.get(OpenStackCredentialParam.KEYSTONE_VERSION.getName()));
+        if (keystoneVersion.equals(KEYSTONE_VERSION_V2)) {
+            valid = validateParams(params, context, paramConstraints)
+                    && validateOpenStackV2Params(params, context, paramConstraints);
+        } else if (keystoneVersion.equals(KEYSTONE_VERSION_V3)) {
+            valid = validateParams(params, context, paramConstraints)
+                    && validateOpenStackV3Params(params, context, paramConstraints);
+        } else {
+            return false;
+        }
+        return valid;
+    }
+
+    private boolean validateOpenStackV2Params(Map<String, Object> params, ConstraintValidatorContext context, List<TemplateParam> paramConstraints) {
+        boolean valid = true;
+        if (!params.containsKey(OpenStackCredentialParam.TENANT_NAME.getName())) {
+            addConstraintViolation(OpenStackCredentialParam.TENANT_NAME.getName(), context);
+            valid = false;
+        }
+        return valid;
+    }
+
+    private boolean validateOpenStackV3Params(Map<String, Object> params, ConstraintValidatorContext context, List<TemplateParam> paramConstraints) {
+        boolean valid;
+        if (!params.containsKey(OpenStackCredentialParam.KEYSTONE_AUTH_SCOPE.getName())) {
+            addConstraintViolation(OpenStackCredentialParam.KEYSTONE_AUTH_SCOPE.getName(), context);
+            valid = false;
+        } else {
+            valid = validateV3Scopes(params, context);
+        }
+        return valid;
+    }
+
+    private boolean validateV3Scopes(Map<String, Object> params, ConstraintValidatorContext context) {
+        boolean valid = true;
+        switch (String.valueOf(params.get(OpenStackCredentialParam.KEYSTONE_AUTH_SCOPE.getName()))) {
+            case KEYSTONE_V3_DEFAULT_SCOPE:
+                if (!params.containsKey(OpenStackCredentialParam.USER_DOMAIN.getName())) {
+                    addConstraintViolation(OpenStackCredentialParam.USER_DOMAIN.getName(), context);
+                    valid = false;
+                }
+                break;
+            case KEYSTONE_V3_DOMAIN_SCOPE:
+                if (!params.containsKey(OpenStackCredentialParam.USER_DOMAIN.getName())) {
+                    addConstraintViolation(OpenStackCredentialParam.USER_DOMAIN.getName(), context);
+                    valid = false;
+                }
+                if (!params.containsKey(OpenStackCredentialParam.DOMAIN_NAME.getName())) {
+                    addConstraintViolation(OpenStackCredentialParam.DOMAIN_NAME.getName(), context);
+                    valid = false;
+                }
+                break;
+            case KEYSTONE_V3_PROJECT_SCOPE:
+                if (!params.containsKey(OpenStackCredentialParam.USER_DOMAIN.getName())) {
+                    addConstraintViolation(OpenStackCredentialParam.USER_DOMAIN.getName(), context);
+                    valid = false;
+                }
+                if (!params.containsKey(OpenStackCredentialParam.PROJECT_NAME.getName())) {
+                    addConstraintViolation(OpenStackCredentialParam.PROJECT_NAME.getName(), context);
+                    valid = false;
+                }
+                if (!params.containsKey(OpenStackCredentialParam.PROJECT_DOMAIN_NAME.getName())) {
+                    addConstraintViolation(OpenStackCredentialParam.PROJECT_DOMAIN_NAME.getName(), context);
+                    valid = false;
+                }
+                break;
+            default:
+                valid = false;
+        }
+        return valid;
+    }
+
+    private void addConstraintViolation(String key, ConstraintValidatorContext context) {
+        String message = String.format("%s is required.", key);
+        context.buildConstraintViolationWithTemplate(message)
+                .addPropertyNode("parameters")
+                .addBeanNode().inIterable().atKey(key)
+                .addConstraintViolation();
+    }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidator.java
@@ -17,6 +17,7 @@ public class CredentialParametersValidator implements ConstraintValidator<ValidC
     private static final String KEYSTONE_V3_DEFAULT_SCOPE = "cb-keystone-v3-default-scope";
     private static final String KEYSTONE_V3_DOMAIN_SCOPE = "cb-keystone-v3-domain-scope";
     private static final String KEYSTONE_V3_PROJECT_SCOPE = "cb-keystone-v3-project-scope";
+    private static final String NULL_STRING = "null";
 
     @Inject
     private List<ParameterValidator> parameterValidators;
@@ -76,7 +77,7 @@ public class CredentialParametersValidator implements ConstraintValidator<ValidC
     private boolean validateOpenStackParams(Map<String, Object> params, ConstraintValidatorContext context, List<TemplateParam> paramConstraints) {
         boolean valid = true;
         String keystoneVersion = String.valueOf(params.get(OpenStackCredentialParam.KEYSTONE_VERSION.getName()));
-        if (keystoneVersion.equals(KEYSTONE_VERSION_V2)) {
+        if (keystoneVersion.equals(NULL_STRING) || keystoneVersion.equals(KEYSTONE_VERSION_V2)) {
             valid = validateParams(params, context, paramConstraints)
                     && validateOpenStackV2Params(params, context, paramConstraints);
         } else if (keystoneVersion.equals(KEYSTONE_VERSION_V3)) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/OpenStackCredentialParam.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/OpenStackCredentialParam.java
@@ -6,7 +6,13 @@ public enum OpenStackCredentialParam implements TemplateParam {
 
     USER("user", true, String.class, Optional.<String>absent()),
     PASSWORD("password", true, String.class, Optional.<String>absent()),
-    TENANT_NAME("tenantName", true, String.class, Optional.<String>absent()),
+    TENANT_NAME("tenantName", false, String.class, Optional.<String>absent()),
+    USER_DOMAIN("userDomain", false, String.class, Optional.<String>absent()),
+    KEYSTONE_VERSION("keystoneVersion", true, String.class, Optional.<String>absent()),
+    KEYSTONE_AUTH_SCOPE("keystoneAuthScope", false, String.class, Optional.<String>absent()),
+    PROJECT_DOMAIN_NAME("projectDomainName", false, String.class, Optional.<String>absent()),
+    PROJECT_NAME("projectName", false, String.class, Optional.<String>absent()),
+    DOMAIN_NAME("domainName", false, String.class, Optional.<String>absent()),
     ENDPOINT("endpoint", true, String.class, Optional.<String>absent());
 
     private final String paramName;

--- a/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/OpenStackCredentialParam.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/controller/validation/OpenStackCredentialParam.java
@@ -8,8 +8,10 @@ public enum OpenStackCredentialParam implements TemplateParam {
     PASSWORD("password", true, String.class, Optional.<String>absent()),
     TENANT_NAME("tenantName", false, String.class, Optional.<String>absent()),
     USER_DOMAIN("userDomain", false, String.class, Optional.<String>absent()),
-    KEYSTONE_VERSION("keystoneVersion", true, String.class, Optional.<String>absent()),
-    KEYSTONE_AUTH_SCOPE("keystoneAuthScope", false, String.class, Optional.<String>absent()),
+    KEYSTONE_VERSION("keystoneVersion", true, String.class, Optional.of("cb-keystone-v2|cb-keystone-v3")),
+    KEYSTONE_AUTH_SCOPE("keystoneAuthScope", false, String.class, Optional.of("cb-keystone-v3-default-scope"
+            + "|cb-keystone-v3-project-scope"
+            + "|cb-keystone-v3-domain-scope")),
     PROJECT_DOMAIN_NAME("projectDomainName", false, String.class, Optional.<String>absent()),
     PROJECT_NAME("projectName", false, String.class, Optional.<String>absent()),
     DOMAIN_NAME("domainName", false, String.class, Optional.<String>absent()),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToOpenStackCredentialConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToOpenStackCredentialConverter.java
@@ -1,14 +1,13 @@
 package com.sequenceiq.cloudbreak.converter;
 
-import javax.inject.Inject;
-
-import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
-import org.springframework.stereotype.Component;
-
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.json.CredentialRequest;
 import com.sequenceiq.cloudbreak.controller.validation.OpenStackCredentialParam;
 import com.sequenceiq.cloudbreak.domain.OpenStackCredential;
+import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
+import org.springframework.stereotype.Component;
+
+import javax.inject.Inject;
 
 @Component
 public class JsonToOpenStackCredentialConverter extends AbstractConversionServiceAwareConverter<CredentialRequest, OpenStackCredential> {
@@ -27,7 +26,13 @@ public class JsonToOpenStackCredentialConverter extends AbstractConversionServic
         openStackCredential.setUserName(encryptor.encrypt(userName));
         String password = String.valueOf(source.getParameters().get(OpenStackCredentialParam.PASSWORD.getName()));
         openStackCredential.setPassword(encryptor.encrypt(password));
+        openStackCredential.setKeystoneVersion(String.valueOf(source.getParameters().get(OpenStackCredentialParam.KEYSTONE_VERSION.getName())));
+        openStackCredential.setKeystoneAuthScope(String.valueOf(source.getParameters().get(OpenStackCredentialParam.KEYSTONE_AUTH_SCOPE.getName())));
         openStackCredential.setTenantName(String.valueOf(source.getParameters().get(OpenStackCredentialParam.TENANT_NAME.getName())));
+        openStackCredential.setUserDomain(String.valueOf(source.getParameters().get(OpenStackCredentialParam.USER_DOMAIN.getName())));
+        openStackCredential.setDomainName(String.valueOf(source.getParameters().get(OpenStackCredentialParam.DOMAIN_NAME.getName())));
+        openStackCredential.setProjectDomainName(String.valueOf(source.getParameters().get(OpenStackCredentialParam.PROJECT_DOMAIN_NAME.getName())));
+        openStackCredential.setProjectName(String.valueOf(source.getParameters().get(OpenStackCredentialParam.PROJECT_NAME.getName())));
         openStackCredential.setEndpoint(String.valueOf(source.getParameters().get(OpenStackCredentialParam.ENDPOINT.getName())));
         openStackCredential.setPublicKey(source.getPublicKey());
         if (source.getLoginUserName() != null) {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToOpenStackCredentialConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToOpenStackCredentialConverter.java
@@ -27,7 +27,11 @@ public class JsonToOpenStackCredentialConverter extends AbstractConversionServic
         openStackCredential.setUserName(encryptor.encrypt(userName));
         String password = String.valueOf(source.getParameters().get(OpenStackCredentialParam.PASSWORD.getName()));
         openStackCredential.setPassword(encryptor.encrypt(password));
-        openStackCredential.setKeystoneVersion(String.valueOf(source.getParameters().get(OpenStackCredentialParam.KEYSTONE_VERSION.getName())));
+        if (!source.getParameters().containsKey(OpenStackCredentialParam.KEYSTONE_VERSION.getName())) {
+            openStackCredential.setKeystoneVersion("cb-keystone-v2");
+        } else {
+            openStackCredential.setKeystoneVersion(String.valueOf(source.getParameters().get(OpenStackCredentialParam.KEYSTONE_VERSION.getName())));
+        }
         openStackCredential.setKeystoneAuthScope(String.valueOf(source.getParameters().get(OpenStackCredentialParam.KEYSTONE_AUTH_SCOPE.getName())));
         openStackCredential.setTenantName(String.valueOf(source.getParameters().get(OpenStackCredentialParam.TENANT_NAME.getName())));
         openStackCredential.setUserDomain(String.valueOf(source.getParameters().get(OpenStackCredentialParam.USER_DOMAIN.getName())));

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToOpenStackCredentialConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToOpenStackCredentialConverter.java
@@ -1,13 +1,14 @@
 package com.sequenceiq.cloudbreak.converter;
 
+import javax.inject.Inject;
+
+import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.controller.BadRequestException;
 import com.sequenceiq.cloudbreak.controller.json.CredentialRequest;
 import com.sequenceiq.cloudbreak.controller.validation.OpenStackCredentialParam;
 import com.sequenceiq.cloudbreak.domain.OpenStackCredential;
-import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
-import org.springframework.stereotype.Component;
-
-import javax.inject.Inject;
 
 @Component
 public class JsonToOpenStackCredentialConverter extends AbstractConversionServiceAwareConverter<CredentialRequest, OpenStackCredential> {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/OpenStackCredentialToJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/OpenStackCredentialToJsonConverter.java
@@ -1,13 +1,14 @@
 package com.sequenceiq.cloudbreak.converter;
 
-import com.sequenceiq.cloudbreak.controller.json.CredentialResponse;
-import com.sequenceiq.cloudbreak.controller.validation.OpenStackCredentialParam;
-import com.sequenceiq.cloudbreak.domain.CloudPlatform;
-import com.sequenceiq.cloudbreak.domain.OpenStackCredential;
-import org.springframework.stereotype.Component;
-
 import java.util.HashMap;
 import java.util.Map;
+
+import org.springframework.stereotype.Component;
+
+import com.sequenceiq.cloudbreak.controller.json.CredentialResponse;
+import com.sequenceiq.cloudbreak.controller.validation.OpenStackCredentialParam;
+import com.sequenceiq.cloudbreak.common.type.CloudPlatform;
+import com.sequenceiq.cloudbreak.domain.OpenStackCredential;
 
 @Component
 public class OpenStackCredentialToJsonConverter extends AbstractConversionServiceAwareConverter<OpenStackCredential, CredentialResponse> {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/OpenStackCredentialToJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/OpenStackCredentialToJsonConverter.java
@@ -1,14 +1,13 @@
 package com.sequenceiq.cloudbreak.converter;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import org.springframework.stereotype.Component;
-
 import com.sequenceiq.cloudbreak.controller.json.CredentialResponse;
 import com.sequenceiq.cloudbreak.controller.validation.OpenStackCredentialParam;
-import com.sequenceiq.cloudbreak.common.type.CloudPlatform;
+import com.sequenceiq.cloudbreak.domain.CloudPlatform;
 import com.sequenceiq.cloudbreak.domain.OpenStackCredential;
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 public class OpenStackCredentialToJsonConverter extends AbstractConversionServiceAwareConverter<OpenStackCredential, CredentialResponse> {
@@ -22,7 +21,13 @@ public class OpenStackCredentialToJsonConverter extends AbstractConversionServic
         credentialJson.setPublicKey(source.getPublicKey());
         credentialJson.setPublicInAccount(source.isPublicInAccount());
         Map<String, Object> parameters = new HashMap<>();
+        parameters.put(OpenStackCredentialParam.KEYSTONE_VERSION.getName(), source.getKeystoneVersion());
+        parameters.put(OpenStackCredentialParam.KEYSTONE_AUTH_SCOPE.getName(), source.getKeystoneAuthScope());
         parameters.put(OpenStackCredentialParam.TENANT_NAME.getName(), source.getTenantName());
+        parameters.put(OpenStackCredentialParam.USER_DOMAIN.getName(), source.getUserDomain());
+        parameters.put(OpenStackCredentialParam.PROJECT_NAME.getName(), source.getProjectName());
+        parameters.put(OpenStackCredentialParam.PROJECT_DOMAIN_NAME.getName(), source.getProjectDomainName());
+        parameters.put(OpenStackCredentialParam.DOMAIN_NAME.getName(), source.getDomainName());
         parameters.put(OpenStackCredentialParam.ENDPOINT.getName(), source.getEndpoint());
         credentialJson.setParameters(parameters);
         credentialJson.setLoginUserName(source.getLoginUserName());

--- a/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
+++ b/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
@@ -1,0 +1,30 @@
+-- // schema changes for keystone v3
+-- Migration SQL that makes the change goes here.
+ALTER TABLE credential ADD COLUMN keystoneversion character varying(255);
+
+ALTER TABLE credential ADD COLUMN keystoneauthscope character varying(255);
+
+ALTER TABLE credential ADD COLUMN projectdomainname character varying(255);
+
+ALTER TABLE credential ADD COLUMN domainname character varying(255);
+
+ALTER TABLE credential ADD COLUMN projectname character varying(255);
+
+ALTER TABLE credential ADD COLUMN userdomain character varying(255);
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE credential DROP COLUMN keystoneversion;
+
+ALTER TABLE credential DROP COLUMN keystoneauthscope;
+
+ALTER TABLE credential DROP COLUMN projectdomainname;
+
+ALTER TABLE credential DROP COLUMN domainname;
+
+ALTER TABLE credential DROP COLUMN projectname;
+
+ALTER TABLE credential DROP COLUMN userdomain;
+
+

--- a/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
+++ b/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
@@ -1,6 +1,6 @@
 -- // schema changes for keystone v3
 -- Migration SQL that makes the change goes here.
-ALTER TABLE credential ADD COLUMN keystoneversion character varying(255) DEFAULT 'cb-keystone-v2' WHERE dtype='OpenStackCredential';
+ALTER TABLE credential ADD COLUMN keystoneversion character varying(255);
 
 ALTER TABLE credential ADD COLUMN keystoneauthscope character varying(255);
 
@@ -11,6 +11,8 @@ ALTER TABLE credential ADD COLUMN domainname character varying(255);
 ALTER TABLE credential ADD COLUMN projectname character varying(255);
 
 ALTER TABLE credential ADD COLUMN userdomain character varying(255);
+
+UPDATE credential SET keystoneversion='cb-keystone-v2' WHERE dtype='OpenStackCredential';
 
 -- //@UNDO
 -- SQL to undo the change goes here. 

--- a/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
+++ b/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
@@ -13,7 +13,7 @@ ALTER TABLE credential ADD COLUMN projectname character varying(255);
 ALTER TABLE credential ADD COLUMN userdomain character varying(255);
 
 -- //@UNDO
--- SQL to undo the change goes here.
+-- SQL to undo the change goes here. 
 
 ALTER TABLE credential DROP COLUMN keystoneversion;
 

--- a/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
+++ b/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
@@ -1,6 +1,6 @@
 -- // schema changes for keystone v3
 -- Migration SQL that makes the change goes here.
-ALTER TABLE credential ADD COLUMN keystoneversion character varying(255);
+ALTER TABLE credential ADD COLUMN keystoneversion character varying(255) DEFAULT 'cb-keystone-v2';
 
 ALTER TABLE credential ADD COLUMN keystoneauthscope character varying(255);
 

--- a/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
+++ b/core/src/main/resources/schema/20151027185309_schema_changes_for_keystone_v3.sql
@@ -1,6 +1,6 @@
 -- // schema changes for keystone v3
 -- Migration SQL that makes the change goes here.
-ALTER TABLE credential ADD COLUMN keystoneversion character varying(255) DEFAULT 'cb-keystone-v2';
+ALTER TABLE credential ADD COLUMN keystoneversion character varying(255) DEFAULT 'cb-keystone-v2' WHERE dtype='OpenStackCredential';
 
 ALTER TABLE credential ADD COLUMN keystoneauthscope character varying(255);
 

--- a/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidatorTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/controller/validation/CredentialParametersValidatorTest.java
@@ -246,6 +246,7 @@ public class CredentialParametersValidatorTest {
         parameters.put(OpenStackCredentialParam.USER.getName(), "user");
         parameters.put(OpenStackCredentialParam.PASSWORD.getName(), "tenant");
         parameters.put(OpenStackCredentialParam.TENANT_NAME.getName(), "user");
+        parameters.put(OpenStackCredentialParam.KEYSTONE_VERSION.getName(), "cb-keystone-v2");
 
         credentialJson.setParameters(parameters);
         credentialJson.setPublicKey("ssh key");


### PR DESCRIPTION
Implementation to support keystone v3 for Openstack. Added support for all 3 supported keystone v3 scopes. 

One important change to note is that the tenantName is no longer a mandatory field in parameter validator for openstack. This is because if the user selects v3, there is no tenantName and instead the parameters would change depending on the scope selected.

I have not yet added unit tests but I am in the process of writing the same and will submit a separate pull request. 

Also sent a pull request for uluwatu for corresponding UI changes.