### PR TITLE
CLOUD-53668 fixed ssh username

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToCredentialConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToCredentialConverter.java
@@ -57,7 +57,8 @@ public class JsonToCredentialConverter extends AbstractConversionServiceAwareCon
     private void setUserName(Credential credential, Map<String, Object> parameters) {
         if (parameters.containsKey("keystoneVersion")) {
             credential.setLoginUserName(SSH_USER_CENT);
-        } else if (parameters.containsKey("roleArn") || (parameters.containsKey("accessKey") && parameters.containsKey("secretKey"))) {
+        } else if (parameters.containsKey("roleArn")
+                || (parameters.containsKey("accessKey") && parameters.containsKey("secretKey") && !parameters.containsKey("subscriptionId"))) {
             credential.setLoginUserName(SSH_USER_EC2);
         } else {
             credential.setLoginUserName(SSH_USER_CB);


### PR DESCRIPTION
@akanto when you create a new azure credential the json contains accessKey and secretKey like in case of aws which cause that the login username will be ec2-user on azure.