### PR TITLE
CLOUD-56572: stack create command doesn't work: 'region' parameter is missing

### DIFF
--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/base/BaseStackCommands.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/base/BaseStackCommands.java
@@ -250,6 +250,7 @@ public class BaseStackCommands implements BaseCommands, StackCommands {
             IdJson id;
             StackRequest stackRequest = new StackRequest();
             stackRequest.setName(name);
+            stackRequest.setRegion(region.getName());
             stackRequest.setRelocateDocker(relocateDocker);
             if (availabilityZone != null) {
                 stackRequest.setAvailabilityZone(availabilityZone.getName());


### PR DESCRIPTION
@doktoric pls review
