### PR TITLE
Stack scale commands should not be available without selected stack

### DIFF
--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/base/BaseStackCommands.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/commands/base/BaseStackCommands.java
@@ -311,7 +311,7 @@ public class BaseStackCommands implements BaseCommands, StackCommands {
 
     }
 
-    @CliAvailabilityIndicator({"stack node", "stack stop --id", "stack stop --name", "stack start --id", "stack start --name"})
+    @CliAvailabilityIndicator({"stack node --ADD", "stack node --REMOVE", "stack stop --id", "stack stop --name", "stack start --id", "stack start --name"})
     public boolean nodeAvailable() {
         return shellContext.isStackAvailable() && !shellContext.isMarathonMode();
     }


### PR DESCRIPTION
`stack node --ADD` and `stack node --REMOVE` commands are available without selecting a stack first.  Of course they don't work:

```
Welcome to Cloudbreak Shell. For command and param completion press TAB, for assistance type 'hint'.
cloudbreak-shell>stack node --ADD --adjustment 1 --instanceGroup host_group_slave_1
Command failed java.lang.RuntimeException: null
```

With the fix:

```
Welcome to Cloudbreak Shell. For command and param completion press TAB, for assistance type 'hint'.
cloudbreak-shell>stack node --ADD --adjustment 1 --instanceGroup host_group_slave_1
Command 'stack node --ADD --adjustment 1 --instanceGroup host_group_slave_1' was found but is not currently available (type 'help' then ENTER to learn about this command)
cloudbreak-shell>stack select --id 1
Stack selected, id: 1
cloudbreak-shell>stack node --ADD --adjustment 1 --instanceGroup host_group_slave_1
1
```