### PR TITLE
FIX BUG-60182: Add x1.32xlarge AWS EC2 instance type to CloudBreak

### DIFF
--- a/cloud-aws/src/main/resources/definitions/aws-vm.json
+++ b/cloud-aws/src/main/resources/definitions/aws-vm.json
@@ -673,6 +673,38 @@
       }
     },
     {
+      "value": "x1.32xlarge",
+      "meta": {
+        "configs": [
+          {
+            "volumeParameterType": "EPHEMERAL",
+            "minimumSize": 1920,
+            "maximumSize": 1920,
+            "minimumNumber": 1,
+            "maximumNumber": 2
+          },
+          {
+            "volumeParameterType": "MAGNETIC",
+            "minimumSize": 1,
+            "maximumSize": 1024,
+            "minimumNumber": 1,
+            "maximumNumber": 24
+          },
+          {
+            "volumeParameterType": "SSD",
+            "minimumSize": 1,
+            "maximumSize": 17592,
+            "minimumNumber": 1,
+            "maximumNumber": 24
+          }
+        ],
+        "properties": {
+          "Memory": "1952.0",
+          "Cpu": "128"
+        }
+      }
+    },
+    {
       "value": "cc2.8xlarge",
       "meta": {
         "configs": [


### PR DESCRIPTION
- For high memory uses such as Spark & LLAP
- https://aws.amazon.com/ec2/instance-types/x1/