### PR TITLE
openstack integrationtest fixes

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/OpenStackNetworkCreationTest.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/OpenStackNetworkCreationTest.java
@@ -3,6 +3,8 @@ package com.sequenceiq.it.cloudbreak;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.util.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.Optional;
 import org.testng.annotations.Parameters;
@@ -11,11 +13,16 @@ import org.testng.annotations.Test;
 import com.sequenceiq.cloudbreak.api.model.NetworkJson;
 
 public class OpenStackNetworkCreationTest extends AbstractCloudbreakIntegrationTest {
+    @Value("${integrationtest.openstack.publicNetId}")
+    private String defaultPublicNetId;
+
     @Test
     @Parameters({ "networkName", "subnetCIDR", "publicNetId" })
-    public void testGcpTemplateCreation(@Optional("it-openstack-network") String networkName, @Optional("10.0.36.0/24") String subnetCIDR, String publicNetId)
+    public void testOpenstackNetworkCreation(@Optional("it-openstack-network") String networkName, @Optional("10.0.36.0/24") String subnetCIDR,
+            @Optional("") String publicNetId)
             throws Exception {
         // GIVEN
+        publicNetId = getPublicNetId(publicNetId, defaultPublicNetId);
         // WHEN
         // TODO: publicInAccount
         NetworkJson networkJson = new NetworkJson();
@@ -31,5 +38,14 @@ public class OpenStackNetworkCreationTest extends AbstractCloudbreakIntegrationT
         // THEN
         Assert.assertNotNull(id);
         getItContext().putContextParam(CloudbreakITContextConstants.NETWORK_ID, id, true);
+    }
+
+    private String getPublicNetId(String publicNetId, String defaultPublicNetId) {
+        if ("__empty__".equals(publicNetId)) {
+            publicNetId = "";
+        } else if (StringUtils.isEmpty(publicNetId)) {
+            publicNetId = defaultPublicNetId;
+        }
+        return publicNetId;
     }
 }

--- a/integration-test/src/main/resources/application.yml
+++ b/integration-test/src/main/resources/application.yml
@@ -62,11 +62,14 @@ integrationtest:
         retryCount: 3
         cleanupBeforeStart: false
 
-    defaultBlueprintName: multi-node-hdfs-yarn
+    defaultBlueprintName:
 
     ambariContainer: hortonworks/ambari-agent
 
     defaultPrivateKeyFile:
+
+    openstack:
+        publicNetId:
 
     testsuite:
         threadPoolSize: 3

--- a/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-startstop-updown.yaml
@@ -1,7 +1,8 @@
 # Aws credential name must be specified
 name: AWS smoke test
 parameters: {
-  cloudProvider: AWS
+  cloudProvider: AWS,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-startstop.yaml
+++ b/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-startstop.yaml
@@ -1,7 +1,8 @@
 # Aws credential name must be specified
 name: AWS smoke test
 parameters: {
-  cloudProvider: AWS
+  cloudProvider: AWS,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate-updown.yaml
@@ -1,7 +1,8 @@
 # Aws credential name must be specified
 name: AWS smoke test
 parameters: {
-  cloudProvider: AWS
+  cloudProvider: AWS,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate.yaml
+++ b/integration-test/src/main/resources/testsuites/aws/smoke/aws-clustercreate.yaml
@@ -1,7 +1,8 @@
 # Aws credential name must be specified
 name: AWS smoke test
 parameters: {
-  cloudProvider: AWS
+  cloudProvider: AWS,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-startstop-updown.yaml
@@ -1,7 +1,8 @@
 # AZURE_RM credential name must be specified
 name: Azure RM smoke test
 parameters: {
-  cloudProvider: AZURE_RM
+  cloudProvider: AZURE_RM,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-startstop.yaml
+++ b/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-startstop.yaml
@@ -1,7 +1,8 @@
 # AZURE_RM credential name must be specified
 name: Azure RM smoke test
 parameters: {
-  cloudProvider: AZURE_RM
+  cloudProvider: AZURE_RM,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate-updown.yaml
@@ -1,7 +1,8 @@
 # AZURE_RM credential name must be specified
 name: Azure RM smoke test
 parameters: {
-  cloudProvider: AZURE_RM
+  cloudProvider: AZURE_RM,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate.yaml
+++ b/integration-test/src/main/resources/testsuites/azurerm/smoke/azurerm-clustercreate.yaml
@@ -1,7 +1,8 @@
 # AZURE_RM credential name must be specified
 name: Azure RM smoke test
 parameters: {
-  cloudProvider: AZURE_RM
+  cloudProvider: AZURE_RM,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/gcp/kerberos/gcp-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/kerberos/gcp-clustercreate-startstop-updown.yaml
@@ -1,7 +1,8 @@
 # GCP credential name must be specified
 name: Gcp_simple_kerberostest
 parameters: {
-  cloudProvider: GCP
+  cloudProvider: GCP,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/gcp/recipe/gcp-clustercreate-up.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/recipe/gcp-clustercreate-up.yaml
@@ -1,7 +1,8 @@
 # GCP credential name must be specified
 name: Gcp_simple_recipetest
 parameters: {
-  cloudProvider: GCP
+  cloudProvider: GCP,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-startstop-updown.yaml
@@ -1,7 +1,8 @@
 # GCP credential name must be specified
 name: Gcp_full_smoketest
 parameters: {
-  cloudProvider: GCP
+  cloudProvider: GCP,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-startstop.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-startstop.yaml
@@ -1,7 +1,8 @@
 # GCP credential name must be specified
 name: Gcp_startstop_smoketest
 parameters: {
-  cloudProvider: GCP
+  cloudProvider: GCP,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate-updown.yaml
@@ -1,7 +1,8 @@
 # GCP credential name must be specified
 name: Gcp_updown_smoketest
 parameters: {
-  cloudProvider: GCP
+  cloudProvider: GCP,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate.yaml
+++ b/integration-test/src/main/resources/testsuites/gcp/smoke/gcp-clustercreate.yaml
@@ -1,7 +1,8 @@
 # GCP credential name must be specified
 name: Gcp_simple_smoketest
 parameters: {
-  cloudProvider: GCP
+  cloudProvider: GCP,
+  blueprintName: multi-node-hdfs-yarn
 }
 
 tests:

--- a/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate-startstop-updown.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-nativeos-credandsmoke-network-ssud
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate-startstop.yaml
+++ b/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate-startstop.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-nativeos-credandsmoke-network-ss
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate-updown.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-nativeos-credandsmoke-network-ud
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate.yaml
+++ b/integration-test/src/main/resources/testsuites/nativeos/credandsmoke/nativeos-clustercreate.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-nativeos-credandsmoke-network
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate-startstop-updown.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-openstack-credandsmoke-network-ssud
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate-startstop.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate-startstop.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-openstack-credandsmoke-network-ss
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate-updown.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-openstack-network-ud
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/credandsmoke/openstack-clustercreate.yaml
@@ -20,7 +20,6 @@ tests:
     parameters:
       networkName: it-openstack-credandsmoke-network
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 290e220b-9177-4d21-9bcb-4cb18cd9c960
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstop-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstop-updown.yaml
@@ -2,6 +2,7 @@
 name: OpenStack_full_smoketest
 parameters:
   cloudProvider: OPENSTACK
+  blueprintName: multi-node-hdfs-yarn
 
 tests:
   - name: init
@@ -13,7 +14,6 @@ tests:
     parameters:
       networkName: it-openstack-network-ssud
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 999e09bc-cf75-4a19-98fb-c0b4ddee6d93
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstop.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstop.yaml
@@ -2,6 +2,7 @@
 name: OpenStack_startstop_smoketest
 parameters:
   cloudProvider: OPENSTACK
+  blueprintName: multi-node-hdfs-yarn
 
 tests:
   - name: init
@@ -13,7 +14,6 @@ tests:
     parameters:
       networkName: it-openstack-network-ss
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 8a1ca549-30cb-4fd5-9d32-84a42433558b
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstopX10.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-startstopX10.yaml
@@ -2,6 +2,7 @@
 name: OpenStack_startstop_smoketest
 parameters:
   cloudProvider: OPENSTACK
+  blueprintName: multi-node-hdfs-yarn
 
 tests:
   - name: init
@@ -13,7 +14,6 @@ tests:
     parameters:
       networkName: it-openstack-network-ss
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 8a1ca549-30cb-4fd5-9d32-84a42433558b
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-updown.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate-updown.yaml
@@ -2,6 +2,7 @@
 name: OpenStack_updown_smoketest
 parameters:
   cloudProvider: OPENSTACK
+  blueprintName: multi-node-hdfs-yarn
 
 tests:
   - name: init
@@ -13,7 +14,6 @@ tests:
     parameters:
       networkName: it-openstack-network-ud
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 8a1ca549-30cb-4fd5-9d32-84a42433558b
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 

--- a/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate.yaml
+++ b/integration-test/src/main/resources/testsuites/openstack/smoke/openstack-clustercreate.yaml
@@ -2,6 +2,7 @@
 name: OpenStack_simple_smoketest
 parameters:
   cloudProvider: OPENSTACK
+  blueprintName: multi-node-hdfs-yarn
 
 tests:
   - name: init
@@ -13,7 +14,6 @@ tests:
     parameters:
       networkName: it-openstack-network
       subnetCIDR: 10.0.36.0/24
-      publicNetId: 8a1ca549-30cb-4fd5-9d32-84a42433558b
     classes:
       - com.sequenceiq.it.cloudbreak.OpenStackNetworkCreationTest
 


### PR DESCRIPTION
@sodre90 pls review

Openstack integrationtest improvement to be able to run them on hwx jenkins:
- publicnetid can be application level parameter
- publicnetid can be empty
- default blueprint is empty in application.yml
