### PR TITLE
CLOUD-52281: Add sensible default hostname

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+spring:
+  cloud:
+    consul:
+      host: consul.service.consul
 cb:
   threadpool:
     core.size: 40


### PR DESCRIPTION
This default value can be used as "fixed" on all environments. On cbd deployments docker takes, care, For local dev, you can:
- configure `/etc/hots`file
- configure `/etc/resolver/service.consul `

## hotst file
use the `docker-machine ip` or `boot2docker ip` for actual ip
```
192.168.59.103 consul.service.consul
```

## osx resolver

use the `docker-machine ip` or `boot2docker ip` for actual ip
```
cat >  /etc/resolver/service.consul <<EOF
nameserver 192.168.59.103
EOF
```
