### PR TITLE
CLOUD-49027 fix onclick event

### DIFF
--- a/web/app/static/partials/dashboard.html
+++ b/web/app/static/partials/dashboard.html
@@ -102,8 +102,8 @@
                 </div>
 
                 <!-- create cluster button -->
-                <div class="col-sm-3 col-xs-2" ng-if="isWriteScope('stacks', userDetails.groups)">
-                    <button id="create-cluster-btn" ng-disabled="activeCredential === undefined && activeStack === undefined" class="btn btn-success btn-block btn-collapse-title" role="button">
+                <div class="col-sm-3 col-xs-2">
+                    <button id="create-cluster-btn" ng-disabled="!isWriteScope('stacks', userDetails.groups) || (activeCredential === undefined && activeStack === undefined)" class="btn btn-success btn-block btn-collapse-title" role="button">
                         <i class="fa fa-plus fa-fw"></i>
                         <span> {{msg.dashboard_create_cluster_label}}</span>
                     </button>


### PR DESCRIPTION
@mhmxs 

isWriteScope takes a while to finish while the page renders in the background and tries to hook a click event on the cluster-create button, but it's not there yet because of the isWriteScope hasn't finished yet

this PR changes that even if you don't have write permission the button is still visible but you cannot click it