### PR TITLE
get the gradle build sub-second

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -164,25 +164,26 @@ buildscript {
   }
 }
 
-apply plugin: 'org.ajoberstar.release-opinion'
+if (project.hasProperty("release.stage")) {
+  apply plugin: 'org.ajoberstar.release-opinion'
 
-release {
-  grgit = Grgit.open(project.file('.'))
+  release {
+    grgit = Grgit.open(project.file('.'))
 
-  VersionStrategies versionStrategies = new VersionStrategies(grgit)
+    VersionStrategies versionStrategies = new VersionStrategies(grgit)
 
-  versionStrategy versionStrategies.FINAL
-  versionStrategy versionStrategies.RC
-  versionStrategy versionStrategies.FEATURE_BRANCH
-  versionStrategy versionStrategies.DEV
+    versionStrategy versionStrategies.FINAL
+    versionStrategy versionStrategies.RC
+    versionStrategy versionStrategies.FEATURE_BRANCH
+    versionStrategy versionStrategies.DEV
 
-  defaultVersionStrategy = versionStrategies.FEATURE_BRANCH
+    defaultVersionStrategy = versionStrategies.FEATURE_BRANCH
 
-  tagStrategy {
-    prefixNameWithV = false
+    tagStrategy {
+      prefixNameWithV = false
+    }
   }
 }
-
 def env = project.hasProperty('env') ? project.getProperty('env') : 'local'
 ext.config = new ConfigSlurper(env).parse(file("$rootDir/gradle/config/buildConfig.groovy").toURL())
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,5 @@
 org.gradle.parallel=true
+org.gradle.configureondemand=true
 
 ambariClientName=ambari-client22
 ambariClientVersion=2.2.8

--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -12,7 +12,7 @@ jar {
   baseName = 'cloudbreak-shell'
   manifest {
     attributes("Implementation-Title": "Gradle",
-            "Implementation-Version": version)
+            "Implementation-Version": "${version ?:'dev'}")
   }
 }
 


### PR DESCRIPTION
with this PR applied:

```
$ gradle :cloud-common:build

Parallel execution with configuration on demand is an incubating feature.
:cloud-common:compileJava UP-TO-DATE
:cloud-common:processResources UP-TO-DATE
:cloud-common:classes UP-TO-DATE
:cloud-common:jar UP-TO-DATE
:cloud-common:assemble UP-TO-DATE
:cloud-common:checkstyleMain UP-TO-DATE
:cloud-common:compileTestJava UP-TO-DATE
:cloud-common:processTestResources UP-TO-DATE
:cloud-common:testClasses UP-TO-DATE
:cloud-common:checkstyleTest UP-TO-DATE
:cloud-common:test UP-TO-DATE
:cloud-common:check UP-TO-DATE
:cloud-common:build UP-TO-DATE

BUILD SUCCESSFUL

Total time: 0.835 secs

```