### PR TITLE
CLOUD-65410 wait until instances are inservice before suspending AS p…

### DIFF
--- a/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
+++ b/cloud-aws/src/main/java/com/sequenceiq/cloudbreak/cloud/aws/CloudFormationStackUtil.java
@@ -54,7 +54,9 @@ public class CloudFormationStackUtil {
         List<String> instanceIds = new ArrayList<>();
         if (describeAutoScalingGroupsResult.getAutoScalingGroups().get(0).getInstances() != null) {
             for (Instance instance : describeAutoScalingGroupsResult.getAutoScalingGroups().get(0).getInstances()) {
-                instanceIds.add(instance.getInstanceId());
+                if (instance.getLifecycleState().equals("InService")) {
+                    instanceIds.add(instance.getInstanceId());
+                }
             }
         }
         return instanceIds;


### PR DESCRIPTION
…rocesses

If we don't wait for instances to become "InService" then spot instances can be stuck in "Pending", and after some timeout in "Failed", so AWS will terminate them when AS processes are resumed before an upscale.