### PR TITLE
CLOUD-53432 workaround for missing hive keytab

### DIFF
--- a/core/src/main/resources/hdp/hive-kerberos-descriptor.json
+++ b/core/src/main/resources/hdp/hive-kerberos-descriptor.json
@@ -1,0 +1,51 @@
+{
+  "kerberos_descriptor": {
+    "services": [
+      {
+        "name": "HIVE",
+        "components": [
+          {
+            "name": "HIVE_METASTORE",
+            "identities": [
+              {
+                "name": "hive_metastore_hive",
+                "keytab": {
+                  "file": "${keytab_dir}/hive2.service.keytab",
+                  "owner": {
+                    "name": "${hive-env/hive_user}",
+                    "access": "r"
+                  },
+                  "group": {
+                    "name": "${cluster-env/user_group}",
+                    "access": ""
+                  },
+                  "configuration": "hive-site/hive.metastore.kerberos.keytab.file"
+                }
+              }
+            ]
+          },
+          {
+            "name": "HIVE_SERVER",
+            "identities": [
+              {
+                "name": "hive_server_hive",
+                "keytab": {
+                  "file": "${keytab_dir}/hive2.service.keytab",
+                  "owner": {
+                    "name": "${hive-env/hive_user}",
+                    "access": "r"
+                  },
+                  "group": {
+                    "name": "${cluster-env/user_group}",
+                    "access": ""
+                  },
+                  "configuration": "hive-site/hive.server2.authentication.kerberos.keytab"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
@akanto in secure cluster if stack advisor used we extend the bp with a kerberos descriptor if there is no user specified