### PR TITLE
Add orchestratorType to the constraint domain

### DIFF
--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/ConstraintTemplateBase.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/ConstraintTemplateBase.java
@@ -34,6 +34,10 @@ public abstract class ConstraintTemplateBase implements JsonEntity {
     @ApiModelProperty(value = ModelDescriptions.ConstraintTemplateModelDescription.DISK, readOnly = true)
     private Double disk;
 
+    @NotNull
+    @ApiModelProperty(value = ModelDescriptions.ConstraintTemplateModelDescription.ORCHESTRATOR_TYPE, readOnly = true)
+    private String orchestratorType;
+
     public String getName() {
         return name;
     }
@@ -72,5 +76,13 @@ public abstract class ConstraintTemplateBase implements JsonEntity {
 
     public void setDisk(Double disk) {
         this.disk = disk;
+    }
+
+    public String getOrchestratorType() {
+        return orchestratorType;
+    }
+
+    public void setOrchestratorType(String orchestratorType) {
+        this.orchestratorType = orchestratorType;
     }
 }

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/doc/ModelDescriptions.java
@@ -45,6 +45,7 @@ public class ModelDescriptions {
         public static final String CPU = "number of CPU cores needed for the Ambari node";
         public static final String MEMORY = "memory needed for the Ambari container (GB)";
         public static final String DISK = "disk size needed for an Ambari node (GB)";
+        public static final String ORCHESTRATOR_TYPE = "type of orchestrator";
     }
 
     public static class StackModelDescription {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/ConstraintTemplate.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/ConstraintTemplate.java
@@ -84,6 +84,9 @@ public class ConstraintTemplate {
     private Double memory;
     private Double disk;
 
+    @Column(nullable = false)
+    private String orchestratorType;
+
     private boolean deleted;
 
     @Enumerated(EnumType.STRING)
@@ -167,6 +170,14 @@ public class ConstraintTemplate {
 
     public void setStatus(ResourceStatus status) {
         this.status = status;
+    }
+
+    public String getOrchestratorType() {
+        return orchestratorType;
+    }
+
+    public void setOrchestratorType(String orchestratorType) {
+        this.orchestratorType = orchestratorType;
     }
 
     public boolean isDeleted() {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/ConstraintTemplateToJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/ConstraintTemplateToJsonConverter.java
@@ -17,6 +17,8 @@ public class ConstraintTemplateToJsonConverter extends AbstractConversionService
         constraintTemplateResponse.setCpu(source.getCpu());
         constraintTemplateResponse.setMemory(source.getMemory());
         constraintTemplateResponse.setDisk(source.getDisk());
+        constraintTemplateResponse.setOrchestratorType(source.getOrchestratorType());
+
         return constraintTemplateResponse;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToConstraintTemplateConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/JsonToConstraintTemplateConverter.java
@@ -14,6 +14,7 @@ public class JsonToConstraintTemplateConverter extends AbstractConversionService
         constraintTemplate.setCpu(source.getCpu());
         constraintTemplate.setMemory(source.getMemory());
         constraintTemplate.setDisk(source.getDisk());
+        constraintTemplate.setOrchestratorType(source.getOrchestratorType());
         constraintTemplate.setName(source.getName());
         constraintTemplate.setDescription(source.getDescription());
         constraintTemplate.setStatus(ResourceStatus.USER_MANAGED);

--- a/core/src/main/resources/schema/app/20160602190114_Add_orchestratorType_to_constrainttemplate.sql
+++ b/core/src/main/resources/schema/app/20160602190114_Add_orchestratorType_to_constrainttemplate.sql
@@ -1,0 +1,10 @@
+-- // Add orchestratorType to constrainttemplate
+-- Migration SQL that makes the change goes here.
+ALTER TABLE constrainttemplate
+    ADD COLUMN orchestratortype CHARACTER VARYING (255) NOT NULL;
+
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+ALTER TABLE constrainttemplate DROP COLUMN orchestratortype;
+

--- a/web/app/static/js/controllers/templateController.js
+++ b/web/app/static/js/controllers/templateController.js
@@ -180,6 +180,7 @@ angular.module('uluwatuControllers').controller('templateController', [
         }
 
         $scope.createMesosTemplate = function() {
+            $scope.mesosTemp.orchestratorType = "MESOS";
             if ($scope.mesosTemp.public) {
                 AccountConstraint.save($scope.mesosTemp, function(result) {
                     handleMesosTemplateSuccess(result)

--- a/web/app/static/js/controllers/templateController.js
+++ b/web/app/static/js/controllers/templateController.js
@@ -180,7 +180,7 @@ angular.module('uluwatuControllers').controller('templateController', [
         }
 
         $scope.createMesosTemplate = function() {
-            $scope.mesosTemp.orchestratorType = "MESOS";
+            $scope.mesosTemp.orchestratorType = "MARATHON";
             if ($scope.mesosTemp.public) {
                 AccountConstraint.save($scope.mesosTemp, function(result) {
                     handleMesosTemplateSuccess(result)

--- a/web/app/static/js/services.js
+++ b/web/app/static/js/services.js
@@ -28,7 +28,7 @@ uluwatuServices.factory('AccountTemplate', ['$resource',
 
 uluwatuServices.factory('UserConstraint', ['$resource',
     function($resource) {
-        return $resource('user/constraints');
+        return $resource('constraints/user');
     }
 ]);
 

--- a/web/app/static/tags/templatepanel.tag
+++ b/web/app/static/tags/templatepanel.tag
@@ -105,7 +105,7 @@
                         <div class="panel-heading">
                             <h5>
                                     <a href="" data-toggle="collapse" data-parent="#constraint-list-accordion" data-target="#panel-constraint-collapse{{constraint.id}}"><i class="fa fa-file-o fa-fw"></i>{{constraint.name}}</a>
-                                    <span class="label label-info pull-right" >MESOS</span>
+                                    <span class="label label-info pull-right" >{{constraint.orchestratorType}}</span>
                                     <i class="fa fa-users fa-lg public-account-info pull-right" style="padding-right: 5px" ng-show="constraint.public"></i>
                                 </h5>
                         </div>


### PR DESCRIPTION
@martonsereg - Please review as time permits. 

This PR adds the orchestratorType field to the constraint domain to enable multiple different orchestrators under the BYOS cloud platform. This allows for controlling UI elements based on the type of orchestrator defined.