### PR TITLE
CLOUD-55843 fix dependencies between ASG and IGW

### DIFF
--- a/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
+++ b/cloud-aws/src/main/resources/templates/aws-cf-stack.ftl
@@ -235,7 +235,7 @@
 	"AmbariNodes${group.groupName?replace('_', '')}" : {
       "Type" : "AWS::AutoScaling::AutoScalingGroup",
       <#if !existingSubnet>
-      "DependsOn" : "PublicSubnet",
+      "DependsOn" : [ "PublicSubnetRouteTableAssociation", "PublicRoute" ],
       </#if>
       "Properties" : {
         <#if !existingSubnet>


### PR DESCRIPTION
@biharitomi 

When deleting the CF stack, the delete of the DetachGateway resource can start while the AutoScalingGroup is still being deleted. Probably this was causing problems when it happened before the instances in the group still had mapped public addresses.

With this fix the route tables and gateway attachments will only be deleted after the ASG is deleted.