### PR TITLE
CLOUD-EAR-4599 avoid duplicated privateids

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -145,10 +145,14 @@ public class StackToCloudStackConverter {
     }
 
     private Long getFirstValidPrivateId(List<InstanceGroup> instanceGroups) {
+        LOGGER.info("Get first valid PrivateId of instanceGroups");
         long highest = 0;
         for (InstanceGroup instanceGroup : instanceGroups) {
-            for (InstanceMetaData metaData : instanceGroup.getInstanceMetaData()) {
+            LOGGER.info("Checking of instanceGroup: {}", instanceGroup.getGroupName());
+            for (InstanceMetaData metaData : instanceGroup.getAllInstanceMetaData()) {
                 Long privateId = metaData.getPrivateId();
+                LOGGER.info("InstanceMetaData metaData: privateId: {}, instanceGroupName: {}, instanceId: {}, status: {}",
+                        privateId, metaData.getInstanceGroupName(), metaData.getInstanceId(), metaData.getInstanceStatus());
                 if (privateId == null) {
                     continue;
                 }
@@ -157,6 +161,7 @@ public class StackToCloudStackConverter {
                 }
             }
         }
+        LOGGER.info("highest privateId: {}", highest);
         return highest == 0 ? 0 : highest + 1;
     }
 


### PR DESCRIPTION

Main issue was that TERMINATED instances were filtered out by instanceGroup.getInstanceMetaData() 