### PR TITLE
CLOUD-66518: Delete HostMetadata instance by ID instance of reference…

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackScalingService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/stack/flow/StackScalingService.java
@@ -78,7 +78,10 @@ public class StackScalingService {
         if (hostMetadata != null) {
             try {
                 ambariDecommissioner.deleteHostFromAmbari(stack, hostMetadata);
-                hostMetadataRepository.delete(hostMetadata);
+                // Deleting by entity will not work because HostMetadata has a reference pointed
+                // from HostGroup and per JPA, we would need to clear that up.
+                // Reference: http://stackoverflow.com/a/22315188
+                hostMetadataRepository.delete(hostMetadata.getId());
                 eventService.fireCloudbreakEvent(stack.getId(), Status.AVAILABLE.name(),
                         cloudbreakMessagesService.getMessage(Msg.STACK_SCALING_HOST_DELETED.code(),
                                 Collections.singletonList(instanceMetaData.getInstanceId())));

--- a/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackScalingServiceTest.java
+++ b/core/src/test/java/com/sequenceiq/cloudbreak/service/stack/flow/StackScalingServiceTest.java
@@ -1,0 +1,52 @@
+package com.sequenceiq.cloudbreak.service.stack.flow;
+
+import com.sequenceiq.cloudbreak.domain.HostMetadata;
+import com.sequenceiq.cloudbreak.domain.InstanceMetaData;
+import com.sequenceiq.cloudbreak.domain.Stack;
+import com.sequenceiq.cloudbreak.repository.HostMetadataRepository;
+import com.sequenceiq.cloudbreak.service.cluster.flow.AmbariDecommissioner;
+import com.sequenceiq.cloudbreak.service.events.CloudbreakEventService;
+import com.sequenceiq.cloudbreak.service.messages.CloudbreakMessagesService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class StackScalingServiceTest {
+
+    @InjectMocks
+    private StackScalingService stackScalingService;
+
+    @Mock
+    private AmbariDecommissioner ambariDecommissioner;
+
+    @Mock
+    private HostMetadataRepository hostMetadataRepository;
+
+    @Mock
+    private CloudbreakEventService eventService;
+
+    @Mock
+    private CloudbreakMessagesService cloudbreakMessagesService;
+
+    @Test
+    public void shouldRemoveHostMetadataUsingId() {
+
+        Stack stack = mock(Stack.class);
+        when(stack.getId()).thenReturn(123L);
+        InstanceMetaData instanceMetaData = mock(InstanceMetaData.class);
+        when(instanceMetaData.getInstanceId()).thenReturn("i-1234567");
+        HostMetadata hostMetadata = mock(HostMetadata.class);
+        when(hostMetadata.getId()).thenReturn(456L);
+
+        stackScalingService.removeHostmetadataIfExists(stack, instanceMetaData, hostMetadata);
+
+        verify(hostMetadataRepository).delete(456L);
+    }
+}


### PR DESCRIPTION
This is a fix to a specific failing scenario. The steps to reproduce:

- Create a new cluster in AWS (>1 nodes in slave host group)
- From AWS EC2 console, stop one of the instances in the slave host group.
- Wait until Ambari receives an Agent Heartbeat timeout alert for this instance.
- Sync Cloudbreak. The host status will be updated to UNHEALTHY
- Terminate the UNHEALTHY node. This does not remove the HostMetadata instance despite a call being fired for the delete.

The impact of the above bug is that a further up-scale operation to replace the UNHEALTHY instance fails with a timeout exception like this:

` 9/28/2016 9:40:19 PM yh-recovery-issue-test - update failed: New node(s) could not be added to the cluster. Reason com.sequenceiq.cloudbreak.service.cluster.AmbariHostsUnavailableException: Operation timed out. Failed to find all '4' Ambari hosts. Stack: '63'`

And before this, we can see the flow stuck on a loop like this:

`2016-09-28 21:06:48,660 [reactorDispatcher-93] checkStatus:24 INFO  c.s.c.s.c.f.AmbariHostsStatusCheckerTask - [owner:554b239c-f11b-4ea6-8a45-461c88bdebf8] [type:STACK] [id:63] [name:yh-recovery-issue-test] Ambari client found 3 hosts (4 needed). [Stack: '63']`

The reason for the issue is that a delete of the HostMetadata instance, as is done in `StackScalingService.removeHostmetadataIfExists` fails to remove the instance, because of how Hibernate / JPA behave when there are references that still hold on to a deleted instance. In our case, a HostMetadata object is referred from the HostGroup object in a set, and this causes the delete to be cancelled. The issue has been faced by many others and there are some links that explain it in detail. E.g.: http://stackoverflow.com/a/16901857 and http://stackoverflow.com/a/22315188.

Working with @akanto, we found that HostMetadata deletion works in a different flow (through a different code path) and the difference why it works there is because the deletion of the instance happens via ID rather than reference. This being the simplest fix, I have modified the code to do the same here.

Tests:
- Added a unit test to ensure deletion is happening via ID. This only tests the contract and not the DB operation itself.
- Verified manually that we are able to execute the failing test case described above manually without getting stuck. Further, an upscale operation now works fine.

Request to please review and merge this as this helps me to move ahead with trying to recover the nodes automatically on fault detection.