### PR TITLE
CLOUD-66581 Enable LDAP group lookup for shared and ephemeral enterpr…

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp25-etl-edw-shared.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp25-etl-edw-shared.bp
@@ -59,6 +59,10 @@
     {
       "name":"ATLAS_REST_ADDRESS",
       "referenceConfiguration":"atlas.rest.address"
+    },
+    {
+      "name":"LDAP_GROUP_SEARCH_BASE",
+      "referenceConfiguration":"hadoop.security.group.mapping.ldap.base"
     }
   ],
   "blueprint":{
@@ -70,7 +74,12 @@
     "configurations":[
       {
         "core-site":{
-          "fs.trash.interval":"4320"
+          "fs.trash.interval":"4320",
+          "hadoop.security.group.mapping":"org.apache.hadoop.security.LdapGroupsMapping",
+          "hadoop.security.group.mapping.ldap.url":"{{ LDAP_URL }}",
+          "hadoop.security.group.mapping.ldap.bind.user":"{{ LDAP_BIND_DN }}",
+          "hadoop.security.group.mapping.ldap.bind.password":"{{ LDAP_BIND_PASSWORD }}",
+          "hadoop.security.group.mapping.ldap.base":"{{ LDAP_GROUP_SEARCH_BASE }}"
         }
       },
       {

--- a/core/src/main/resources/defaults/blueprints/shared-services.bp
+++ b/core/src/main/resources/defaults/blueprints/shared-services.bp
@@ -51,6 +51,10 @@
     {
       "name":"LDAP_SYNC_SEARCH_BASE",
       "referenceConfiguration":"ranger.usersync.ldap.user.searchbase"
+    },
+    {
+      "name":"LDAP_GROUP_SEARCH_BASE",
+      "referenceConfiguration":"hadoop.security.group.mapping.ldap.base"
     }
   ],
   "blueprint":{
@@ -62,7 +66,12 @@
     "configurations":[
       {
         "core-site":{
-          "fs.trash.interval":"4320"
+          "fs.trash.interval":"4320",
+          "hadoop.security.group.mapping":"org.apache.hadoop.security.LdapGroupsMapping",
+          "hadoop.security.group.mapping.ldap.url":"{{ LDAP_URL }}",
+          "hadoop.security.group.mapping.ldap.bind.user":"{{ LDAP_BIND_DN }}",
+          "hadoop.security.group.mapping.ldap.bind.password":"{{ LDAP_BIND_PASSWORD }}",
+          "hadoop.security.group.mapping.ldap.base":"{{ LDAP_GROUP_SEARCH_BASE }}"
         }
       },
       {
@@ -151,6 +160,7 @@
           "atlas.authentication.method.ldap.ad.url":"{{ LDAP_URL }}",
           "atlas.authentication.method.ldap.ad.base.dn":"{{ LDAP_SYNC_SEARCH_BASE }}",
           "atlas.authentication.method.ldap.ad.domain":"{{ LDAP_DOMAIN }}",
+          "atlas.authentication.method.ldap.ugi-groups":"false",
           "atlas.authorizer.impl":"ranger"
         }
       },


### PR DESCRIPTION
This PR makes changes to the shared-services and hdp25-etl-edw-shared blueprints to support LDAP group configuration, so that policies can be set on LDAP groups rather than individual users. This makes it easier to support enterprise use cases as most policies work at a group level.

I tested these changes manually as follows:

- Created a new blueprint from the Blueprint text on a controller
- Manually updated the DB with the input parameters required.
- Created a cluster from the CLI by generating a template and filling in the values
- Validated the configuration is correctly set (including replacing variables) in Ambari on the created clusters.
- Setup group based policies in Ranger for Atlas and Hive. Validated they work by logging in as users in   the group.

I am assuming that just the changes in the template are sufficient for populating the DB correctly - as it seems to be happening in `BlueprintLoaderService.loadBlueprints`. Please do let me know if more changes are required to support inclusion of these variables elsewhere.