### PR TITLE
removed zeppelin as it's not in hdp 2.4.3

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp-spark-cluster.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp-spark-cluster.bp
@@ -142,9 +142,6 @@
           "name": "HIVE_METASTORE"
         },
         {
-          "name": "ZEPPELIN_MASTER"
-        },
-        {
           "name": "HDFS_CLIENT"
         },
         {
@@ -209,4 +206,3 @@
     "stack_version": "2.4"
   }
 }
-    


### PR DESCRIPTION
Remove Zeppelin from 1.3 release as it's not supported in HDP 2.4.3.