### PR TITLE
CLOUD-56733 show status reason in shell on failure

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToStatusConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToStatusConverter.java
@@ -3,9 +3,10 @@ package com.sequenceiq.cloudbreak.converter;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.stereotype.Component;
+
 import com.sequenceiq.cloudbreak.domain.Cluster;
 import com.sequenceiq.cloudbreak.domain.Stack;
-import org.springframework.stereotype.Component;
 
 @Component
 public class StackToStatusConverter extends AbstractConversionServiceAwareConverter<Stack, Map> {
@@ -15,9 +16,11 @@ public class StackToStatusConverter extends AbstractConversionServiceAwareConver
         Map<String, Object> stackStatus = new HashMap<>();
         stackStatus.put("id", source.getId());
         stackStatus.put("status", source.getStatus().name());
+        stackStatus.put("statusReason", source.getStatusReason());
         Cluster cluster = source.getCluster();
         if (cluster != null) {
             stackStatus.put("clusterStatus", cluster.getStatus().name());
+            stackStatus.put("clusterStatusReason", cluster.getStatusReason());
         }
         return stackStatus;
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterService.java
@@ -173,6 +173,9 @@ public class AmbariClusterService implements ClusterService {
         if (clusterRepository.findByNameInAccount(cluster.getName(), user.getAccount()) != null) {
             throw new DuplicateKeyValueException(APIResourceType.CLUSTER, cluster.getName());
         }
+        if (Status.CREATE_FAILED.equals(stack.getStatus())) {
+            throw new BadRequestException("Stack creation failed, cannot create cluster.");
+        }
         for (HostGroup hostGroup : cluster.getHostGroups()) {
             constraintRepository.save(hostGroup.getConstraint());
         }

--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/base/BaseStackCommands.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/base/BaseStackCommands.java
@@ -140,8 +140,8 @@ public class BaseStackCommands implements BaseCommands, StackCommands {
                 shellContext.removeStack(id.toString());
                 if (wait) {
                     CloudbreakShellUtil.WaitResult waitResult = cloudbreakShellUtil.waitAndCheckStackStatus(Long.valueOf(id), Status.DELETE_COMPLETED.name());
-                    if (CloudbreakShellUtil.WaitResult.FAILED.equals(waitResult)) {
-                        throw shellContext.exceptionTransformer().transformToRuntimeException("Stack terminated failed on stack with id: " + id);
+                    if (CloudbreakShellUtil.WaitResultStatus.FAILED.equals(waitResult.getWaitResultStatus())) {
+                        throw shellContext.exceptionTransformer().transformToRuntimeException("Stack termination failed: " + waitResult.getReason());
                     } else {
                         return "Stack terminated with id: " + id;
                     }
@@ -155,9 +155,9 @@ public class BaseStackCommands implements BaseCommands, StackCommands {
 
                 if (wait) {
                     CloudbreakShellUtil.WaitResult waitResult = cloudbreakShellUtil.waitAndCheckStackStatus(response.getId(), Status.DELETE_COMPLETED.name());
-                    if (CloudbreakShellUtil.WaitResult.FAILED.equals(waitResult)) {
+                    if (CloudbreakShellUtil.WaitResultStatus.FAILED.equals(waitResult.getWaitResultStatus())) {
                         throw shellContext.exceptionTransformer()
-                                .transformToRuntimeException("Stack terminated failed on stack with id: " + response.getId());
+                                .transformToRuntimeException("Stack termination failed: " + waitResult.getReason());
                     } else {
                         return "Stack terminated with name: " + name;
                     }
@@ -295,8 +295,8 @@ public class BaseStackCommands implements BaseCommands, StackCommands {
 
             if (wait) {
                 CloudbreakShellUtil.WaitResult waitResult = cloudbreakShellUtil.waitAndCheckStackStatus(id.getId(), Status.AVAILABLE.name());
-                if (CloudbreakShellUtil.WaitResult.FAILED.equals(waitResult)) {
-                    throw shellContext.exceptionTransformer().transformToRuntimeException("Stack creation failed with name:" + name);
+                if (CloudbreakShellUtil.WaitResultStatus.FAILED.equals(waitResult.getWaitResultStatus())) {
+                    throw shellContext.exceptionTransformer().transformToRuntimeException("Stack creation failed:" + waitResult.getReason());
                 } else {
                     return "Stack creation finished with name: " + name;
                 }

--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/common/ClusterCommands.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/common/ClusterCommands.java
@@ -152,9 +152,9 @@ public class ClusterCommands implements BaseCommands {
             if (wait) {
                 CloudbreakShellUtil.WaitResult waitResult =
                         cloudbreakShellUtil.waitAndCheckClusterStatus(Long.valueOf(stackId), Status.AVAILABLE.name());
-                if (CloudbreakShellUtil.WaitResult.FAILED.equals(waitResult)) {
+                if (CloudbreakShellUtil.WaitResultStatus.FAILED.equals(waitResult.getWaitResultStatus())) {
                     throw shellContext.exceptionTransformer().transformToRuntimeException(
-                            String.format("Cluster creation failed on stack with id: '%d' and name: '%s'", stackId, shellContext.getStackName()));
+                            String.format("Cluster creation failed on stack with id: '%s': '%s'", stackId, waitResult.getReason()));
                 } else {
                     return "Cluster creation finished";
                 }


### PR DESCRIPTION
@doktoric 

If something fails when --wait=yes is set, cloudbreak shell will show the status reason, not only a generic failure message.