### PR TITLE
CLOUD-69681 reduce host name length on Azure

### DIFF
--- a/cloud-arm/src/main/java/com/sequenceiq/cloudbreak/cloud/arm/view/ArmInstanceView.java
+++ b/cloud-arm/src/main/java/com/sequenceiq/cloudbreak/cloud/arm/view/ArmInstanceView.java
@@ -17,6 +17,8 @@ import com.sequenceiq.cloudbreak.util.JsonUtil;
 
 public class ArmInstanceView {
 
+    private static final int MAX_STACK_NAME_IN_HOSTNAME = 3;
+
     private CloudInstance instance;
 
     private InstanceTemplate instanceTemplate;
@@ -48,7 +50,13 @@ public class ArmInstanceView {
     public String getHostName() {
         String hostName = instance.getStringParameter(CloudInstance.DISCOVERY_NAME);
         if (hostName == null) {
-            hostName = stackName + "-" + getInstanceId();
+            String shortenedStackname;
+            if (stackName.length() > MAX_STACK_NAME_IN_HOSTNAME) {
+                shortenedStackname = stackName.substring(0, MAX_STACK_NAME_IN_HOSTNAME);
+            } else {
+                shortenedStackname = stackName;
+            }
+            hostName = shortenedStackname + "-" + getInstanceId();
         }
         return hostName;
     }


### PR DESCRIPTION
Reduce host name length on Azure in order to be sure that the fully qualified hostname is under 64 chars

The Azure-created DNS suffix cannot be modified as this document states:
https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances

Unfortunately no any proper fix exist for this issue, since the fully qualified domain name has a fixed pattern:

```
<hostname>.<hash>.<network zone>.internal.cloudapp.net

where:
hash: is the id (hash) of an Azure virtual network, its 26 chars long
network zone: describes a network zone inside the specific Azure datacenter, where the VM is allocated, it is 2 chars long
```

https://blogs.msdn.microsoft.com/igorpag/2016/07/24/my-personal-azure-faq-on-azure-networking-and-arm/
http://stackoverflow.com/questions/33596380/using-custom-hostname-domainname-for-virtual-network

