### PR TITLE
CLOUD-63639: Added check for spot instances to disallow stop flow

### DIFF
--- a/core-model/build.gradle
+++ b/core-model/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     compile project(':core-api')
     compile group: 'org.hibernate.javax.persistence',  name: 'hibernate-jpa-2.1-api',  version: '1.0.0.Final'
     compile group: 'org.apache.commons',               name: 'commons-lang3',  version: apacheCommonsLangVersion
+    testCompile group: 'junit',                     name: 'junit',                          version: junitVersion
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {

--- a/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/StopRestrictionReason.java
+++ b/core-model/src/main/java/com/sequenceiq/cloudbreak/domain/StopRestrictionReason.java
@@ -1,0 +1,18 @@
+package com.sequenceiq.cloudbreak.domain;
+
+public enum StopRestrictionReason {
+
+    NONE ("Instances can be stopped."),
+    EPHEMERAL_VOLUMES ("Instances with ephemeral volumes cannot be stopped."),
+    SPOT_INSTANCES ("Spot instances cannot be stopped.");
+
+    private String reason;
+
+    StopRestrictionReason(String reason) {
+        this.reason = reason;
+    }
+
+    public String getReason() {
+        return reason;
+    }
+}

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/TestUtil.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.sequenceiq.cloudbreak.domain.json.JsonToString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -577,5 +578,16 @@ public class TestUtil {
         resource.setResourceName("testResource");
         resource.setResourceType(ResourceType.GCP_INSTANCE);
         return resource;
+    }
+
+    public static Stack setSpotInstances(Stack stack) {
+        if (stack.cloudPlatform().equals(AWS)) {
+            for (InstanceGroup instanceGroup : stack.getInstanceGroups()) {
+                (instanceGroup.getTemplate()).setAttributes(new JsonToString().convertToEntityAttribute(
+                        "{\"sshLocation\":\"0.0.0.0/0\",\"encrypted\":false,\"spotPrice\":0.04}"));
+            }
+        }
+        return stack;
+
     }
 }

--- a/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/StackTest.java
+++ b/core-model/src/test/java/com/sequenceiq/cloudbreak/domain/StackTest.java
@@ -1,0 +1,73 @@
+package com.sequenceiq.cloudbreak.domain;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.sequenceiq.cloudbreak.domain.json.JsonToString;
+import org.junit.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.junit.Assert.assertEquals;
+
+public class StackTest {
+
+    @Test
+    public void infrastructureShouldNotBeStoppableForEphemeralStorage() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AWS");
+        Set<InstanceGroup> groups = new HashSet<>();
+        groups.add(createGroup("ebs"));
+        groups.add(createGroup("ephemeral"));
+        stack.setInstanceGroups(groups);
+        StopRestrictionReason infrastructureStoppable = stack.isInfrastructureStoppable();
+        assertEquals(StopRestrictionReason.EPHEMERAL_VOLUMES, infrastructureStoppable);
+    }
+
+    @Test
+    public void infrastructureShouldNotBeStoppableForSpotInstances() throws JsonProcessingException {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AWS");
+        Set<InstanceGroup> groups = new HashSet<>();
+        groups.add(createGroup("ebs"));
+        InstanceGroup master = createGroup("ebs");
+        master.getTemplate().setAttributes(
+                new JsonToString().convertToEntityAttribute(
+                        "{\"sshLocation\":\"0.0.0.0/0\",\"encrypted\":false,\"spotPrice\":0.04}"));
+        groups.add(master);
+        stack.setInstanceGroups(groups);
+        StopRestrictionReason infrastructureStoppable = stack.isInfrastructureStoppable();
+        assertEquals(StopRestrictionReason.SPOT_INSTANCES, infrastructureStoppable);
+    }
+
+    @Test
+    public void infrastructureShouldBeStoppableForNonAWSClusters() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("GCP");
+        StopRestrictionReason infrastructureStoppable = stack.isInfrastructureStoppable();
+        assertEquals(StopRestrictionReason.NONE, infrastructureStoppable);
+    }
+
+    @Test
+    public void infrastructureShouldBeStoppableForValidInstanceGroups() {
+        Stack stack = new Stack();
+        stack.setCloudPlatform("AWS");
+        Set<InstanceGroup> groups = new HashSet<>();
+        groups.add(createGroup("ebs"));
+        InstanceGroup master = createGroup("ebs");
+        master.getTemplate().setAttributes(
+                new JsonToString().convertToEntityAttribute(
+                        "{\"sshLocation\":\"0.0.0.0/0\",\"encrypted\":false}"));
+        groups.add(master);
+        stack.setInstanceGroups(groups);
+        StopRestrictionReason infrastructureStoppable = stack.isInfrastructureStoppable();
+        assertEquals(StopRestrictionReason.NONE, infrastructureStoppable);
+    }
+
+    private InstanceGroup createGroup(String volumeType) {
+        InstanceGroup group = new InstanceGroup();
+        Template ephemeralTemplate = new Template();
+        ephemeralTemplate.setVolumeType(volumeType);
+        group.setTemplate(ephemeralTemplate);
+        return group;
+    }
+}

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterHostServiceTypeTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/cluster/AmbariClusterHostServiceTypeTest.java
@@ -128,6 +128,21 @@ public class AmbariClusterHostServiceTypeTest {
     }
 
     @Test(expected = BadRequestException.class)
+    public void testStopWhenAwsHasSpotInstances() {
+        cluster = TestUtil.cluster(TestUtil.blueprint(), TestUtil.stack(Status.AVAILABLE, TestUtil.awsCredential()), 1L);
+        cluster.getStack().setCloudPlatform("AWS");
+        stack = TestUtil.setSpotInstances(cluster.getStack());
+        cluster.setStatus(Status.AVAILABLE);
+        cluster.setStack(stack);
+        stack.setCluster(cluster);
+
+        when(stackService.get(anyLong())).thenReturn(stack);
+        when(stackService.getById(anyLong())).thenReturn(stack);
+
+        underTest.updateStatus(1L, StatusRequest.STOPPED);
+    }
+
+    @Test(expected = BadRequestException.class)
     public void testRetrieveClusterJsonWhenClusterJsonIsNull() throws HttpResponseException {
         // GIVEN
         doReturn(ambariClient).when(ambariClientProvider).getAmbariClient(any(HttpClientConfig.class), anyInt(), any(String.class), any(String.class));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackHostServiceTypeTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/DefaultStackHostServiceTypeTest.java
@@ -183,6 +183,15 @@ public class DefaultStackHostServiceTypeTest {
         underTest.updateStatus(1L, StatusRequest.STOPPED);
     }
 
+    @Test(expected = BadRequestException.class)
+    public void updateStatusTestStopWhenClusterAndStackAvailableAndSpotInstancesThenBadRequestExceptionDropping() {
+        Stack stack = TestUtil.setSpotInstances(TestUtil.stack(AVAILABLE, TestUtil.awsCredential()));
+        given(stackRepository.findOneWithLists(anyLong())).willReturn(stack);
+        given(clusterRepository.findOneWithLists(anyLong())).willReturn(stack.getCluster());
+        given(stackUpdater.updateStackStatus(anyLong(), any(Status.class))).willReturn(stack);
+        underTest.updateStatus(1L, StatusRequest.STOPPED);
+    }
+
     private Stack stack(Status stackStatus, Status clusterStatus) {
         Credential gcpCredential = new Credential();
         Stack stack = new Stack();


### PR DESCRIPTION
For the stop flow, added a check for instances being of type Spot and throwing a BadRequestException in that case. This is similar to how we check for ephemeral volumes before stopping.

Couple of things to call out:

- Have replaced the method Stack.isInfrastructuralEphemeral with Stack.isInfrastructureStoppable, primarily to just have one iteration on the instance groups. If this seems unclear, can retain the original method and add a new one and call both from callers.
- Have used the presence of spotPrice in the Template.attributes JSON to determine if this is a spot instance. Please let me know if this is assumption is ok, or should we do something better?
- This fix only adds backend checks. So, front-end will still show a stop button, but stop fails with an error message. I noticed that for ephemeral volumes, we don't show the stop button in the details page (but still show it for a 'cluster card'). Maybe the UI should be fixed for not showing the Stop in such a case for better user experience. I am not very conversant with UI - hence did not attempt it.
- Have added unit tests for new code paths, and also verified from UI that stopping a cluster with spot instances fails with an error message.