### PR TITLE
Upgrade Spring Shell to 1.2.0.RELEASE

### DIFF
--- a/shell/build.gradle
+++ b/shell/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
   compile project(':core-api')
 
-  compile group: 'org.springframework.shell',     name: 'spring-shell',                 version: '1.1.0.RELEASE'
+  compile group: 'org.springframework.shell',     name: 'spring-shell',                 version: '1.2.0.RELEASE'
   compile group: 'org.springframework.boot',      name: 'spring-boot-starter',          version: springBootVersion
   compile group: 'org.springframework.boot',      name: 'spring-boot-starter-web',      version: springBootVersion
 


### PR DESCRIPTION
With Spring Shell 1.1.0 it is [not possible to get completion for a command that is a prefix of another command](https://jira.spring.io/browse/SHL-183).

Example:

```
cloudbreak-shell>network create --AWS --NEW --name asdf --sub[press TAB]
network create --AWS --NEW           network create --AWS --NEW_SUBNET
cloudbreak-shell>network create --AWS --NEW
```

This is [fixed in Spring Shell 1.2.0](https://github.com/spring-projects/spring-shell/commit/e693a7da9cfcc8fd7526c8f25dad4d8f4c8a916d):

```
cloudbreak-shell>network create --AWS --NEW --name asdf --sub[press TAB]
cloudbreak-shell>network create --AWS --NEW --name asdf --subnet
```

Similarly, detailed help is not available with 1.1.0 for prefix commands:

```
cloudbreak-shell>help 'network create --AWS --NEW'
* network create --AWS --NEW - Create an AWS network configuration with a new network and a new subnet
* network create --AWS --NEW_SUBNET - Create an AWS network configuration with a new subnet in an existing network
```

With 1.2.0:

```
cloudbreak-shell>help 'network create --AWS --NEW'
Keyword:                   network create --AWS --NEW
Description:               Create an AWS network configuration with a new network and a new subnet
 Keyword:                  name
   Help:                   Name of the network
   Mandatory:              true
...
```