### PR TITLE
 CLOUD-58099 Update to Ambari 2.4.0.0-660

### DIFF
--- a/cloud-arm/src/main/resources/arm-images.yml
+++ b/cloud-arm/src/main/resources/arm-images.yml
@@ -1,15 +1,15 @@
 
 azure_rm:
-  East Asia: https://sequenceiqeastasia2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  East US: https://sequenceiqeastus2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  Central US: https://sequenceiqcentralus2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  North Europe: https://sequenceiqnortheurope2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  South Central US: https://sequenceiqouthcentralus2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  North Central US: https://sequenceiqorthcentralus2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  East US 2: https://sequenceiqeastus22.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  Japan East: https://sequenceiqjapaneast2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  Japan West: https://sequenceiqjapanwest2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  Southeast Asia: https://sequenceiqsoutheastasia2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  West US: https://sequenceiqwestus2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  West Europe: https://sequenceiqwesteurope2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
-  Brazil South: https://sequenceiqbrazilsouth2.blob.core.windows.net/images/cb-2016-06-13-01-33.vhd
+  East Asia: https://sequenceiqeastasia2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  East US: https://sequenceiqeastus2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  Central US: https://sequenceiqcentralus2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  North Europe: https://sequenceiqnortheurope2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  South Central US: https://sequenceiqouthcentralus2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  North Central US: https://sequenceiqorthcentralus2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  East US 2: https://sequenceiqeastus22.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  Japan East: https://sequenceiqjapaneast2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  Japan West: https://sequenceiqjapanwest2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  Southeast Asia: https://sequenceiqsoutheastasia2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  West US: https://sequenceiqwestus2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  West Europe: https://sequenceiqwesteurope2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd
+  Brazil South: https://sequenceiqbrazilsouth2.blob.core.windows.net/images/cb-2016-06-14-03-27.vhd

--- a/cloud-aws/src/main/resources/aws-images.yml
+++ b/cloud-aws/src/main/resources/aws-images.yml
@@ -1,11 +1,11 @@
 aws:
-  ap-northeast-1: ami-46c62d27
-  ap-northeast-2: ami-9406cdfa
-  ap-southeast-1: ami-eab66589
-  ap-southeast-2: ami-2aefc649
-  eu-central-1: ami-b7f910d8
-  eu-west-1: ami-e1c15e92
-  sa-east-1: ami-f8d55f94
-  us-east-1: ami-ca25e0a7
-  us-west-1: ami-37470257
-  us-west-2: ami-a903f9c9
+  ap-northeast-1: ami-76729917
+  ap-northeast-2: ami-7c1ad112
+  ap-southeast-1: ami-a7ac7fc4
+  ap-southeast-2: ami-acf7decf
+  eu-central-1: ami-71da331e
+  eu-west-1: ami-cba43bb8
+  sa-east-1: ami-f8901a94
+  us-east-1: ami-bde327d0
+  us-west-1: ami-b76421d7
+  us-west-2: ami-d541bbb5

--- a/cloud-gcp/src/main/resources/gcp-images.yml
+++ b/cloud-gcp/src/main/resources/gcp-images.yml
@@ -1,2 +1,2 @@
 gcp:
-  default: sequenceiqimage/cb-2016-06-13-01-48.tar.gz
+  default: sequenceiqimage/cb-2016-06-14-03-27.tar.gz

--- a/cloud-openstack/src/main/resources/os-images.yml
+++ b/cloud-openstack/src/main/resources/os-images.yml
@@ -1,2 +1,2 @@
 openstack:
-  default: cloudbreak-2016-06-13-01-09
+  default: cloudbreak-2016-06-14-10-58


### PR DESCRIPTION
- RM does not work with kerberos
- The Ambari is more memory hungry: 4GB is not enough