### PR TITLE
CLOUD-56745 itest fix, networkid have to be string in context

### DIFF
--- a/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTestSuiteInitializer.java
+++ b/integration-test/src/main/java/com/sequenceiq/it/cloudbreak/CloudbreakTestSuiteInitializer.java
@@ -134,7 +134,7 @@ public class CloudbreakTestSuiteInitializer extends AbstractTestNGSpringContextT
         if (StringUtils.hasLength(networkName)) {
             Long resourceId = endpoint.getPublic(networkName).getId();
             if (resourceId != null) {
-                itContext.putContextParam(CloudbreakITContextConstants.NETWORK_ID, resourceId);
+                itContext.putContextParam(CloudbreakITContextConstants.NETWORK_ID, resourceId.toString());
             }
         }
     }


### PR DESCRIPTION
@doktoric pls review