### PR TITLE
CLOUD-58111 use warmup images on Amazon for ambari_2.2.2.0-hdp_2.4.2.…

### DIFF
--- a/cloud-aws/src/main/resources/aws-images.yml
+++ b/cloud-aws/src/main/resources/aws-images.yml
@@ -11,13 +11,13 @@ aws:
   us-west-2: ami-6d0df30d
 
 aws-ambari_2.2.2.0-hdp_2.4.2.0_258:
-  ap-northeast-1: ami-1bf7157a
-  ap-northeast-2: ami-19be7577
-  ap-southeast-1: ami-48fc2d2b
-  ap-southeast-2: ami-f09cb393
-  eu-central-1: ami-549e713b
-  eu-west-1: ami-4f92033c
-  sa-east-1: ami-5fed6633
-  us-east-1: ami-7f3ec812
-  us-west-1: ami-3a750e5a
-  us-west-2: ami-6d0df30d
+  ap-northeast-1: ami-5de00c3c
+  ap-northeast-2: ami-d9c50eb7
+  ap-southeast-1: ami-e079a883
+  ap-southeast-2: ami-513a1432
+  eu-central-1: ami-9216f9fd
+  eu-west-1: ami-d20494a1
+  sa-east-1: ami-a78c07cb
+  us-east-1: ami-d0e81abd
+  us-west-1: ami-e0f48f80
+  us-west-2: ami-2104fd41


### PR DESCRIPTION
…0_258
@doktoric 

You can use on the API on StackRequest  "ambariHDPVersion": "ambari_2.2.2.0-hdp_2.4.2.0_258"