### PR TITLE
set a default for orchestratortype for existing rows

### DIFF
--- a/core/src/main/resources/schema/app/20160602190114_Add_orchestratorType_to_constrainttemplate.sql
+++ b/core/src/main/resources/schema/app/20160602190114_Add_orchestratorType_to_constrainttemplate.sql
@@ -1,7 +1,9 @@
 -- // Add orchestratorType to constrainttemplate
 -- Migration SQL that makes the change goes here.
 ALTER TABLE constrainttemplate
-    ADD COLUMN orchestratortype CHARACTER VARYING (255) NOT NULL;
+    ADD COLUMN orchestratortype CHARACTER VARYING (255) NOT NULL DEFAULT 'MARATHON';
+ALTER TABLE constrainttemplate
+    ALTER COLUMN orchestratortype DROP DEFAULT;
 
 
 -- //@UNDO


### PR DESCRIPTION
@martonsereg - Here is the PR that fixes the db migration when the constrainttemplate table already exists.