### PR TITLE
CLOUD-57293: Error handling improvement on new flow

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/ChainFlow.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/ChainFlow.java
@@ -18,6 +18,21 @@ public abstract class ChainFlow implements Flow, Chainable {
     }
 
     @Override
+    public String getFlowId() {
+        return actFlow.getFlowId();
+    }
+
+    @Override
+    public void setFlowFailed() {
+        actFlow.setFlowFailed();
+    }
+
+    @Override
+    public boolean isFlowFailed() {
+        return actFlow.isFlowFailed();
+    }
+
+    @Override
     public void sendEvent(String key, Object object) {
         actFlow.sendEvent(key, object);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/Flow.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/Flow.java
@@ -4,4 +4,7 @@ public interface Flow {
     void initialize();
     void sendEvent(String key, Object object);
     FlowState getCurrentState();
+    String getFlowId();
+    void setFlowFailed();
+    boolean isFlowFailed();
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/FlowAdapter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/FlowAdapter.java
@@ -12,6 +12,7 @@ public class FlowAdapter<S extends FlowState, E> implements Flow {
     private final StateConverter<S> stateConverter;
     private final EventConverter<E> eventConverter;
     private final MessageFactory<E> messageFactory;
+    private boolean flowFailed;
 
     public FlowAdapter(String flowId, StateMachine<S, E> flowMachine, MessageFactory<E> messageFactory, StateConverter<S> stateConverter,
             EventConverter<E> eventConverter) {
@@ -42,5 +43,20 @@ public class FlowAdapter<S extends FlowState, E> implements Flow {
 
     public void sendEvent(String key, Object object) {
         flowMachine.sendEvent(messageFactory.createMessage(flowId, eventConverter.convert(key), object));
+    }
+
+    @Override
+    public String getFlowId() {
+        return flowId;
+    }
+
+    @Override
+    public void setFlowFailed() {
+        this.flowFailed = true;
+    }
+
+    @Override
+    public boolean isFlowFailed() {
+        return flowFailed;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/FlowFinalizeAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/FlowFinalizeAction.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.statemachine.StateContext;
 import org.springframework.stereotype.Component;
@@ -15,8 +16,7 @@ public final class FlowFinalizeAction extends AbstractAction<FlowState, FlowEven
     }
 
     @Override
-    protected CommonContext createFlowContext(StateContext<FlowState, FlowEvent> stateContext, Payload payload) {
-        String flowId = (String) stateContext.getMessageHeader(MessageFactory.HEADERS.FLOW_ID.name());
+    protected CommonContext createFlowContext(String flowId, StateContext<FlowState, FlowEvent> stateContext, Payload payload) {
         return new CommonContext(flowId);
     }
 
@@ -31,7 +31,7 @@ public final class FlowFinalizeAction extends AbstractAction<FlowState, FlowEven
     }
 
     @Override
-    protected Object getFailurePayload(CommonContext flowContext, Exception ex) {
+    protected Object getFailurePayload(Payload payload, Optional<CommonContext> flowContext, Exception ex) {
         return null;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/FlowRegister.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/FlowRegister.java
@@ -1,0 +1,23 @@
+package com.sequenceiq.cloudbreak.core.flow2;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class FlowRegister {
+    private Map<String, Flow> runningFlows = new ConcurrentHashMap<>();
+
+    public void put(Flow flow) {
+        runningFlows.put(flow.getFlowId(), flow);
+    }
+
+    public Flow get(String flowId) {
+        return runningFlows.get(flowId);
+    }
+
+    public Flow remove(String flowId) {
+        return runningFlows.remove(flowId);
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/AbstractClusterTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/AbstractClusterTerminationAction.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.cluster.termination;
 
+import java.util.Optional;
+
 import javax.inject.Inject;
 
 import org.springframework.statemachine.StateContext;
@@ -7,7 +9,6 @@ import org.springframework.statemachine.StateContext;
 import com.sequenceiq.cloudbreak.cloud.event.ClusterPayload;
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
 import com.sequenceiq.cloudbreak.core.flow2.AbstractAction;
-import com.sequenceiq.cloudbreak.core.flow2.MessageFactory;
 import com.sequenceiq.cloudbreak.domain.Cluster;
 import com.sequenceiq.cloudbreak.service.cluster.ClusterService;
 
@@ -22,14 +23,13 @@ abstract class AbstractClusterTerminationAction<P extends ClusterPayload>
     }
 
     @Override
-    protected ClusterContext createFlowContext(StateContext<ClusterTerminationState, ClusterTerminationEvent> stateContext, P payload) {
-        String flowId = (String) stateContext.getMessageHeader(MessageFactory.HEADERS.FLOW_ID.name());
+    protected ClusterContext createFlowContext(String flowId, StateContext<ClusterTerminationState, ClusterTerminationEvent> stateContext, P payload) {
         Cluster cluster = clusterService.getById(payload.getClusterId());
         return new ClusterContext(flowId, cluster);
     }
 
     @Override
-    protected Object getFailurePayload(ClusterContext flowContext, Exception ex) {
+    protected Object getFailurePayload(P payload, Optional<ClusterContext> flowContext, Exception ex) {
         return null;
     }
 
@@ -37,5 +37,4 @@ abstract class AbstractClusterTerminationAction<P extends ClusterPayload>
     protected Selectable createRequest(ClusterContext context) {
         return null;
     }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationFlowConfig.java
@@ -24,13 +24,13 @@ public class ClusterTerminationFlowConfig extends AbstractFlowConfiguration<Clus
     private static final List<Transition<ClusterTerminationState, ClusterTerminationEvent>> TRANSITIONS =
             new Transition.Builder<ClusterTerminationState, ClusterTerminationEvent>()
                     .defaultFailureEvent(TERMINATION_FAILED_EVENT)
-                    .from(INIT_STATE).to(TERMINATION_STATE).event(TERMINATION_EVENT).defaultFailureEvent()
+                    .from(INIT_STATE).to(TERMINATION_STATE).event(TERMINATION_EVENT).noFailureEvent()
                     .from(TERMINATION_STATE).to(TERMINATION_FINISHED_STATE).event(TERMINATION_FINISHED_EVENT).defaultFailureEvent()
+                    .from(TERMINATION_FINISHED_STATE).to(FINAL_STATE).event(TERMINATION_FINALIZED_EVENT).defaultFailureEvent()
                     .build();
 
     private static final FlowEdgeConfig<ClusterTerminationState, ClusterTerminationEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TERMINATION_FINISHED_STATE, TERMINATION_FINALIZED_EVENT, TERMINATION_FAILED_STATE,
-                    CLUSTER_TERMINATION_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TERMINATION_FAILED_STATE, CLUSTER_TERMINATION_FAIL_HANDLED_EVENT);
 
     public ClusterTerminationFlowConfig() {
         super(ClusterTerminationState.class, ClusterTerminationEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationFlowService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/termination/ClusterTerminationFlowService.java
@@ -67,5 +67,4 @@ public class ClusterTerminationFlowService {
             flowMessageService.fireEventAndLog(cluster.getStack().getId(), Msg.CLUSTER_EMAIL_SENT, DELETE_FAILED.name());
         }
     }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/cluster/upscale/ClusterUpscaleFlowConfig.java
@@ -48,30 +48,29 @@ public class ClusterUpscaleFlowConfig extends AbstractFlowConfiguration<ClusterU
     private static final List<Transition<ClusterUpscaleState, ClusterUpscaleEvent>> TRANSITIONS =
             new Transition.Builder<ClusterUpscaleState, ClusterUpscaleEvent>()
                 .defaultFailureEvent(FAILURE_EVENT)
-                .from(INIT_STATE).to(ADD_CLUSTER_CONTAINERS_STATE).event(ADD_CONTAINERS_EVENT)
-                    .failureEvent(ADD_CONTAINERS_FAILED_EVENT)
-                .from(ADD_CLUSTER_CONTAINERS_STATE).to(INSTALL_FS_RECIPES_STATE).event(ADD_CONTAINERS_FINISHED_EVENT)
-                    .failureEvent(INSTALL_FS_RECIPES_FAILED_EVENT)
+                .from(INIT_STATE).to(ADD_CLUSTER_CONTAINERS_STATE).event(ADD_CONTAINERS_EVENT).noFailureEvent()
+                .from(ADD_CLUSTER_CONTAINERS_STATE).to(INSTALL_FS_RECIPES_STATE).event(ADD_CONTAINERS_FINISHED_EVENT).failureEvent(ADD_CONTAINERS_FAILED_EVENT)
                 .from(INSTALL_FS_RECIPES_STATE).to(WAIT_FOR_AMBARI_HOSTS_STATE).event(INSTALL_FS_RECIPES_FINISHED_EVENT)
-                    .failureEvent(WAIT_FOR_AMBARI_HOSTS_FAILED_EVENT)
+                    .failureEvent(INSTALL_FS_RECIPES_FAILED_EVENT)
                 .from(WAIT_FOR_AMBARI_HOSTS_STATE).to(CONFIGURE_SSSD_STATE).event(WAIT_FOR_AMBARI_HOSTS_FINISHED_EVENT)
-                    .failureEvent(SSSD_CONFIG_FAILED_EVENT)
+                    .failureEvent(WAIT_FOR_AMBARI_HOSTS_FAILED_EVENT)
                 .from(CONFIGURE_SSSD_STATE).to(INSTALL_RECIPES_STATE).event(SSSD_CONFIG_FINISHED_EVENT)
-                    .failureEvent(INSTALL_RECIPES_FAILED_EVENT)
+                    .failureEvent(SSSD_CONFIG_FAILED_EVENT)
                 .from(INSTALL_RECIPES_STATE).to(EXECUTE_PRE_RECIPES_STATE).event(INSTALL_RECIPES_FINISHED_EVENT)
-                    .failureEvent(EXECUTE_PRE_RECIPES_FAILED_EVENT)
+                    .failureEvent(INSTALL_RECIPES_FAILED_EVENT)
                 .from(EXECUTE_PRE_RECIPES_STATE).to(INSTALL_SERVICES_STATE).event(EXECUTE_PRE_RECIPES_FINISHED_EVENT)
-                    .failureEvent(INSTALL_SERVICES_FAILED_EVENT)
+                    .failureEvent(EXECUTE_PRE_RECIPES_FAILED_EVENT)
                 .from(INSTALL_SERVICES_STATE).to(EXECUTE_POST_RECIPES_STATE).event(INSTALL_SERVICES_FINISHED_EVENT)
-                    .failureEvent(EXECUTE_POST_RECIPES_FAILED_EVENT)
+                    .failureEvent(INSTALL_SERVICES_FAILED_EVENT)
                 .from(EXECUTE_POST_RECIPES_STATE).to(UPDATE_METADATA_STATE).event(EXECUTE_POST_RECIPES_FINISHED_EVENT)
-                    .failureEvent(UPDATE_METADATA_FAILED_EVENT)
+                    .failureEvent(EXECUTE_POST_RECIPES_FAILED_EVENT)
                 .from(UPDATE_METADATA_STATE).to(FINALIZE_STATE).event(UPDATE_METADATA_FINISHED_EVENT)
-                    .defaultFailureEvent()
+                    .failureEvent(UPDATE_METADATA_FAILED_EVENT)
+                .from(FINALIZE_STATE).to(FINAL_STATE).event(FINALIZED_EVENT).defaultFailureEvent()
                 .build();
 
     private static final FlowEdgeConfig<ClusterUpscaleState, ClusterUpscaleEvent> EDGE_CONFIG = new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE,
-            FINALIZE_STATE, FINALIZED_EVENT, FAILED_STATE, FAIL_HANDLED_EVENT);
+            FAILED_STATE, FAIL_HANDLED_EVENT);
 
     public ClusterUpscaleFlowConfig() {
         super(ClusterUpscaleState.class, ClusterUpscaleEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/OfflineStateGenerator.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/config/OfflineStateGenerator.java
@@ -10,17 +10,22 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.AbstractApplicationContext;
+import org.springframework.statemachine.StateContext;
 import org.springframework.statemachine.StateMachine;
 import org.springframework.statemachine.transition.Transition;
 
+import com.sequenceiq.cloudbreak.cloud.event.Payload;
+import com.sequenceiq.cloudbreak.cloud.event.Selectable;
+import com.sequenceiq.cloudbreak.core.flow2.AbstractAction;
+import com.sequenceiq.cloudbreak.core.flow2.CommonContext;
 import com.sequenceiq.cloudbreak.core.flow2.Flow;
 import com.sequenceiq.cloudbreak.core.flow2.FlowEvent;
-import com.sequenceiq.cloudbreak.core.flow2.FlowFinalizeAction;
 import com.sequenceiq.cloudbreak.core.flow2.FlowState;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.termination.ClusterTerminationFlowConfig;
 import com.sequenceiq.cloudbreak.core.flow2.cluster.upscale.ClusterUpscaleFlowConfig;
@@ -148,7 +153,7 @@ public class OfflineStateGenerator {
 
         @Override
         public <T> T getBean(String name, Class<T> requiredType) throws BeansException {
-            return (T) new FlowFinalizeAction();
+            return (T) new CustomAction();
         }
 
         @Override
@@ -163,6 +168,36 @@ public class OfflineStateGenerator {
 
         @Override
         public ConfigurableListableBeanFactory getBeanFactory() {
+            return null;
+        }
+    }
+
+    static class CustomAction extends AbstractAction<FlowState, FlowEvent, CommonContext, Payload> {
+        CustomAction() {
+            super(Payload.class);
+        }
+
+        @Override
+        public void execute(StateContext<FlowState, FlowEvent> context) {
+        }
+
+        @Override
+        protected CommonContext createFlowContext(String flowId, StateContext<FlowState, FlowEvent> stateContext, Payload payload) {
+            return null;
+        }
+
+        @Override
+        protected void doExecute(CommonContext context, Payload payload, Map<Object, Object> variables) throws Exception {
+
+        }
+
+        @Override
+        protected Selectable createRequest(CommonContext context) {
+            return null;
+        }
+
+        @Override
+        protected Object getFailurePayload(Payload payload, Optional<CommonContext> flowContext, Exception ex) {
             return null;
         }
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/AbstractStackFailureAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/AbstractStackFailureAction.java
@@ -1,0 +1,48 @@
+package com.sequenceiq.cloudbreak.core.flow2.stack;
+
+import java.util.List;
+import java.util.Optional;
+
+import javax.inject.Inject;
+
+import org.springframework.statemachine.StateContext;
+
+import com.sequenceiq.cloudbreak.core.flow2.AbstractAction;
+import com.sequenceiq.cloudbreak.core.flow2.Flow;
+import com.sequenceiq.cloudbreak.core.flow2.FlowEvent;
+import com.sequenceiq.cloudbreak.core.flow2.FlowRegister;
+import com.sequenceiq.cloudbreak.core.flow2.FlowState;
+import com.sequenceiq.cloudbreak.core.flow2.PayloadConverter;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.logger.MDCBuilder;
+import com.sequenceiq.cloudbreak.service.stack.StackService;
+
+public abstract class AbstractStackFailureAction<S extends FlowState, E extends FlowEvent> extends AbstractAction<S, E, StackFailureContext, FlowFailureEvent> {
+    @Inject
+    private StackService stackService;
+    @Inject
+    private FlowRegister runningFlows;
+
+    protected AbstractStackFailureAction() {
+        super(FlowFailureEvent.class);
+    }
+
+    @Override
+    protected StackFailureContext createFlowContext(String flowId, StateContext<S, E> stateContext, FlowFailureEvent payload) {
+        Flow flow = runningFlows.get(flowId);
+        Stack stack = stackService.getById(payload.getStackId());
+        MDCBuilder.buildMdcContext(stack);
+        flow.setFlowFailed();
+        return new StackFailureContext(flowId, stack);
+    }
+
+    @Override
+    protected Object getFailurePayload(FlowFailureEvent payload, Optional<StackFailureContext> flowContext, Exception ex) {
+        return null;
+    }
+
+    @Override
+    protected void initPayloadConverterMap(List<PayloadConverter<FlowFailureEvent>> payloadConverters) {
+        payloadConverters.add(new CloudPlatformResponseToFlowFailureConverter());
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/Msg.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/Msg.java
@@ -16,6 +16,7 @@ public enum Msg {
     STACK_ADDING_INSTANCES("stack.adding.instances"),
     STACK_REMOVING_INSTANCE("stack.removing.instance"),
     STACK_REMOVING_INSTANCE_FINISHED("stack.removing.instance.finished"),
+    STACK_REMOVING_INSTANCE_FAILED("stack.removing.instance.failed"),
     STACK_METADATA_EXTEND("stack.metadata.extend"),
     STACK_BOOTSTRAP_NEW_NODES("stack.bootstrap.new.nodes"),
     STACK_UPSCALE_FINISHED("stack.upscale.finished"),

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/StackFailureContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/StackFailureContext.java
@@ -1,0 +1,17 @@
+package com.sequenceiq.cloudbreak.core.flow2.stack;
+
+import com.sequenceiq.cloudbreak.core.flow2.CommonContext;
+import com.sequenceiq.cloudbreak.domain.Stack;
+
+public class StackFailureContext  extends CommonContext {
+    private Stack stack;
+
+    public StackFailureContext(String flowId, Stack stack) {
+        super(flowId);
+        this.stack = stack;
+    }
+
+    public Stack getStack() {
+        return stack;
+    }
+}

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/downscale/StackDownscaleConfig.java
@@ -22,13 +22,13 @@ public class StackDownscaleConfig extends AbstractFlowConfiguration<StackDownsca
     private static final List<Transition<StackDownscaleState, StackDownscaleEvent>> TRANSITIONS =
             new Transition.Builder<StackDownscaleState, StackDownscaleEvent>()
                 .defaultFailureEvent(DOWNSCALE_FAILURE_EVENT)
-                .from(INIT_STATE).to(DOWNSCALE_STATE).event(DOWNSCALE_EVENT).defaultFailureEvent()
+                .from(INIT_STATE).to(DOWNSCALE_STATE).event(DOWNSCALE_EVENT).noFailureEvent()
                 .from(DOWNSCALE_STATE).to(DOWNSCALE_FINISHED_STATE).event(DOWNSCALE_FINISHED_EVENT).defaultFailureEvent()
+                .from(DOWNSCALE_FINISHED_STATE).to(FINAL_STATE).event(DOWNSCALE_FINALIZED_EVENT).defaultFailureEvent()
                 .build();
 
     private static final FlowEdgeConfig<StackDownscaleState, StackDownscaleEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, DOWNSCALE_FINISHED_STATE, DOWNSCALE_FINALIZED_EVENT,
-                    DOWNSCALE_FAILED_STATE, DOWNSCALE_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, DOWNSCALE_FAILED_STATE, DOWNSCALE_FAIL_HANDLED_EVENT);
 
     public StackDownscaleConfig() {
         super(StackDownscaleState.class, StackDownscaleEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationAction.java
@@ -1,6 +1,7 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.instance.termination;
 
 import java.util.Map;
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -32,7 +33,7 @@ public class InstanceTerminationAction extends AbstractInstanceTerminationAction
         } else {
             LOGGER.info("Couldn't remove instance '{}' because other delete in progress", context.getCloudInstance().getInstanceId());
             sendEvent(context.getFlowId(), InstanceTerminationEvent.TERMINATION_FAILED_EVENT.stringRepresentation(),
-                    getFailurePayload(context, new IllegalStateException("Other delete operation in progress.")));
+                    getFailurePayload(payload, Optional.ofNullable(context), new IllegalStateException("Other delete operation in progress.")));
         }
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationFailureAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationFailureAction.java
@@ -7,26 +7,24 @@ import javax.inject.Inject;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
-import com.sequenceiq.cloudbreak.cloud.event.resource.RemoveInstanceResult;
+import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
+import com.sequenceiq.cloudbreak.core.flow2.stack.FlowFailureEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.SelectableFlowStackEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
 
 @Component("InstanceTerminationFailureAction")
-public class InstanceTerminationFailureAction extends AbstractInstanceTerminationAction<RemoveInstanceResult> {
+public class InstanceTerminationFailureAction extends AbstractStackFailureAction<InstanceTerminationState, InstanceTerminationEvent> {
     @Inject
     private InstanceTerminationService instanceTerminationService;
 
-    public InstanceTerminationFailureAction() {
-        super(RemoveInstanceResult.class);
-    }
-
     @Override
-    protected void doExecute(InstanceTerminationContext context, RemoveInstanceResult payload, Map<Object, Object> variables) {
-        instanceTerminationService.handleInstanceTerminationError(context, payload);
+    protected void doExecute(StackFailureContext context, FlowFailureEvent payload, Map<Object, Object> variables) {
+        instanceTerminationService.handleInstanceTerminationError(context.getStack(), payload);
         sendEvent(context);
     }
 
     @Override
-    protected Selectable createRequest(InstanceTerminationContext context) {
+    protected Selectable createRequest(StackFailureContext context) {
         return new SelectableFlowStackEvent(context.getStack().getId(), InstanceTerminationEvent.TERMINATION_FAIL_HANDLED_EVENT.stringRepresentation());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationFlowConfig.java
@@ -23,13 +23,13 @@ public class InstanceTerminationFlowConfig extends AbstractFlowConfiguration<Ins
     private static final List<Transition<InstanceTerminationState, InstanceTerminationEvent>> TRANSITIONS =
             new Transition.Builder<InstanceTerminationState, InstanceTerminationEvent>()
                     .defaultFailureEvent(TERMINATION_FAILED_EVENT)
-                    .from(INIT_STATE).to(TERMINATION_STATE).event(TERMINATION_EVENT).defaultFailureEvent()
+                    .from(INIT_STATE).to(TERMINATION_STATE).event(TERMINATION_EVENT).noFailureEvent()
                     .from(TERMINATION_STATE).to(TERMINATION_FINISHED_STATE).event(TERMINATION_FINISHED_EVENT).defaultFailureEvent()
+                    .from(TERMINATION_FINISHED_STATE).to(FINAL_STATE).event(TERMINATION_FINALIZED_EVENT).defaultFailureEvent()
                     .build();
 
     private static final FlowEdgeConfig<InstanceTerminationState, InstanceTerminationEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TERMINATION_FINISHED_STATE, TERMINATION_FINALIZED_EVENT, TERMINATION_FAILED_STATE,
-                    TERMINATION_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TERMINATION_FAILED_STATE, TERMINATION_FAIL_HANDLED_EVENT);
 
     public InstanceTerminationFlowConfig() {
         super(InstanceTerminationState.class, InstanceTerminationEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationService.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import com.sequenceiq.cloudbreak.cloud.event.resource.RemoveInstanceResult;
 import com.sequenceiq.cloudbreak.common.type.HostMetadataState;
+import com.sequenceiq.cloudbreak.core.flow2.stack.FlowFailureEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.FlowMessageService;
 import com.sequenceiq.cloudbreak.core.flow2.stack.Msg;
 import com.sequenceiq.cloudbreak.domain.HostMetadata;
@@ -73,10 +74,10 @@ public class InstanceTerminationService {
         flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_REMOVING_INSTANCE_FINISHED, AVAILABLE.name());
     }
 
-    public void handleInstanceTerminationError(InstanceTerminationContext context, RemoveInstanceResult payload) {
-        LOGGER.error("Error during instance terminating flow:", payload.getErrorDetails());
-        Stack stack = context.getStack();
-        stackUpdater.updateStackStatus(stack.getId(), AVAILABLE, "Stack update failed. " + payload.getStatusReason());
-        flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_INFRASTRUCTURE_UPDATE_FAILED, AVAILABLE.name(), payload.getStatusReason());
+    public void handleInstanceTerminationError(Stack stack, FlowFailureEvent payload) {
+        Exception ex = payload.getException();
+        LOGGER.error("Error during instance terminating flow:", ex);
+        stackUpdater.updateStackStatus(stack.getId(), AVAILABLE, "Instance termination failed. " + ex.getMessage());
+        flowMessageService.fireEventAndLog(stack.getId(), Msg.STACK_REMOVING_INSTANCE_FAILED, AVAILABLE.name(), ex.getMessage());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/StackCreationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/StackCreationFlowConfig.java
@@ -1,13 +1,18 @@
 package com.sequenceiq.cloudbreak.core.flow2.stack.provision;
 
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.COLLECT_METADATA_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.COLLECT_METADATA_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.IMAGE_COPY_CHECK_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.IMAGE_COPY_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.IMAGE_COPY_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.IMAGE_PREPARATION_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.IMAGE_PREPARATION_FINISHED_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.LAUNCH_STACK_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.LAUNCH_STACK_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.SETUP_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.SETUP_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.SSHFINGERPRINTS_EVENT;
+import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.SSHFINGERPRINTS_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.STACK_CREATION_FAILED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.STACK_CREATION_FINISHED_EVENT;
 import static com.sequenceiq.cloudbreak.core.flow2.stack.provision.StackCreationEvent.START_CREATION_EVENT;
@@ -34,24 +39,22 @@ import com.sequenceiq.cloudbreak.core.flow2.config.AbstractFlowConfiguration;
 public class StackCreationFlowConfig extends AbstractFlowConfiguration<StackCreationState, StackCreationEvent> {
 
     private static final List<Transition<StackCreationState, StackCreationEvent>> TRANSITIONS = new Transition.Builder<StackCreationState, StackCreationEvent>()
-            .from(INIT_STATE).to(SETUP_STATE).event(START_CREATION_EVENT).failureEvent(SETUP_FAILED_EVENT)
-            .from(INIT_STATE).to(SETUP_STATE).event(START_STACKANDCLUSTER_CREATION_EVENT).failureEvent(SETUP_FAILED_EVENT)
-            .from(SETUP_STATE).to(IMAGESETUP_STATE).event(SETUP_FINISHED_EVENT).failureEvent(StackCreationEvent.IMAGE_PREPARATION_FAILED_EVENT)
-            .from(IMAGESETUP_STATE).to(IMAGE_CHECK_STATE).event(IMAGE_PREPARATION_FINISHED_EVENT).failureEvent(StackCreationEvent.IMAGE_COPY_FAILED_EVENT)
-            .from(IMAGE_CHECK_STATE).to(IMAGE_CHECK_STATE).event(IMAGE_COPY_CHECK_EVENT).failureEvent(StackCreationEvent.IMAGE_COPY_FAILED_EVENT)
-            .from(IMAGE_CHECK_STATE).to(START_PROVISIONING_STATE).event(IMAGE_COPY_FINISHED_EVENT).failureEvent(StackCreationEvent.LAUNCH_STACK_FAILED_EVENT)
-            .from(START_PROVISIONING_STATE).to(PROVISIONING_FINISHED_STATE)
-                    .event(LAUNCH_STACK_FINISHED_EVENT).failureEvent(StackCreationEvent.COLLECT_METADATA_FAILED_EVENT)
-            .from(PROVISIONING_FINISHED_STATE).to(COLLECTMETADATA_STATE)
-                    .event(COLLECT_METADATA_FINISHED_EVENT).failureEvent(StackCreationEvent.SSHFINGERPRINTS_FAILED_EVENT)
-            .from(COLLECTMETADATA_STATE).to(TLS_SETUP_STATE).event(SSHFINGERPRINTS_EVENT).failureEvent(StackCreationEvent.SSHFINGERPRINTS_FAILED_EVENT)
+            .from(INIT_STATE).to(SETUP_STATE).event(START_CREATION_EVENT).noFailureEvent()
+            .from(INIT_STATE).to(SETUP_STATE).event(START_STACKANDCLUSTER_CREATION_EVENT).noFailureEvent()
+            .from(SETUP_STATE).to(IMAGESETUP_STATE).event(SETUP_FINISHED_EVENT).failureEvent(SETUP_FAILED_EVENT)
+            .from(IMAGESETUP_STATE).to(IMAGE_CHECK_STATE).event(IMAGE_PREPARATION_FINISHED_EVENT).failureEvent(IMAGE_PREPARATION_FAILED_EVENT)
+            .from(IMAGE_CHECK_STATE).to(IMAGE_CHECK_STATE).event(IMAGE_COPY_CHECK_EVENT).failureEvent(IMAGE_COPY_FAILED_EVENT)
+            .from(IMAGE_CHECK_STATE).to(START_PROVISIONING_STATE).event(IMAGE_COPY_FINISHED_EVENT).failureEvent(IMAGE_COPY_FAILED_EVENT)
+            .from(START_PROVISIONING_STATE).to(PROVISIONING_FINISHED_STATE).event(LAUNCH_STACK_FINISHED_EVENT).failureEvent(LAUNCH_STACK_FAILED_EVENT)
+            .from(PROVISIONING_FINISHED_STATE).to(COLLECTMETADATA_STATE).event(COLLECT_METADATA_FINISHED_EVENT).failureEvent(COLLECT_METADATA_FAILED_EVENT)
+            .from(COLLECTMETADATA_STATE).to(TLS_SETUP_STATE).event(SSHFINGERPRINTS_EVENT).failureEvent(SSHFINGERPRINTS_FAILED_EVENT)
+            .from(TLS_SETUP_STATE).to(FINAL_STATE).event(STACK_CREATION_FINISHED_EVENT).failureEvent(STACK_CREATION_FAILED_EVENT)
             .build();
 
     private static final FlowEdgeConfig<StackCreationState, StackCreationEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TLS_SETUP_STATE, STACK_CREATION_FINISHED_EVENT, STACK_CREATION_FAILED_STATE,
-                    STACK_CREATION_FAILED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, STACK_CREATION_FAILED_STATE, STACK_CREATION_FAILED_EVENT);
 
-    private static final EnumSet<StackCreationEvent> OWNEVENTS = EnumSet.complementOf(EnumSet.of(StackCreationEvent.START_STACKANDCLUSTER_CREATION_EVENT));
+    private static final EnumSet<StackCreationEvent> OWNEVENTS = EnumSet.complementOf(EnumSet.of(START_STACKANDCLUSTER_CREATION_EVENT));
 
     public StackCreationFlowConfig() {
         super(StackCreationState.class, StackCreationEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/AbstractStackCreationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/AbstractStackCreationAction.java
@@ -3,7 +3,8 @@ package com.sequenceiq.cloudbreak.core.flow2.stack.provision.action;
 import static com.sequenceiq.cloudbreak.cloud.model.AvailabilityZone.availabilityZone;
 import static com.sequenceiq.cloudbreak.cloud.model.Location.location;
 import static com.sequenceiq.cloudbreak.cloud.model.Region.region;
-import static com.sequenceiq.cloudbreak.core.flow2.MessageFactory.HEADERS;
+
+import java.util.Optional;
 
 import javax.inject.Inject;
 
@@ -37,8 +38,7 @@ public abstract class AbstractStackCreationAction<P extends Payload> extends Abs
         super(payloadClass);
     }
 
-    protected StackContext createFlowContext(StateContext<StackCreationState, StackCreationEvent> stateContext, P payload) {
-        String flowId = (String) stateContext.getMessageHeader(HEADERS.FLOW_ID.name());
+    protected StackContext createFlowContext(String flowId, StateContext<StackCreationState, StackCreationEvent> stateContext, P payload) {
         Stack stack = stackService.getById(payload.getStackId());
         // TODO LogAspect!!
         MDCBuilder.buildMdcContext(stack);
@@ -51,8 +51,7 @@ public abstract class AbstractStackCreationAction<P extends Payload> extends Abs
     }
 
     @Override
-    protected Object getFailurePayload(StackContext flowContext, Exception ex) {
-        return new FlowFailureEvent(flowContext.getStack().getId(), ex);
+    protected Object getFailurePayload(P payload, Optional<StackContext> flowContext, Exception ex) {
+        return new FlowFailureEvent(payload.getStackId(), ex);
     }
-
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/CheckImageAction.java
@@ -12,8 +12,9 @@ import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
 import com.sequenceiq.cloudbreak.cloud.event.setup.CheckImageResult;
-import com.sequenceiq.cloudbreak.core.flow2.stack.FlowStackEvent;
+import com.sequenceiq.cloudbreak.core.flow.CloudbreakFlowException;
 import com.sequenceiq.cloudbreak.core.flow2.PayloadConverter;
+import com.sequenceiq.cloudbreak.core.flow2.stack.FlowStackEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.SelectableFlowStackEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.StackContext;
 import com.sequenceiq.cloudbreak.core.flow2.stack.provision.PrepareImageResultToFlowStackEventConverter;
@@ -53,7 +54,7 @@ public class CheckImageAction extends AbstractStackCreationAction<FlowStackEvent
                 int faultNum = getFaultNum(variables) + 1;
                 if (faultNum == FAULT_TOLERANCE) {
                     removeFaultNum(variables);
-                    sendEvent(context.getFlowId(), StackCreationEvent.IMAGE_COPY_FAILED_EVENT.stringRepresentation(), payload);
+                    throw new CloudbreakFlowException("Image copy failed.");
                 } else {
                     setFaultNum(variables, faultNum);
                     repeat(context);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/provision/action/StackCreationService.java
@@ -159,8 +159,7 @@ public class StackCreationService {
         return stackService.getById(stack.getId());
     }
 
-    public void handleStackCreationFailure(StackContext context, Exception errorDetails) {
-        final Stack stack = context.getStack();
+    public void handleStackCreationFailure(Stack stack, Exception errorDetails) {
         MDCBuilder.buildMdcContext(stack);
         LOGGER.error("Error during stack creation flow:", errorDetails);
         String errorReason = errorDetails == null ? "Unknown error" : errorDetails.getMessage();

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/start/StackStartFlowConfig.java
@@ -22,12 +22,13 @@ public class StackStartFlowConfig extends AbstractFlowConfiguration<StackStartSt
 
     private static final List<Transition<StackStartState, StackStartEvent>> TRANSITIONS = new Transition.Builder<StackStartState, StackStartEvent>()
             .defaultFailureEvent(START_FAILURE_EVENT)
-            .from(INIT_STATE).to(START_STATE).event(START_EVENT).defaultFailureEvent()
+            .from(INIT_STATE).to(START_STATE).event(START_EVENT).noFailureEvent()
             .from(START_STATE).to(START_FINISHED_STATE).event(START_FINISHED_EVENT).defaultFailureEvent()
+            .from(START_FINISHED_STATE).to(FINAL_STATE).event(START_FINALIZED_EVENT).defaultFailureEvent()
             .build();
 
     private static final FlowEdgeConfig<StackStartState, StackStartEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, START_FINISHED_STATE, START_FINALIZED_EVENT, START_FAILED_STATE, START_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, START_FAILED_STATE, START_FAIL_HANDLED_EVENT);
 
     public StackStartFlowConfig() {
         super(StackStartState.class, StackStartEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/stop/StackStopFlowConfig.java
@@ -21,12 +21,13 @@ public class StackStopFlowConfig extends AbstractFlowConfiguration<StackStopStat
 
     private static final List<Transition<StackStopState, StackStopEvent>> TRANSITIONS = new Transition.Builder<StackStopState, StackStopEvent>()
             .defaultFailureEvent(StackStopEvent.STOP_FAILURE_EVENT)
-            .from(INIT_STATE).to(STOP_STATE).event(STOP_EVENT).defaultFailureEvent()
+            .from(INIT_STATE).to(STOP_STATE).event(STOP_EVENT).noFailureEvent()
             .from(STOP_STATE).to(STOP_FINISHED_STATE).event(STOP_FINISHED_EVENT).defaultFailureEvent()
+            .from(STOP_FINISHED_STATE).to(FINAL_STATE).event(STOP_FINALIZED_EVENT).defaultFailureEvent()
             .build();
 
     private static final FlowEdgeConfig<StackStopState, StackStopEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, STOP_FINISHED_STATE, STOP_FINALIZED_EVENT, STOP_FAILED_STATE, STOP_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, STOP_FAILED_STATE, STOP_FAIL_HANDLED_EVENT);
 
     public StackStopFlowConfig() {
         super(StackStopState.class, StackStopEvent.class);

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/sync/StackSyncFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/sync/StackSyncFlowConfig.java
@@ -23,13 +23,14 @@ public class StackSyncFlowConfig extends AbstractFlowConfiguration<StackSyncStat
 
     private static final List<Transition<StackSyncState, StackSyncEvent>> TRANSITIONS = new Transition.Builder<StackSyncState, StackSyncEvent>()
             .defaultFailureEvent(StackSyncEvent.SYNC_FAILURE_EVENT)
-            .from(INIT_STATE).to(SYNC_STATE).event(SYNC_EVENT).defaultFailureEvent()
-            .from(INIT_STATE).to(SYNC_STATE).event(FULL_SYNC_EVENT).defaultFailureEvent()
+            .from(INIT_STATE).to(SYNC_STATE).event(SYNC_EVENT).noFailureEvent()
+            .from(INIT_STATE).to(SYNC_STATE).event(FULL_SYNC_EVENT).noFailureEvent()
             .from(SYNC_STATE).to(SYNC_FINISHED_STATE).event(SYNC_FINISHED_EVENT).defaultFailureEvent()
+            .from(SYNC_FINISHED_STATE).to(FINAL_STATE).event(SYNC_FINALIZED_EVENT).defaultFailureEvent()
             .build();
 
     private static final FlowEdgeConfig<StackSyncState, StackSyncEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, SYNC_FINISHED_STATE, SYNC_FINALIZED_EVENT, SYNC_FAILED_STATE, SYNC_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, SYNC_FAILED_STATE, SYNC_FAIL_HANDLED_EVENT);
 
     private static final EnumSet<StackSyncEvent> EVENTS = EnumSet.complementOf(EnumSet.of(StackSyncEvent.FULL_SYNC_EVENT));
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackForceTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackForceTerminationAction.java
@@ -4,14 +4,10 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import com.sequenceiq.cloudbreak.core.flow.context.DefaultFlowContext;
-
 @Component("StackForceTerminationAction")
 public class StackForceTerminationAction extends StackTerminationAction {
-
     @Override
-    protected void doExecute(StackTerminationContext context, DefaultFlowContext payload, Map<Object, Object> variables) {
+    protected void prepareExecution(Map<Object, Object> variables) {
         variables.put("FORCEDTERMINATION", Boolean.TRUE);
-        doExecute(context);
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationFailureAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationFailureAction.java
@@ -9,27 +9,25 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 import com.sequenceiq.cloudbreak.cloud.event.Selectable;
-import com.sequenceiq.cloudbreak.cloud.event.resource.TerminateStackResult;
+import com.sequenceiq.cloudbreak.core.flow2.stack.AbstractStackFailureAction;
+import com.sequenceiq.cloudbreak.core.flow2.stack.FlowFailureEvent;
 import com.sequenceiq.cloudbreak.core.flow2.stack.SelectableFlowStackEvent;
+import com.sequenceiq.cloudbreak.core.flow2.stack.StackFailureContext;
 
 @Component("StackTerminationFailureAction")
-public class StackTerminationFailureAction extends AbstractStackTerminationAction<TerminateStackResult> {
+public class StackTerminationFailureAction extends AbstractStackFailureAction<StackTerminationState, StackTerminationEvent> {
     private static final Logger LOGGER = LoggerFactory.getLogger(StackTerminationFailureAction.class);
     @Inject
     private StackTerminationService stackTerminationService;
 
-    public StackTerminationFailureAction() {
-        super(TerminateStackResult.class);
-    }
-
     @Override
-    protected void doExecute(StackTerminationContext context, TerminateStackResult payload, Map<Object, Object> variables) {
-        stackTerminationService.handleStackTerminationError(context, payload, variables);
+    protected void doExecute(StackFailureContext context, FlowFailureEvent payload, Map<Object, Object> variables) {
+        stackTerminationService.handleStackTerminationError(context.getStack(), payload, variables.get("FORCEDTERMINATION") != null);
         sendEvent(context);
     }
 
     @Override
-    protected Selectable createRequest(StackTerminationContext context) {
+    protected Selectable createRequest(StackFailureContext context) {
         return new SelectableFlowStackEvent(context.getStack().getId(), StackTerminationEvent.STACK_TERMINATION_FAIL_HANDLED_EVENT.stringRepresentation());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationFlowConfig.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/termination/StackTerminationFlowConfig.java
@@ -25,15 +25,15 @@ public class StackTerminationFlowConfig extends AbstractFlowConfiguration<StackT
     private static final List<Transition<StackTerminationState, StackTerminationEvent>> TRANSITIONS =
             new Transition.Builder<StackTerminationState, StackTerminationEvent>()
                     .defaultFailureEvent(TERMINATION_FAILED_EVENT)
-                    .from(INIT_STATE).to(TERMINATION_STATE).event(TERMINATION_EVENT).defaultFailureEvent()
-                    .from(INIT_STATE).to(FORCE_TERMINATION_STATE).event(FORCE_TERMINATION_EVENT).defaultFailureEvent()
+                    .from(INIT_STATE).to(TERMINATION_STATE).event(TERMINATION_EVENT).noFailureEvent()
+                    .from(INIT_STATE).to(FORCE_TERMINATION_STATE).event(FORCE_TERMINATION_EVENT).noFailureEvent()
                     .from(TERMINATION_STATE).to(TERMINATION_FINISHED_STATE).event(TERMINATION_FINISHED_EVENT).defaultFailureEvent()
                     .from(FORCE_TERMINATION_STATE).to(TERMINATION_FINISHED_STATE).event(TERMINATION_FINISHED_EVENT).defaultFailureEvent()
+                    .from(TERMINATION_FINISHED_STATE).to(FINAL_STATE).event(TERMINATION_FINALIZED_EVENT).defaultFailureEvent()
                     .build();
 
     private static final FlowEdgeConfig<StackTerminationState, StackTerminationEvent> EDGE_CONFIG =
-            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TERMINATION_FINISHED_STATE, TERMINATION_FINALIZED_EVENT, TERMINATION_FAILED_STATE,
-                    STACK_TERMINATION_FAIL_HANDLED_EVENT);
+            new FlowEdgeConfig<>(INIT_STATE, FINAL_STATE, TERMINATION_FAILED_STATE, STACK_TERMINATION_FAIL_HANDLED_EVENT);
 
     public StackTerminationFlowConfig() {
         super(StackTerminationState.class, StackTerminationEvent.class);

--- a/core/src/main/resources/messages/messages.properties
+++ b/core/src/main/resources/messages/messages.properties
@@ -14,6 +14,7 @@ stack.forced.delete.completed=The cluster and its infrastructure have been force
 stack.adding.instances=Adding {0, number, integer} new instances to the infrastructure
 stack.removing.instance=Removing instance from the infrastructure
 stack.removing.instance.finished=Instance removed
+stack.removing.instance.failed=Failed to remove instance
 stack.metadata.extend=Infrastructure metadata extension finished
 stack.bootstrap.new.nodes=Bootstrapping new nodes
 stack.upscale.finished=Stack successfully upscaled

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/Flow2HandlerTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/Flow2HandlerTest.java
@@ -41,7 +41,7 @@ public class Flow2HandlerTest {
     private Map<String, FlowConfiguration<?>> flowConfigurationMap;
 
     @Mock
-    private Map<String, Flow> runningFlows;
+    private FlowRegister runningFlows;
 
     @Mock
     private FlowConfiguration flowConfig;
@@ -76,7 +76,7 @@ public class Flow2HandlerTest {
         event.setKey(FlowPhases.STACK_SYNC.name());
         underTest.accept(event);
         verify(flowConfigurationMap, times(1)).get(anyString());
-        verify(runningFlows, times(1)).put(anyString(), eq(flow));
+        verify(runningFlows, times(1)).put(eq(flow));
         verify(flowLogService, times(1)).save(anyString(), eq(FlowPhases.STACK_SYNC.name()), any(Payload.class), eq(flowConfig.getClass()),
                 eq(StackSyncState.INIT_STATE));
         verify(flow, times(1)).sendEvent(anyString(), any());
@@ -88,14 +88,14 @@ public class Flow2HandlerTest {
         event.setKey(FlowPhases.STACK_SYNC.name());
         underTest.accept(event);
         verify(flowConfigurationMap, times(1)).get(anyString());
-        verify(runningFlows, times(0)).put(eq(FLOW_ID), any(Flow.class));
+        verify(runningFlows, times(0)).put(any(Flow.class));
         verify(flowLogService, times(0)).save(anyString(), anyString(), any(Payload.class), Matchers.<Class>any(), any(FlowState.class));
     }
 
     @Test
     public void testExistingFlow() {
         BDDMockito.<FlowConfiguration>given(flowConfigurationMap.get(any())).willReturn(flowConfig);
-        given(runningFlows.get(any())).willReturn(flow);
+        given(runningFlows.get(anyString())).willReturn(flow);
         given(flow.getCurrentState()).willReturn(StackSyncState.SYNC_STATE);
         dummyEvent.setKey("KEY");
         underTest.accept(dummyEvent);
@@ -119,6 +119,6 @@ public class Flow2HandlerTest {
         verify(flowLogService, times(1)).close(anyLong(), eq(FLOW_ID));
         verify(runningFlows, times(1)).remove(eq(FLOW_ID));
         verify(runningFlows, times(0)).get(eq(FLOW_ID));
-        verify(runningFlows, times(0)).put(eq(FLOW_ID), any(Flow.class));
+        verify(runningFlows, times(0)).put(any(Flow.class));
     }
 }

--- a/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/config/AbstractFlowConfigurationTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/core/flow2/config/AbstractFlowConfigurationTest.java
@@ -52,11 +52,12 @@ public class AbstractFlowConfigurationTest {
         given(applicationContext.getBean(anyString(), any(Class.class))).willReturn(action);
         transitions = new AbstractFlowConfiguration.Transition.Builder<State, Event>()
                 .defaultFailureEvent(Event.FAILURE)
-                .from(State.INIT).to(State.DO).event(Event.START).defaultFailureEvent()
-                .from(State.DO).to(State.DO2).event(Event.CONTINUE).failureState(State.FAILED2).failureEvent(Event.FAILURE2)
-                .from(State.DO2).to(State.FINISH).event(Event.FINISHED).defaultFailureEvent()
+                .from(State.INIT).to(State.DO).event(Event.START).noFailureEvent()
+                .from(State.DO).to(State.DO2).event(Event.CONTINUE).defaultFailureEvent()
+                .from(State.DO2).to(State.FINISH).event(Event.FINISHED).failureState(State.FAILED2).failureEvent(Event.FAILURE2)
+                .from(State.FINISH).to(State.FINAL).event(Event.FINALIZED).defaultFailureEvent()
                 .build();
-        edgeConfig = new FlowConfiguration.FlowEdgeConfig(State.INIT, State.FINAL, State.FINISH, Event.FINALIZED, State.FAILED, Event.FAIL_HANDLED);
+        edgeConfig = new FlowConfiguration.FlowEdgeConfig(State.INIT, State.FINAL, State.FAILED, Event.FAIL_HANDLED);
         underTest.init();
         verify(applicationContext, times(8)).getBean(anyString(), any(Class.class));
         flow = underTest.createFlow("flowId");


### PR DESCRIPTION
@bbihari or @mhmxs pls review

1. Config refactor: from(srcstate).to(targetstate).event(normal flow event from src to target).failureEvent(failure event from src to default error state)
2. Error handling: failure action is the same on all stack flow, context creation moved to try - catch, context could be optional on failure event creation
3. In case of error on the first flow of a chain flow, the second flow won't be triggered
4. new method in AbstractExecution: prepareExecution() this method will be called first during action execution. Default implementation is do nothing.
