### PR TITLE
CLOUD-52524 support access and secret based authentication on AWS

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsAuthenticator.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/AwsAuthenticator.java
@@ -34,7 +34,7 @@ public class AwsAuthenticator implements Authenticator {
     @Override
     public AuthenticatedContext authenticate(CloudContext cloudContext, CloudCredential cloudCredential) {
         LOGGER.info("Authenticating to aws ...");
-        awsClient.checkAwsEnvironmentVariables();
+        awsClient.checkAwsEnvironmentVariables(cloudCredential);
         return awsClient.createAuthenticatedContext(cloudContext, cloudCredential);
     }
 }

--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsCredentialView.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/view/AwsCredentialView.java
@@ -22,8 +22,12 @@ public class AwsCredentialView {
         return cloudCredential.getParameter("roleArn", String.class);
     }
 
-    public String getKeyPairName() {
-        return cloudCredential.getParameter("keyPairName", String.class);
+    public String getAccessKey() {
+        return cloudCredential.getParameter("accessKey", String.class);
+    }
+
+    public String getSecretKey() {
+        return cloudCredential.getParameter("secretKey", String.class);
     }
 
     public Long getId() {

--- a/cloud-aws/src/main/resources/definitions/aws-credential.json
+++ b/cloud-aws/src/main/resources/definitions/aws-credential.json
@@ -3,6 +3,16 @@
     {
       "name": "roleArn",
       "type": "String"
+    },
+    {
+      "name": "accessKey",
+      "type": "String",
+      "encrypted": true
+    },
+    {
+      "name": "secretKey",
+      "type": "String",
+      "encrypted": true
     }
   ]
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/definition/credential/CredentialDefinitionService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/resource/definition/credential/CredentialDefinitionService.java
@@ -12,7 +12,6 @@ import org.jasypt.encryption.pbe.PBEStringCleanablePasswordEncryptor;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
-import com.sequenceiq.cloudbreak.service.stack.resource.definition.MissingParameterException;
 import com.sequenceiq.cloudbreak.service.stack.resource.definition.ResourceDefinitionService;
 import com.sequenceiq.cloudbreak.util.JsonUtil;
 
@@ -81,10 +80,12 @@ public class CredentialDefinitionService {
         for (Value value : values) {
             String key = value.getName();
             String property = getProperty(properties, key);
-            if (isEncrypted(value)) {
-                property = revert ? encryptor.decrypt(property) : encryptor.encrypt(property);
+            if (property != null) {
+                if (isEncrypted(value)) {
+                    property = revert ? encryptor.decrypt(property) : encryptor.encrypt(property);
+                }
+                processed.put(key, property);
             }
-            processed.put(key, property);
         }
         return processed;
     }
@@ -100,10 +101,7 @@ public class CredentialDefinitionService {
 
     private String getProperty(Map<String, Object> properties, String key) {
         Object value = properties.get(key);
-        if (value == null) {
-            throw new MissingParameterException(String.format("Missing '%s' property!", key));
-        }
-        return String.valueOf(value);
+        return value == null ? null : String.valueOf(value);
     }
 
 }

--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/AwsCredentialCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/AwsCredentialCreationTest.java
@@ -16,27 +16,35 @@ import com.sequenceiq.it.util.ResourceUtil;
 public class AwsCredentialCreationTest extends AbstractCloudbreakIntegrationTest {
     @Value("${integrationtest.awscredential.name}")
     private String defaultName;
-    @Value("${integrationtest.awscredential.roleArn}")
+    @Value("${integrationtest.awscredential.roleArn:}")
     private String defaultRoleArn;
+    @Value("${integrationtest.awscredential.accessKey:}")
+    private String defaultAccessKey;
+    @Value("${integrationtest.awscredential.secretKey:}")
+    private String defaultSecretKey;
     @Value("${integrationtest.awscredential.publicKeyFile}")
     private String defaultPublicKeyFile;
 
     @Test
-    @Parameters({ "credentialName", "roleArn", "publicKeyFile" })
+    @Parameters({ "credentialName", "roleArn", "accessKey", "secretKey", "publicKeyFile" })
     public void testAwsCredentialCreation(@Optional("") String credentialName, @Optional("") String roleArn,
-            @Optional("") String publicKeyFile) throws Exception {
+            @Optional("") String accessKey, @Optional("") String secretKey, @Optional("") String publicKeyFile) throws Exception {
         // GIVEN
         credentialName = StringUtils.hasLength(credentialName) ? credentialName : defaultName;
         roleArn = StringUtils.hasLength(roleArn) ? roleArn : defaultRoleArn;
+        accessKey = StringUtils.hasLength(accessKey) ? accessKey : defaultAccessKey;
+        secretKey = StringUtils.hasLength(secretKey) ? secretKey : defaultSecretKey;
         publicKeyFile = StringUtils.hasLength(publicKeyFile) ? publicKeyFile : defaultPublicKeyFile;
         String publicKey = ResourceUtil.readStringFromResource(applicationContext, publicKeyFile).replaceAll("\n", "");
         // TODO publicInAccount
         CredentialRequest credentialRequest = new CredentialRequest();
         credentialRequest.setName(credentialName);
         credentialRequest.setPublicKey(publicKey);
-        credentialRequest.setDescription("Aws Rm credential for integartiontest");
+        credentialRequest.setDescription("Aws credential for integrationtest");
         Map<String, Object> map = new HashMap<>();
         map.put("roleArn", roleArn);
+        map.put("accessKey", accessKey);
+        map.put("secretKey", secretKey);
         credentialRequest.setParameters(map);
         credentialRequest.setCloudPlatform("AWS");
         // WHEN

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -32,6 +32,8 @@ integrationtest:
     awscredential:
        name:
        roleArn:
+       accessKey:
+       secretKey:
        publicKeyFile:
 
     # openstack credential details

--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/CredentialCommands.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/CredentialCommands.java
@@ -254,7 +254,10 @@ public class CredentialCommands implements CommandMarker {
             help = "Create a new AWS credential")
     public String createAwsCredential(
             @CliOption(key = "name", mandatory = true, help = "Name of the credential") String name,
-            @CliOption(key = "roleArn", mandatory = true, help = "roleArn of the credential") String roleArn,
+            @CliOption(key = "roleArn", mandatory = false,
+                    help = "roleArn for assuming roles or use access and secret based authentication") String roleArn,
+            @CliOption(key = "accessKey", mandatory = false, help = "accessKey of the credential") String accessKey,
+            @CliOption(key = "secretKey", mandatory = false, help = "secretKey of the credential") String secretKey,
             @CliOption(key = "sshKeyPath", mandatory = false, help = "path of a public SSH key file") File sshKeyPath,
             @CliOption(key = "sshKeyUrl", mandatory = false, help = "URL of a public SSH key file") String sshKeyUrl,
             @CliOption(key = "sshKeyString", mandatory = false, help = "Raw data of a public SSH key file") String sshKeyString,
@@ -262,7 +265,7 @@ public class CredentialCommands implements CommandMarker {
             @CliOption(key = "description", mandatory = false, help = "Description of the template") String description,
             @CliOption(key = "platformId", mandatory = false, help = "Id of a platform the credential belongs to") Long platformId
     ) {
-        return createEc2Credential(name, roleArn, sshKeyPath, sshKeyUrl, sshKeyString, publicInAccount, description, platformId);
+        return createEc2Credential(name, roleArn, accessKey, secretKey, sshKeyPath, sshKeyUrl, sshKeyString, publicInAccount, description, platformId);
     }
 
 
@@ -270,7 +273,10 @@ public class CredentialCommands implements CommandMarker {
             help = "Create a new AWS credential ('credential create --EC2' is deprecated will be removed soon)")
     public String createEc2Credential(
             @CliOption(key = "name", mandatory = true, help = "Name of the credential") String name,
-            @CliOption(key = "roleArn", mandatory = true, help = "roleArn of the credential") String roleArn,
+            @CliOption(key = "roleArn", mandatory = false,
+                    help = "roleArn for assuming roles or use access and secret based authentication") String roleArn,
+            @CliOption(key = "accessKey", mandatory = false, help = "accessKey of the credential") String accessKey,
+            @CliOption(key = "secretKey", mandatory = false, help = "secretKey of the credential") String secretKey,
             @CliOption(key = "sshKeyPath", mandatory = false, help = "path of a public SSH key file") File sshKeyPath,
             @CliOption(key = "sshKeyUrl", mandatory = false, help = "URL of a public SSH key file") String sshKeyUrl,
             @CliOption(key = "sshKeyString", mandatory = false, help = "Raw data of a public SSH key file") String sshKeyString,
@@ -306,7 +312,14 @@ public class CredentialCommands implements CommandMarker {
             credentialRequest.setPublicKey(sshKey);
 
             Map<String, Object> parameters = new HashMap<>();
-            parameters.put("roleArn", roleArn);
+            if (roleArn != null) {
+                parameters.put("roleArn", roleArn);
+            } else if (accessKey != null && secretKey != null) {
+                parameters.put("accessKey", accessKey);
+                parameters.put("secretKey", secretKey);
+            } else {
+                return "Please specify the roleArn or both the access and secret key";
+            }
 
             credentialRequest.setParameters(parameters);
             if (platformId != null) {
@@ -328,7 +341,6 @@ public class CredentialCommands implements CommandMarker {
             throw exceptionTransformer.transformToRuntimeException(ex);
         }
     }
-
 
 
     @CliCommand(value = "credential create --GCP", help = "Create a new Gcp credential")


### PR DESCRIPTION
@akanto @doktoric 

@schfeca75 for IT

keys are encrypted in the db

there is no switch to choose auth form both role and key based are supported

it's not really a good idea to limit to one as existing clusters with previous credentials might fail

on the UI we can make it configurable to only create one type of them