### PR TITLE
CLOUD-46100 create a restricted security group for each cluster

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 ambariClientName=ambari-client21
 ambariClientVersion=2.1.27
-cloudbreakClientVersion=0.4.18
+cloudbreakClientVersion=0.4.26
 springBootVersion=1.1.8.RELEASE
 azureRestClientVersion=0.1.52
 eventBusVersion=2.0.3.RELEASE

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SecurityGroupCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/SecurityGroupCreationTest.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.it.cloudbreak;
+
+import static java.util.Collections.singletonMap;
+
+import org.testng.Assert;
+import org.testng.annotations.Optional;
+import org.testng.annotations.Parameters;
+import org.testng.annotations.Test;
+
+public class SecurityGroupCreationTest extends AbstractCloudbreakIntegrationTest {
+
+    @Test
+    @Parameters({ "name", "ports" })
+    public void testGcpTemplateCreation(@Optional("restricted-ambari") String name, @Optional("22,443,8080") String ports) throws Exception {
+        // GIVEN
+        // WHEN
+        String id = getClient().postSecurityGroup(name, "Security group created by IT", singletonMap("0.0.0.0/0", ports), null, false);
+        // THEN
+        Assert.assertNotNull(id);
+        getItContext().putContextParam(CloudbreakITContextConstants.SECURITY_GROUP_ID, id, true);
+    }
+
+}

--- a/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-startstop-updown.yaml
@@ -10,6 +10,12 @@ tests:
       - com.sequenceiq.it.TestSuiteInitializer
       - com.sequenceiq.it.cloudbreak.CloudbreakTestSuiteInitializer
 
+  - name: create security group
+    parameters:
+      name: restricted-ambari-aws
+    classes:
+      - com.sequenceiq.it.cloudbreak.SecurityGroupCreationTest
+
   - name: create gateway template
     parameters: {
       awsTemplateName: it-aws-smoke-gateway-ssud,

--- a/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-startstop-updown.yaml
@@ -10,6 +10,12 @@ tests:
       - com.sequenceiq.it.TestSuiteInitializer
       - com.sequenceiq.it.cloudbreak.CloudbreakTestSuiteInitializer
 
+  - name: create security group
+    parameters:
+      name: restricted-ambari-arm
+    classes:
+      - com.sequenceiq.it.cloudbreak.SecurityGroupCreationTest
+
   - name: create gateway template
     parameters: {
       azureTemplateName: it-azurerm-smoke-gateway-ssud,

--- a/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-startstop-updown.yaml
@@ -10,6 +10,12 @@ tests:
       - com.sequenceiq.it.TestSuiteInitializer
       - com.sequenceiq.it.cloudbreak.CloudbreakTestSuiteInitializer
 
+  - name: create security group
+    parameters:
+      name: restricted-ambari-gcp
+    classes:
+      - com.sequenceiq.it.cloudbreak.SecurityGroupCreationTest
+
   - name: create gateway template
     parameters: {
       gcpName: it-gcp-smoke-gateway-ssud,

--- a/integration-test/src/main/resources/testsuites/nativeos/smoke/nativeos-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/nativeos/smoke/nativeos-clustercreate-startstop-updown.yaml
@@ -17,6 +17,12 @@ tests:
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 
+  - name: create security group
+    parameters:
+      name: restricted-ambari-osn
+    classes:
+      - com.sequenceiq.it.cloudbreak.SecurityGroupCreationTest
+
   - name: create gateway template
     parameters:
       templateName: it-nativeos-smoke-gateway-ssud

--- a/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstop-updown.yaml
@@ -17,6 +17,12 @@ tests:
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 
+  - name: create security group
+    parameters:
+      name: restricted-ambari-os
+    classes:
+      - com.sequenceiq.it.cloudbreak.SecurityGroupCreationTest
+
   - name: create gateway template
     parameters:
       templateName: it-openstack-smoke-gateway-ssud


### PR DESCRIPTION
@schfeca75 

Let's test the clusters using a restricted security group. 8080 is open as the IT itself tries to communicate with Ambari, 443 should be enough for that, but it requires 2-way-ssl connection and we don't have the client cert.