### PR TITLE
CLOUD-55167 use the provided public network id for allocation floatin…

### DIFF
--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpCredentialConnector.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/GcpCredentialConnector.java
@@ -37,7 +37,7 @@ public class GcpCredentialConnector implements CredentialConnector {
     @Override
     public CloudCredentialStatus verify(AuthenticatedContext authenticatedContext) {
         LOGGER.info("Verify credential: {}", authenticatedContext.getCloudCredential());
-        GcpContext gcpContext = gcpContextBuilder.contextInit(authenticatedContext.getCloudContext(), authenticatedContext, null, false);
+        GcpContext gcpContext = gcpContextBuilder.contextInit(authenticatedContext.getCloudContext(), authenticatedContext, null, null, false);
         try {
             Compute compute = gcpContext.getCompute();
             if (compute == null) {

--- a/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/context/GcpContextBuilder.java
+++ b/cloud-gcp/src/main/java/com/sequenceiq/cloudbreak/cloud/gcp/context/GcpContextBuilder.java
@@ -12,6 +12,7 @@ import com.sequenceiq.cloudbreak.cloud.gcp.util.GcpStackUtil;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.Location;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.template.ResourceContextBuilder;
@@ -22,7 +23,7 @@ public class GcpContextBuilder implements ResourceContextBuilder<GcpContext> {
     public static final int PARALLEL_RESOURCE_REQUEST = 30;
 
     @Override
-    public GcpContext contextInit(CloudContext context, AuthenticatedContext auth, List<CloudResource> resources, boolean build) {
+    public GcpContext contextInit(CloudContext context, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build) {
         CloudCredential credential = auth.getCloudCredential();
         String projectId = GcpStackUtil.getProjectId(credential);
         Compute compute = GcpStackUtil.buildCompute(credential);

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackConstants.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/common/OpenStackConstants.java
@@ -17,6 +17,7 @@ public class OpenStackConstants {
     public static final String PORT_ID = "portId";
     public static final String SERVER = "server";
     public static final String FLOATING_IP_IDS = "floatingIpIds";
+    public static final String PUBLIC_NET_ID = "publicNetId";
 
     private OpenStackConstants() {
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/compute/OpenStackFloatingIPBuilder.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/compute/OpenStackFloatingIPBuilder.java
@@ -29,8 +29,8 @@ public class OpenStackFloatingIPBuilder extends AbstractOpenStackComputeResource
             OSClient osClient = createOSClient(auth);
             List<CloudResource> computeResources = context.getComputeResources(privateId);
             CloudResource instance = getInstance(computeResources);
-            String pool = osClient.compute().floatingIps().getPoolNames().get(0);
-            FloatingIP unusedIp = osClient.compute().floatingIps().allocateIP(pool);
+            String publicNetId = context.getStringParameter(OpenStackConstants.PUBLIC_NET_ID);
+            FloatingIP unusedIp = osClient.compute().floatingIps().allocateIP(publicNetId);
             ActionResponse response = osClient.compute().floatingIps().addFloatingIP(instance.getParameter(OpenStackConstants.SERVER, Server.class),
                     unusedIp.getFloatingIpAddress());
             if (!response.isSuccess()) {

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/context/OpenStackContextBuilder.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/nativ/context/OpenStackContextBuilder.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.model.Platform;
 import com.sequenceiq.cloudbreak.cloud.model.Variant;
 import com.sequenceiq.cloudbreak.cloud.openstack.auth.OpenStackClient;
@@ -31,7 +32,7 @@ public class OpenStackContextBuilder implements ResourceContextBuilder<OpenStack
     private OpenStackClient openStackClient;
 
     @Override
-    public OpenStackContext contextInit(CloudContext cloudContext, AuthenticatedContext auth, List<CloudResource> resources, boolean build) {
+    public OpenStackContext contextInit(CloudContext cloudContext, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build) {
         OSClient osClient = openStackClient.createOSClient(auth);
         KeystoneCredentialView credentialView = new KeystoneCredentialView(auth);
 
@@ -58,6 +59,9 @@ public class OpenStackContextBuilder implements ResourceContextBuilder<OpenStack
             }
         }
         openStackContext.putParameter(OpenStackConstants.FLOATING_IP_IDS, Collections.synchronizedList(new ArrayList<String>()));
+        if (network != null) {
+            openStackContext.putParameter(OpenStackConstants.PUBLIC_NET_ID, network.getStringParameter(OpenStackConstants.PUBLIC_NET_ID));
+        }
 
         return openStackContext;
     }

--- a/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/NeutronNetworkView.java
+++ b/cloud-openstack/src/main/java/com/sequenceiq/cloudbreak/cloud/openstack/view/NeutronNetworkView.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.openstack.view;
 
 import com.sequenceiq.cloudbreak.cloud.model.Network;
+import com.sequenceiq.cloudbreak.cloud.openstack.common.OpenStackConstants;
 
 public class NeutronNetworkView {
 
@@ -15,7 +16,7 @@ public class NeutronNetworkView {
     }
 
     public String getPublicNetId() {
-        return network.getParameter("publicNetId", String.class);
+        return network.getParameter(OpenStackConstants.PUBLIC_NET_ID, String.class);
     }
 
 }

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractInstanceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractInstanceConnector.java
@@ -32,7 +32,7 @@ public abstract class AbstractInstanceConnector implements InstanceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, resources, false);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, null, resources, false);
 
         //compute
         return computeResourceService.stopInstances(context, ac, resources, vms);
@@ -44,7 +44,7 @@ public abstract class AbstractInstanceConnector implements InstanceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, resources, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, ac, null, resources, true);
 
         //compute
         return computeResourceService.startInstances(context, ac, resources, vms);

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/AbstractResourceConnector.java
@@ -49,7 +49,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, null, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), null, true);
 
         //network
         List<CloudResourceStatus> networkStatuses = networkResourceService.buildResources(context, auth, stack.getNetwork(), stack.getSecurity());
@@ -69,7 +69,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, cloudResources, false);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), cloudResources, false);
 
         //compute
         List<CloudResourceStatus> computeStatuses = computeResourceService.deleteResources(context, auth, cloudResources, false);
@@ -87,7 +87,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, resources, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, true);
 
         //network
         context.addNetworkResources(networkResourceService.getNetworkResources(platform, resources));
@@ -105,7 +105,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, resources, false);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, false);
 
         //compute
         //TODO we should somehow group the corresponding resources together
@@ -119,7 +119,7 @@ public abstract class AbstractResourceConnector implements ResourceConnector {
         Platform platform = cloudContext.getPlatform();
 
         //context
-        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, resources, true);
+        ResourceBuilderContext context = contextBuilders.get(platform).contextInit(cloudContext, auth, stack.getNetwork(), resources, true);
 
         //network
         List<CloudResource> networkResources = networkResourceService.getNetworkResources(platform, resources);

--- a/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/ResourceContextBuilder.java
+++ b/cloud-template/src/main/java/com/sequenceiq/cloudbreak/cloud/template/ResourceContextBuilder.java
@@ -6,6 +6,7 @@ import com.sequenceiq.cloudbreak.cloud.CloudPlatformAware;
 import com.sequenceiq.cloudbreak.cloud.context.AuthenticatedContext;
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
+import com.sequenceiq.cloudbreak.cloud.model.Network;
 import com.sequenceiq.cloudbreak.cloud.template.context.ResourceBuilderContext;
 
 /**
@@ -21,10 +22,11 @@ public interface ResourceContextBuilder<C extends ResourceBuilderContext> extend
      *
      * @param cloudContext Context for the specific cloud stack.
      * @param auth         Authenticated context is provided to be able to send the requests to the cloud provider.
+     * @param network      Network can provide extra information during compute resource creation time
      * @param resources    The context can be initialized with base resources.
      * @param build        Provides a simple boolean flag used to determine creation/deletion or stop/start
      * @return Returns the initialized context object.
      */
-    C contextInit(CloudContext cloudContext, AuthenticatedContext auth, List<CloudResource> resources, boolean build);
+    C contextInit(CloudContext cloudContext, AuthenticatedContext auth, Network network, List<CloudResource> resources, boolean build);
 
 }


### PR DESCRIPTION
…g ips

@akanto 

Currently this is in use: ```String pool = osClient.compute().floatingIps().getPoolNames().get(0);``` which can be different if there are many pools.