### PR TITLE
CLOUD-70189 update ambari 2.4.2.0 to 2.4.2.2-1, since downscale does …

### DIFF
--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -120,9 +120,9 @@ cb:
 
   ambari:
     repo:
-      version: 2.4.2.0-136
-      baseurl: http://public-repo-1.hortonworks.com/ambari/centos7/2.x/updates/2.4.2.0
-      gpgkey: http://public-repo-1.hortonworks.com/ambari/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
+      version: 2.4.2.2-1
+      baseurl: http://s3.amazonaws.com/dev.hortonworks.com/ambari/centos7/2.x/BUILDS/2.4.2.2-1
+      gpgkey: http://s3.amazonaws.com/dev.hortonworks.com/ambari/centos7/RPM-GPG-KEY/RPM-GPG-KEY-Jenkins
     database:
       vendor: embedded
       host: localhost


### PR DESCRIPTION
…not work with 2.4.2.0.

**Note:
The 2.4.2.2-1 version is available in dev repo, which is back by S3, therefore it does not scale (releases use CloudFront to address scaling issues).**