### PR TITLE
CLOUD-68246: Allow deleting multiple instances in a stack in the backend

### DIFF
--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/InstancePayload.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/InstancePayload.java
@@ -1,5 +1,7 @@
 package com.sequenceiq.cloudbreak.cloud.event;
 
+import java.util.Set;
+
 public interface InstancePayload extends Payload {
-    String getInstanceId();
+    Set<String> getInstanceIds();
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/RemoveInstanceRequest.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/RemoveInstanceRequest.java
@@ -1,18 +1,17 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource;
 
-import java.util.Collections;
-import java.util.List;
-
 import com.sequenceiq.cloudbreak.cloud.context.CloudContext;
 import com.sequenceiq.cloudbreak.cloud.model.CloudCredential;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
 import com.sequenceiq.cloudbreak.cloud.model.CloudResource;
 import com.sequenceiq.cloudbreak.cloud.model.CloudStack;
 
+import java.util.List;
+
 public class RemoveInstanceRequest<T> extends DownscaleStackRequest<T> {
 
     public RemoveInstanceRequest(CloudContext cloudContext, CloudCredential cloudCredential, CloudStack cloudStack, List<CloudResource> cloudResources,
-            CloudInstance instance) {
-        super(cloudContext, cloudCredential, cloudStack, cloudResources, Collections.singletonList(instance));
+            List<CloudInstance> instances) {
+        super(cloudContext, cloudCredential, cloudStack, cloudResources, instances);
     }
 }

--- a/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/RemoveInstanceResult.java
+++ b/cloud-reactor-api/src/main/java/com/sequenceiq/cloudbreak/cloud/event/resource/RemoveInstanceResult.java
@@ -1,10 +1,12 @@
 package com.sequenceiq.cloudbreak.cloud.event.resource;
 
-import java.util.List;
-
 import com.sequenceiq.cloudbreak.cloud.event.CloudPlatformResult;
 import com.sequenceiq.cloudbreak.cloud.event.InstancePayload;
 import com.sequenceiq.cloudbreak.cloud.model.CloudInstance;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 public class RemoveInstanceResult extends CloudPlatformResult<RemoveInstanceRequest> implements InstancePayload {
 
@@ -22,11 +24,12 @@ public class RemoveInstanceResult extends CloudPlatformResult<RemoveInstanceRequ
     }
 
     @Override
-    public String getInstanceId() {
+    public Set<String> getInstanceIds() {
         if (getCloudInstance() == null) {
             return null;
         } else {
-            return getCloudInstance().getInstanceId();
+            List<CloudInstance> instances = getRequest().getInstances();
+            return instances.stream().map(CloudInstance::getInstanceId).collect(Collectors.toSet());
         }
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/spi/StackToCloudStackConverter.java
@@ -56,7 +56,7 @@ public class StackToCloudStackConverter {
         return convert(stack, Collections.singleton(instanceId));
     }
 
-    private CloudStack convert(Stack stack, Set<String> deleteRequestedInstances) {
+    public CloudStack convert(Stack stack, Set<String> deleteRequestedInstances) {
         Image image = null;
         List<Group> instanceGroups = buildInstanceGroups(stack.getInstanceGroupsAsList(), deleteRequestedInstances);
         try {

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/InstanceTerminationTriggerEvent.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/event/InstanceTerminationTriggerEvent.java
@@ -3,16 +3,18 @@ package com.sequenceiq.cloudbreak.core.flow2.event;
 import com.sequenceiq.cloudbreak.cloud.event.InstancePayload;
 import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
-public class InstanceTerminationTriggerEvent extends StackEvent implements InstancePayload {
-    private final String instanceId;
+import java.util.Set;
 
-    public InstanceTerminationTriggerEvent(String selector, Long stackId, String instanceId) {
+public class InstanceTerminationTriggerEvent extends StackEvent implements InstancePayload {
+    private final Set<String> instanceIds;
+
+    public InstanceTerminationTriggerEvent(String selector, Long stackId, Set<String> instanceIds) {
         super(selector, stackId);
-        this.instanceId = instanceId;
+        this.instanceIds = instanceIds;
     }
 
     @Override
-    public String getInstanceId() {
-        return instanceId;
+    public Set<String> getInstanceIds() {
+        return instanceIds;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/service/ReactorFlowManager.java
@@ -21,6 +21,8 @@ import com.sequenceiq.cloudbreak.reactor.api.event.StackEvent;
 
 import reactor.bus.EventBus;
 
+import java.util.Collections;
+
 /**
  * Flow manager implementation backed by Reactor.
  * This class is the flow state machine and mediates between the states and reactor events
@@ -72,7 +74,8 @@ public class ReactorFlowManager {
 
     public void triggerStackRemoveInstance(Long stackId, String instanceId) {
         String selector = FlowTriggers.REMOVE_INSTANCE_TRIGGER_EVENT;
-        InstanceTerminationTriggerEvent event = new InstanceTerminationTriggerEvent(selector, stackId, instanceId);
+        InstanceTerminationTriggerEvent event = new InstanceTerminationTriggerEvent(selector, stackId,
+                Collections.singleton(instanceId));
         reactor.notify(selector, eventFactory.createEvent(event, selector));
     }
 

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationAction.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationAction.java
@@ -32,6 +32,6 @@ public class InstanceTerminationAction extends AbstractInstanceTerminationAction
     @Override
     protected Selectable createRequest(InstanceTerminationContext context) {
         return new RemoveInstanceRequest<>(context.getCloudContext(), context.getCloudCredential(), context.getCloudStack(),
-                context.getCloudResources(), context.getCloudInstance());
+                context.getCloudResources(), context.getCloudInstances());
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationContext.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/flow2/stack/instance/termination/InstanceTerminationContext.java
@@ -24,20 +24,20 @@ public class InstanceTerminationContext extends CommonContext {
 
     private final List<CloudResource> cloudResources;
 
-    private final CloudInstance cloudInstance;
+    private final List<CloudInstance> cloudInstances;
 
-    private final InstanceMetaData instanceMetaData;
+    private final List<InstanceMetaData> instanceMetaDataList;
 
     public InstanceTerminationContext(String flowId, Stack stack, CloudContext cloudContext, CloudCredential cloudCredential,
-            CloudStack cloudStack, List<CloudResource> cloudResources, CloudInstance cloudInstance, InstanceMetaData instanceMetaData) {
+            CloudStack cloudStack, List<CloudResource> cloudResources, List<CloudInstance> cloudInstances, List<InstanceMetaData> instanceMetaDataList) {
         super(flowId);
         this.stack = stack;
         this.cloudContext = cloudContext;
         this.cloudCredential = cloudCredential;
         this.cloudStack = cloudStack;
         this.cloudResources = ImmutableList.copyOf(cloudResources);
-        this.cloudInstance = cloudInstance;
-        this.instanceMetaData = instanceMetaData;
+        this.cloudInstances = cloudInstances;
+        this.instanceMetaDataList = instanceMetaDataList;
     }
 
     public Stack getStack() {
@@ -60,11 +60,11 @@ public class InstanceTerminationContext extends CommonContext {
         return cloudResources;
     }
 
-    public CloudInstance getCloudInstance() {
-        return cloudInstance;
+    public List<CloudInstance> getCloudInstances() {
+        return cloudInstances;
     }
 
-    public InstanceMetaData getInstanceMetaData() {
-        return instanceMetaData;
+    public List<InstanceMetaData> getInstanceMetaDataList() {
+        return instanceMetaDataList;
     }
 }


### PR DESCRIPTION
This enhancement allows multiple instances to be deleted in the backend InstanceTerminationFlow. The flow involves termination from the cloud provider and Ambari. Multiple instance termination from cloud provider is already supported in the API (due to downscale).

This enhancement will help in ongoing work to recover from multiple faulty slave nodes in the cluster. So, while there is no front end exposure to this capability right now, it will be used with development of that feature.

Could you please review this and let me know if it can be merged, or any other feedback to address.