### PR TITLE
[RMP-8002] adding druid to the stack 2.6

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp26-etl-edw-shared.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-etl-edw-shared.bp
@@ -1,0 +1,364 @@
+{
+  "inputs":[
+    {
+      "name":"RANGER_DB_ROOT_USER",
+      "referenceConfiguration":"db_root_user"
+    },
+    {
+      "name":"RANGER_DB_ROOT_PASSWORD",
+      "referenceConfiguration":"db_root_password"
+    },
+    {
+      "name":"RANGER_DB_USER",
+      "referenceConfiguration":"db_user"
+    },
+    {
+      "name":"RANGER_DB_PASSWORD",
+      "referenceConfiguration":"db_password"
+    },
+    {
+      "name":"RANGER_DB_NAME",
+      "referenceConfiguration":"db_name"
+    },
+    {
+      "name":"RANGER_DB_HOST",
+      "referenceConfiguration":"db_host"
+    },
+    {
+      "name":"RANGER_ADMIN_PASSWORD",
+      "referenceConfiguration":"ranger_admin_password"
+    },
+    {
+      "name":"LDAP_URL",
+      "referenceConfiguration":"hive.server2.authentication.ldap.url"
+    },
+    {
+      "name":"LDAP_DOMAIN",
+      "referenceConfiguration":"hive.server2.authentication.ldap.Domain"
+    },
+    {
+      "name":"POLICYMGR_EXTERNAL_URL",
+      "referenceConfiguration":"policymgr_external_url"
+    },
+    {
+      "name":"REMOTE_CLUSTER_NAME",
+      "referenceConfiguration":"cluster_name"
+    },
+    {
+      "name":"SOLR_ZOOKEPERS_URL",
+      "referenceConfiguration":"xasecure.audit.destination.solr.zookeepers"
+    },
+    {
+      "name":"KAFKA_SERVERS",
+      "referenceConfiguration":"atlas.kafka.bootstrap.servers"
+    },
+    {
+      "name":"SOLR_ZOOKEPERS_SERVERS",
+      "referenceConfiguration":"atlas.kafka.zookeeper.connect"
+    },
+    {
+      "name":"ATLAS_REST_ADDRESS",
+      "referenceConfiguration":"atlas.rest.address"
+    },
+    {
+      "name":"LDAP_GROUP_SEARCH_BASE",
+      "referenceConfiguration":"hadoop.security.group.mapping.ldap.base"
+    }
+  ],
+  "blueprint":{
+    "Blueprints":{
+      "blueprint_name":"hdp26-etl-edw-shared",
+      "stack_name":"HDP",
+      "stack_version":"2.6"
+    },
+    "configurations":[
+      {
+        "core-site":{
+          "fs.trash.interval":"4320",
+          "hadoop.security.group.mapping":"org.apache.hadoop.security.LdapGroupsMapping",
+          "hadoop.security.group.mapping.ldap.url":"{{ LDAP_URL }}",
+          "hadoop.security.group.mapping.ldap.bind.user":"{{ LDAP_BIND_DN }}",
+          "hadoop.security.group.mapping.ldap.bind.password":"{{ LDAP_BIND_PASSWORD }}",
+          "hadoop.security.group.mapping.ldap.base":"{{ LDAP_GROUP_SEARCH_BASE }}"
+        }
+      },
+      {
+        "hdfs-site":{
+          "dfs.namenode.safemode.threshold-pct":"0.99"
+        }
+      },
+      {
+        "hive-site":{
+          "hive.exec.compress.output":"true",
+          "hive.merge.mapfiles":"true",
+          "hive.server2.tez.initialize.default.sessions":"true",
+          "hive.server2.authentication.ldap.url":"{{ LDAP_URL }}",
+          "hive.server2.authentication.ldap.Domain":"{{ LDAP_DOMAIN }}",
+          "hive.server2.authentication":"LDAP"
+        }
+      },
+      {
+        "mapred-site":{
+          "mapreduce.job.reduce.slowstart.completedmaps":"0.7",
+          "mapreduce.map.output.compress":"true",
+          "mapreduce.output.fileoutputformat.compress":"true"
+        }
+      },
+      {
+        "yarn-site":{
+          "yarn.acl.enable":"true"
+        }
+      },
+      {
+        "admin-properties":{
+          "db_root_user":"{{ RANGER_DB_ROOT_USER }}",
+          "db_root_password":"{{ RANGER_DB_ROOT_PASSWORD }}",
+          "db_user":"{{ RANGER_DB_USER }}",
+          "db_password":"{{ RANGER_DB_PASSWORD }}",
+          "db_name":"{{ RANGER_DB_NAME }}",
+          "db_host":"{{ RANGER_DB_HOST }}",
+          "policymgr_external_url":"{{ POLICYMGR_EXTERNAL_URL }}",
+          "DB_FLAVOR":"POSTGRES"
+        }
+      },
+      {
+        "ranger-env":{
+          "ranger_admin_password":"{{ RANGER_ADMIN_PASSWORD }}",
+          "ranger-hdfs-plugin-enabled":"No",
+          "ranger-hive-plugin-enabled":"Yes",
+          "ranger-yarn-plugin-enabled":"No",
+          "xasecure.audit.destination.solr":"false",
+          "xasecure.audit.destination.hdfs":"false",
+          "ranger_privelege_user_jdbc_url":"jdbc:postgresql://{{ RANGER_DB_HOST }}",
+          "create_db_dbuser":"false"
+        }
+      },
+      {
+        "ranger-admin-site":{
+          "ranger.jpa.jdbc.driver":"org.postgresql.Driver",
+          "ranger.jpa.jdbc.url":"jdbc:postgresql://{{ RANGER_DB_HOST }}/{{ RANGER_DB_NAME }}"
+        }
+      },
+      {
+        "ranger-hive-security":{
+          "ranger.plugin.hive.service.name":"{{ REMOTE_CLUSTER_NAME }}_hive"
+        }
+      },
+      {
+        "ranger-hive-audit":{
+          "xasecure.audit.is.enabled":"true",
+          "xasecure.audit.destination.hdfs":"false",
+          "xasecure.audit.destination.solr":"true",
+          "xasecure.audit.destination.solr.zookeepers":"{{ SOLR_ZOOKEPERS_URL }}"
+        }
+      },
+      {
+        "ranger-ugsync-site":{
+          "ranger.usersync.enabled":"false"
+        }
+      },
+      {
+        "application-properties":{
+          "atlas.cluster.name":"{{ REMOTE_CLUSTER_NAME }}",
+          "atlas.kafka.bootstrap.servers":"{{ KAFKA_SERVERS }}",
+          "atlas.kafka.zookeeper.connect":"{{ SOLR_ZOOKEPERS_SERVERS }}",
+          "atlas.kafka.zookeeper.connection.timeout.ms":"20000",
+          "atlas.kafka.zookeeper.session.timeout.ms":"40000",
+          "atlas.rest.address":"{{ ATLAS_REST_ADDRESS }}",
+          "atlas.notification.embedded": "true"
+        }
+      },
+      {
+      "druid-overlord" : {
+        "properties_attributes" : { },
+        "properties" : {
+          "druid.indexer.storage.type" : "metadata",
+          "druid.indexer.runner.type" : "remote",
+          "druid.service" : "druid/overlord",
+          "druid.port" : "8090"
+        }
+      }
+    },
+      {
+      "druid-middlemanager" : {
+        "properties_attributes" : { },
+        "properties" : {
+          "druid.indexer.task.hadoopWorkingPath" : "/tmp/druid-indexing",
+          "druid.server.http.numThreads" : "50",
+          "druid.indexer.runner.startPort" : "8100",
+          "druid.worker.capacity" : "3",
+          "druid.processing.numThreads" : "2",
+          "druid.indexer.runner.javaOpts" : "-server -Xmx2g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dhdp.version={{stack_version}} -Dhadoop.mapreduce.job.classloader=true",
+          "druid.indexer.task.baseTaskDir" : "/tmp/persistent/tasks",
+          "druid.processing.buffer.sizeBytes" : "256000000",
+          "druid.service" : "druid/middlemanager",
+          "druid.port" : "8091"
+        }
+      }
+    }
+    ],
+    "host_groups":[
+      {
+        "name":"master",
+        "configurations":[
+
+        ],
+        "components":[
+          {
+            "name":"APP_TIMELINE_SERVER"
+          },
+          {
+            "name":"HCAT"
+          },
+          {
+            "name":"HDFS_CLIENT"
+          },
+          {
+            "name":"HISTORYSERVER"
+          },
+          {
+            "name":"HIVE_CLIENT"
+          },
+          {
+            "name":"HIVE_METASTORE"
+          },
+          {
+            "name":"HIVE_SERVER"
+          },
+          {
+            "name":"JOURNALNODE"
+          },
+          {
+            "name":"LIVY_SERVER"
+          },
+          {
+            "name":"MAPREDUCE2_CLIENT"
+          },
+          {
+            "name":"METRICS_COLLECTOR"
+          },
+          {
+            "name":"METRICS_MONITOR"
+          },
+          {
+            "name":"MYSQL_SERVER"
+          },
+          {
+            "name":"NAMENODE"
+          },
+          {
+            "name":"PIG"
+          },
+          {
+            "name":"RESOURCEMANAGER"
+          },
+          {
+            "name":"SECONDARY_NAMENODE"
+          },
+          {
+            "name":"SPARK_CLIENT"
+          },
+          {
+            "name":"SPARK_JOBHISTORYSERVER"
+          },
+          {
+            "name":"SQOOP"
+          },
+          {
+            "name":"TEZ_CLIENT"
+          },
+          {
+            "name":"WEBHCAT_SERVER"
+          },
+          {
+            "name":"YARN_CLIENT"
+          },
+          {
+            "name":"ZOOKEEPER_CLIENT"
+          },
+          {
+            "name":"ZOOKEEPER_SERVER"
+          },
+          {
+            "name":"RANGER_ADMIN"
+          },
+          {
+            "name":"RANGER_USERSYNC"
+          },
+          {
+            "name":"RANGER_TAGSYNC"
+          },
+          {
+            "name":"HBASE_MASTER"
+          },
+          {
+            "name":"INFRA_SOLR_CLIENT"
+          },
+          {
+            "name":"INFRA_SOLR"
+          },
+          {
+            "name":"KAFKA_BROKER"
+          },
+          {
+            "name":"ATLAS_SERVER"
+          },
+          {
+            "name":"HBASE_CLIENT"
+          },
+          {
+            "name":"ATLAS_CLIENT"
+          },
+          {
+            "name" : "DRUID_OVERLORD",
+            "provision_action": "INSTALL_ONLY"
+          }
+        ],
+        "cardinality":"1"
+      },
+      {
+        "name":"worker",
+        "configurations":[
+
+        ],
+        "components":[
+          {
+            "name":"HIVE_CLIENT"
+          },
+          {
+            "name":"TEZ_CLIENT"
+          },
+          {
+            "name":"SPARK_CLIENT"
+          },
+          {
+            "name":"DATANODE"
+          },
+          {
+            "name":"METRICS_MONITOR"
+          },
+          {
+            "name":"NODEMANAGER"
+          },
+          {
+            "name":"INFRA_SOLR_CLIENT"
+          },
+          {
+            "name":"HBASE_REGIONSERVER"
+          },
+          {
+            "name":"HBASE_CLIENT"
+          },
+          {
+            "name":"ATLAS_CLIENT"
+          },
+          {
+            "name" : "DRUID_MIDDLEMANAGER",
+            "provision_action": "INSTALL_ONLY"
+          }
+        ],
+        "cardinality":"1+"
+      }
+    ]
+  }
+}

--- a/core/src/main/resources/defaults/blueprints/hdp26-etl-edw.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-etl-edw.bp
@@ -1,0 +1,186 @@
+{
+  "inputs": [],
+  "blueprint": {
+    "Blueprints": {
+      "blueprint_name": "hdp-etl-edw",
+      "stack_name": "HDP",
+      "stack_version": "2.6"
+    },
+    "configurations": [
+      {
+        "core-site": {
+          "fs.trash.interval": "4320"
+        }
+      },
+      {
+        "hdfs-site": {
+          "dfs.namenode.safemode.threshold-pct": "0.99"
+        }
+      },
+      {
+        "hive-site": {
+          "hive.exec.compress.output": "true",
+          "hive.merge.mapfiles": "true",
+          "hive.server2.tez.initialize.default.sessions": "true"
+        }
+      },
+      {
+        "mapred-site": {
+          "mapreduce.job.reduce.slowstart.completedmaps": "0.7",
+          "mapreduce.map.output.compress": "true",
+          "mapreduce.output.fileoutputformat.compress": "true"
+        }
+      },
+      {
+        "yarn-site": {
+          "yarn.acl.enable": "true"
+        }
+      },
+      {
+      "druid-overlord" : {
+        "properties_attributes" : { },
+        "properties" : {
+          "druid.indexer.storage.type" : "metadata",
+          "druid.indexer.runner.type" : "remote",
+          "druid.service" : "druid/overlord",
+          "druid.port" : "8090"
+        }
+      }
+    },
+      {
+      "druid-middlemanager" : {
+        "properties_attributes" : { },
+        "properties" : {
+          "druid.indexer.task.hadoopWorkingPath" : "/tmp/druid-indexing",
+          "druid.server.http.numThreads" : "50",
+          "druid.indexer.runner.startPort" : "8100",
+          "druid.worker.capacity" : "3",
+          "druid.processing.numThreads" : "2",
+          "druid.indexer.runner.javaOpts" : "-server -Xmx2g -Duser.timezone=UTC -Dfile.encoding=UTF-8 -Djava.util.logging.manager=org.apache.logging.log4j.jul.LogManager -Dhdp.version={{stack_version}} -Dhadoop.mapreduce.job.classloader=true",
+          "druid.indexer.task.baseTaskDir" : "/tmp/persistent/tasks",
+          "druid.processing.buffer.sizeBytes" : "256000000",
+          "druid.service" : "druid/middlemanager",
+          "druid.port" : "8091"
+        }
+      }
+    }
+    ],
+    "host_groups": [
+      {
+        "name": "master",
+        "configurations": [],
+        "components": [
+          {
+            "name": "APP_TIMELINE_SERVER"
+          },
+          {
+            "name": "HCAT"
+          },
+          {
+            "name": "HDFS_CLIENT"
+          },
+          {
+            "name": "HISTORYSERVER"
+          },
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "HIVE_METASTORE"
+          },
+          {
+            "name": "HIVE_SERVER"
+          },
+          {
+            "name": "JOURNALNODE"
+          },
+          {
+            "name": "LIVY_SERVER"
+          },
+          {
+            "name": "MAPREDUCE2_CLIENT"
+          },
+          {
+            "name": "METRICS_COLLECTOR"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "MYSQL_SERVER"
+          },
+          {
+            "name": "NAMENODE"
+          },
+          {
+            "name": "PIG"
+          },
+          {
+            "name": "RESOURCEMANAGER"
+          },
+          {
+            "name": "SECONDARY_NAMENODE"
+          },
+          {
+            "name": "SPARK_CLIENT"
+          },
+          {
+            "name": "SPARK_JOBHISTORYSERVER"
+          },
+          {
+            "name": "SQOOP"
+          },
+          {
+            "name": "TEZ_CLIENT"
+          },
+          {
+            "name": "WEBHCAT_SERVER"
+          },
+          {
+            "name": "YARN_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_CLIENT"
+          },
+          {
+            "name": "ZOOKEEPER_SERVER"
+          },
+          {
+            "name" : "DRUID_OVERLORD",
+            "provision_action": "INSTALL_ONLY"
+          }
+        ],
+        "cardinality": "1"
+      },
+      {
+        "name": "worker",
+        "configurations": [],
+        "components": [
+          {
+            "name": "HIVE_CLIENT"
+          },
+          {
+            "name": "TEZ_CLIENT"
+          },
+          {
+            "name": "SPARK_CLIENT"
+          },
+          {
+            "name": "DATANODE"
+          },
+          {
+            "name": "METRICS_MONITOR"
+          },
+          {
+            "name": "NODEMANAGER"
+          },
+          {
+            "name" : "DRUID_MIDDLEMANAGER",
+            "provision_action": "INSTALL_ONLY"
+          }
+        ],
+        "cardinality": "1+"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
part of [RMP-8002] this PR adds a blue prints for 2.6 stack in order to include druid.
the new BP is a copy and past from 2.5 stack plus the druid spec/properties.