### PR TITLE
CLOUD-65291 Proper handling of upstart config to avoid concurrency

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/agent.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/agent.sls
@@ -84,9 +84,22 @@ start-ambari-agent:
 
 {% else %}
 
+# Upstart case
+
+# Avoid concurrency between SysV and Upstart
+disable-ambari-agent-sysv:
+  cmd.run:
+    - name: chkconfig ambari-agent off
+    - onlyif: chkconfig --list ambari-agent | grep on
+
+
+/etc/init/ambari-agent.override:
+  file.managed:
+    - source: salt://ambari/upstart/ambari-agent.override
+
 start-ambari-agent:
   service.running:
-    - name: ambari-agent
     - enable: True
+    - name: ambari-agent
 
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/server.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/server.sls
@@ -64,16 +64,21 @@ start-ambari-server:
 
 {% else %}
 
-update-ambari-server-conf:
-  file.append:
-    - name: /etc/init/ambari-server.conf
-    - source: salt://ambari/upstart/ambari-server.conf
+# Upstart case
+
+# Avoid concurrency between SysV and Upstart
+disable-ambari-server-sysv:
+  cmd.run:
+    - name: chkconfig ambari-server off
+    - onlyif: chkconfig --list ambari-server | grep on
+
+/etc/init/ambari-server.override:
+  file.managed:
+    - source: salt://ambari/upstart/ambari-server.override
 
 start-ambari-server:
   service.running:
     - enable: True
     - name: ambari-server
-    - watch:
-      - file: /etc/init/ambari-server.conf
 
 {% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/upstart/ambari-agent.override
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/upstart/ambari-agent.override
@@ -1,0 +1,2 @@
+
+start on runlevel [2345]

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/upstart/ambari-server.override
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/upstart/ambari-server.override
@@ -1,4 +1,6 @@
 
+start on runlevel [2345]
+
 pre-start script
   /opt/ambari-server/ambari-server-init.sh
 end script

--- a/orchestrator-salt/src/main/resources/salt/salt/kernel/init.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/kernel/init.sls
@@ -1,3 +1,0 @@
-echo_kernel_version:
-  cmd.run:
-    - name: uname -a

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -1,24 +1,11 @@
 base:
   '*':
-    - kernel.init
-    - users.init
-
-  'platform:OPENSTACK':
-    - match: pillar
-    - discovery.init
-
-  'platform:GCP':
-    - match: pillar
-    - discovery.init
-
-  'platform:AZURE_RM':
-    - match: pillar
-    - discovery.init
+    - discovery
+    - users
 
   'platform:AWS':
     - match: pillar
-    - discovery.init
-    - dns.init
+    - dns
 
   'roles:kerberos_server':
     - match: grain
@@ -34,18 +21,18 @@ base:
 
   'G@recipes:post and G@roles:knox_gateway':
     - match: compound
-    - ldap.init
+    - ldap
 
   'I@platform:AWS and G@roles:smartsense':
     - match: compound
-    - smartsense.init
+    - smartsense
 
   'recipes:pre':
     - match: grain
-    - pre-recipes.init
+    - pre-recipes
 
   'recipes:post':
     - match: grain
-    - post-recipes.init
+    - post-recipes
     - users.add-to-group
 


### PR DESCRIPTION
@schfeca75, @keyki 

Proper handling of upstart config to avoid concurrency between sysv and upstart. Code is also aligned with rh_service.py: https://github.com/saltstack/salt/blob/develop/salt/modules/rh_service.py

