### PR TITLE
CLOUD-65947 add extra logging to figure out why start cluster fails s…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -409,6 +409,7 @@ public class AmbariClusterConnector {
     }
 
     private void stopAllServices(Stack stack, AmbariClient ambariClient) throws CloudbreakException {
+        LOGGER.info("Stop all Hadoop services");
         eventService.fireCloudbreakEvent(stack.getId(), Status.UPDATE_IN_PROGRESS.name(),
                 cloudbreakMessagesService.getMessage(Msg.AMBARI_CLUSTER_SERVICES_STOPPING.code()));
         int requestId = ambariClient.stopAllServices();
@@ -422,6 +423,7 @@ public class AmbariClusterConnector {
                 throw new CloudbreakException("Timeout while stopping Ambari services.");
             }
         } else {
+            LOGGER.warn("Failed to stop Hadoop services.");
             throw new CloudbreakException("Failed to stop Hadoop services.");
         }
         eventService.fireCloudbreakEvent(stack.getId(), Status.UPDATE_IN_PROGRESS.name(),
@@ -429,6 +431,7 @@ public class AmbariClusterConnector {
     }
 
     private void startAllServices(Stack stack, AmbariClient ambariClient) throws CloudbreakException {
+        LOGGER.info("Start all Hadoop services");
         eventService.fireCloudbreakEvent(stack.getId(), Status.UPDATE_IN_PROGRESS.name(),
                 cloudbreakMessagesService.getMessage(Msg.AMBARI_CLUSTER_SERVICES_STARTING.code()));
         int requestId = ambariClient.startAllServices();
@@ -442,6 +445,7 @@ public class AmbariClusterConnector {
                 throw new CloudbreakException("Timeout while starting Ambari services.");
             }
         } else {
+            LOGGER.warn("Failed to start Hadoop services.");
             throw new CloudbreakException("Failed to start Hadoop services.");
         }
         eventService.fireCloudbreakEvent(stack.getId(), Status.UPDATE_IN_PROGRESS.name(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 
 ambariClientName=ambari-client
-ambariClientVersion=2.4.11
+ambariClientVersion=2.4.12
 springBootVersion=1.3.4.RELEASE
 azureRestClientVersion=0.1.56
 eventBusVersion=2.0.7.RELEASE


### PR DESCRIPTION
…poradically

More logs are in AmbariClient.  Probably we need extra polling around client.startAllServices call.