### PR TITLE
CLOUD-62537 increase poll timeout for ARM

### DIFF
--- a/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
+++ b/orchestrator-salt/src/main/java/com/sequenceiq/cloudbreak/orchestrator/salt/SaltOrchestrator.java
@@ -61,7 +61,7 @@ import com.sequenceiq.cloudbreak.orchestrator.state.ExitCriteriaModel;
 public class SaltOrchestrator implements HostOrchestrator {
 
     private static final int MAX_NODES = 5000;
-    private static final int MAX_RETRY_COUNT = 60;
+    private static final int MAX_RETRY_COUNT = 90;
     private static final int SLEEP_TIME = 10000;
 
     private static final Logger LOGGER = LoggerFactory.getLogger(SaltOrchestrator.class);


### PR DESCRIPTION
@biharitomi @martonsereg @doktoric 

If you're launching a non-warmed up image on ARM, since we're installing Ambari on-the-fly it exceeds the 10 minutes threshold so I raised it to 15 minutes.