### PR TITLE
CLOUD-52916: add reference to all images, so cloudbreak-images can use this a "source of truth"

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -69,6 +69,11 @@ cb:
       ldap: sequenceiq/docker-ldap:1.0
       shipyard: shipyard/shipyard:v3.0.0
       shipyard.db: rethinkdb:2.2.4
+      certs: ehazlett/cert-tool:0.0.3
+      alpine: gliderlabs/alpine:3.1
+      consul: gliderlabs/consul:0.6
+      gateway: sequenceiq/cb-gateway-nginx:0.3
+      swarm: swarm:1.1.0
     env:
       ldap: SLAPD_PASSWORD=cloudbreak|SLAPD_BINDUSER=ambari-qa|SLAPD_BINDPWD=cloudbreak|SLAPD_BINDGROUP=hadoop
       shipyard.enabled: true


### PR DESCRIPTION
@akanto,@keyki pls

We should avoid keeping 2 yaml (one in cloudbreak,  one in cloudbreak-images) to list docker images we need on the cloud-images.

cloudbreak-image should use application.yml from cloud-common, and remoce vars-docker-images.yml