### PR TITLE
NPE in OutputTransformer.render if first value in map is null

### DIFF
--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/support/TableRenderer.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/support/TableRenderer.java
@@ -19,7 +19,7 @@ import org.springframework.stereotype.Component;
  * Utility class used to render tables.
  */
 @Component
-public final class TableRenderer {
+public class TableRenderer {
 
     public static final int THREE = 3;
 

--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/transformer/OutputTransformer.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/transformer/OutputTransformer.java
@@ -30,9 +30,10 @@ public class OutputTransformer {
             if (object instanceof Map) {
                 Map map = (Map) object;
                 if (!map.values().isEmpty()) {
-                    if (map.values().toArray()[0] instanceof Collection) {
+                    Object value = map.values().stream().filter(e -> e != null).findAny().orElse(null);
+                    if (value instanceof Collection) {
                         return tableRenderer.renderMultiValueMap((Map<String, List<String>>) object, true, headers);
-                    } else if (map.values().toArray()[0] instanceof String) {
+                    } else if (value instanceof String) {
                         return tableRenderer.renderSingleMapWithSortedColumn((Map<Object, String>) object, headers);
                     } else {
                         return tableRenderer.renderObjectValueMap((Map<String, Object>) object, headers[0]);

--- a/shell/src/test/java/com/sequenceiq/cloudbreak/shell/transformer/OutputTransformerTest.java
+++ b/shell/src/test/java/com/sequenceiq/cloudbreak/shell/transformer/OutputTransformerTest.java
@@ -1,0 +1,50 @@
+package com.sequenceiq.cloudbreak.shell.transformer;
+
+import java.util.Map;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.mockito.Spy;
+
+import com.google.common.collect.Maps;
+import com.sequenceiq.cloudbreak.shell.model.OutPutType;
+import com.sequenceiq.cloudbreak.shell.support.JsonRenderer;
+import com.sequenceiq.cloudbreak.shell.support.TableRenderer;
+
+public class OutputTransformerTest {
+
+    @InjectMocks
+    private OutputTransformer underTest;
+
+    @Spy
+    private TableRenderer tableRenderer = new TableRenderer();
+
+    @Mock
+    private JsonRenderer jsonRenderer;
+
+    @Before
+    public void setUp() throws Exception {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void renderMapWithNullFirstValue() throws Exception {
+        Map<String, String> map = Maps.newTreeMap();
+        map.put("subnetCIDR", null);
+        map.put("description", null);
+        map.put("name", "net1479586335554335717");
+        map.put("cloudPlatform", "AWS");
+        map.put("topologyId", null);
+        map.put("id", "42");
+        map.put("publicInAccount", "true");
+
+        String expectedResult = new TableRenderer().renderSingleMapWithSortedColumn(map, "FIELD", "VALUE");
+        String actualResult = underTest.render(OutPutType.RAW, map, "FIELD", "VALUE");
+
+        Assert.assertEquals(expectedResult, actualResult);
+    }
+}


### PR DESCRIPTION
`OutputTransformer.render` only checks the first value when deciding how to render the `map`.  If the first value happens to be `null`, the `else` branch is executed, resulting in the following exception:

```
java.lang.NullPointerException
  at org.springframework.shell.support.table.Table.calculateColumnWidths(Table.java:85)
  at com.sequenceiq.cloudbreak.shell.support.TableRenderer.format(TableRenderer.java:174)
  at com.sequenceiq.cloudbreak.shell.support.TableRenderer.renderObjectValueMap(TableRenderer.java:120)
```

This may happen in real life eg. with the `network show` command:

```
cloudbreak-shell>network show --id 63
Command failed java.lang.RuntimeException
```

This particular network had `subnetCIDR=null`, which was the first item in the `HashMap` (at least on this JVM):

```
{subnetCIDR=null, cloudPlatform=AWS, publicInAccount=true ...
```