### PR TITLE
CLOUD-EAR-4658 missing files from gcp images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ generate-image-yamls:
 	 make -C cloud-arm generate-yml
 	 make -C cloud-gcp generate-yml
 	 make -C cloud-aws generate-yml
+
+generate-ambari-docker-image:
 	 make -C cloud-common update-ambari-image
 
 beautify:

--- a/cloud-aws/src/main/resources/aws-images.yml
+++ b/cloud-aws/src/main/resources/aws-images.yml
@@ -1,11 +1,11 @@
 aws:
-  ap-northeast-1: ami-618e5100
-  ap-northeast-2: ami-8c6ebbe2
-  ap-southeast-1: ami-a6ab0fc5
-  ap-southeast-2: ami-905c6ff3
-  eu-central-1: ami-a809f5c7
-  eu-west-1: ami-60de9913
-  sa-east-1: ami-18ff6d74
-  us-east-1: ami-d7b9ffc0
-  us-west-1: ami-b4df91d4
-  us-west-2: ami-89ce10e9
+  ap-northeast-1: ami-e526fd84
+  ap-northeast-2: ami-38ac7856
+  ap-southeast-1: ami-5d69ce3e
+  ap-southeast-2: ami-91497bf2
+  eu-central-1: ami-71916f1e
+  eu-west-1: ami-781d5f0b
+  sa-east-1: ami-7cd64b10
+  us-east-1: ami-36642c21
+  us-west-1: ami-e0fcb580
+  us-west-2: ami-c9c813a9

--- a/cloud-gcp/src/main/resources/gcp-images.yml
+++ b/cloud-gcp/src/main/resources/gcp-images.yml
@@ -1,2 +1,2 @@
 gcp:
-  default: sequenceiqimage/cb-2016-09-29-10-05.tar.gz
+  default: sequenceiqimage/cb-2016-10-10-13-51.tar.gz

--- a/cloud-openstack/os-images.tmpl
+++ b/cloud-openstack/os-images.tmpl
@@ -1,2 +1,2 @@
 openstack:{{$atlas:=httpget "https://atlas.hashicorp.com/api/v1/artifacts/sequenceiq/cloudbreak/openstack.image/search" | json | pointer "/versions/0"}}
-  default: {{ $atlas.id | replace ".img" "" }}
+  default: {{ $atlas.metadata.image_name }}

--- a/cloud-openstack/src/main/resources/os-images.yml
+++ b/cloud-openstack/src/main/resources/os-images.yml
@@ -1,2 +1,2 @@
 openstack:
-  default: cloudbreak-2016-09-29-09-14
+  default: cloudbreak-2016-10-10-14-19


### PR DESCRIPTION
Although this fix is not strictly related to HDC AWS, but our GCP tests are failing on this branch