### PR TITLE
Removed Spark1 components, not needed with newer build of Ambari

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp25-etl-edw-spark2.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp25-etl-edw-spark2.bp
@@ -56,8 +56,6 @@
         { "name": "PIG" },
         { "name": "RESOURCEMANAGER" },
         { "name": "SECONDARY_NAMENODE" },
-        { "name": "SPARK_CLIENT" },
-        { "name": "SPARK_JOBHISTORYSERVER" },
         { "name": "SPARK2_CLIENT" },
         { "name": "SPARK2_JOBHISTORYSERVER" },
         { "name": "TEZ_CLIENT" },


### PR DESCRIPTION
The workaround that was applied with Ambari build 660 is not needed in 2.4.0.0-680 and above.