### PR TITLE
Optionally wait for stack/cluster up/downscale

### DIFF
--- a/shell/src/main/java/com/sequenceiq/cloudbreak/shell/configuration/CommandDefinition.java
+++ b/shell/src/main/java/com/sequenceiq/cloudbreak/shell/configuration/CommandDefinition.java
@@ -114,7 +114,7 @@ public class CommandDefinition {
 
     @Bean
     ClusterCommands clusterCommands() {
-        return new ClusterCommands(shellContext, cloudbreakShellUtil);
+        return new ClusterCommands(shellContext, cloudbreakShellUtil, stackCommands());
     }
 
     @Bean

--- a/shell/src/test/java/com/sequenceiq/cloudbreak/shell/commands/common/ClusterCommandsTest.java
+++ b/shell/src/test/java/com/sequenceiq/cloudbreak/shell/commands/common/ClusterCommandsTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 
 import com.sequenceiq.cloudbreak.api.endpoint.ClusterEndpoint;
 import com.sequenceiq.cloudbreak.client.CloudbreakClient;
+import com.sequenceiq.cloudbreak.shell.commands.base.BaseStackCommands;
 import com.sequenceiq.cloudbreak.shell.completion.HostGroup;
 import com.sequenceiq.cloudbreak.shell.model.ShellContext;
 import com.sequenceiq.cloudbreak.shell.util.CloudbreakShellUtil;
@@ -36,11 +37,14 @@ public class ClusterCommandsTest {
     @Mock
     private ClusterEndpoint clusterEndpoint;
 
+    @Mock
+    private BaseStackCommands stackCommands;
+
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        underTest = new ClusterCommands(shellContext, cloudbreakShellUtil);
+        underTest = new ClusterCommands(shellContext, cloudbreakShellUtil, stackCommands);
 
         given(shellContext.cloudbreakClient()).willReturn(cloudbreakClient);
         given(cloudbreakClient.clusterEndpoint()).willReturn(clusterEndpoint);
@@ -55,7 +59,7 @@ public class ClusterCommandsTest {
         given(shellContext.getSelectedMarathonStackId()).willReturn(null);
 
         HostGroup hostGroup = new HostGroup("master");
-        String addNodeResult = underTest.addNode(hostGroup, +1);
+        String addNodeResult = underTest.addNode(hostGroup, +1, false);
 
         verify(clusterEndpoint).put(eq(stackId), anyObject());
         Assert.assertThat(addNodeResult, containsString("id: " + stackIdStr));
@@ -69,7 +73,7 @@ public class ClusterCommandsTest {
         given(shellContext.getSelectedMarathonStackId()).willReturn(stackId);
 
         HostGroup hostGroup = new HostGroup("master");
-        String addNodeResult = underTest.addNode(hostGroup, +1);
+        String addNodeResult = underTest.addNode(hostGroup, +1, false);
 
         verify(clusterEndpoint).put(eq(stackId), anyObject());
         Assert.assertThat(addNodeResult, containsString("id: " + stackId));
@@ -84,7 +88,7 @@ public class ClusterCommandsTest {
         given(shellContext.getSelectedMarathonStackId()).willReturn(null);
 
         HostGroup hostGroup = new HostGroup("master");
-        String removeNodeResult = underTest.removeNode(hostGroup, -1, false);
+        String removeNodeResult = underTest.removeNode(hostGroup, -1, false, false);
 
         verify(clusterEndpoint).put(eq(stackId), anyObject());
         Assert.assertThat(removeNodeResult, containsString("id: " + stackIdStr));
@@ -98,7 +102,7 @@ public class ClusterCommandsTest {
         given(shellContext.getSelectedMarathonStackId()).willReturn(stackId);
 
         HostGroup hostGroup = new HostGroup("master");
-        String removeNodeResult = underTest.removeNode(hostGroup, -1, false);
+        String removeNodeResult = underTest.removeNode(hostGroup, -1, false, false);
 
         verify(clusterEndpoint).put(eq(stackId), anyObject());
         Assert.assertThat(removeNodeResult, containsString("id: " + stackId));


### PR DESCRIPTION
Add `--wait` option to the following commands:

* `stack node --ADD`
* `stack node --REMOVE`
* `cluster node --ADD`
* `cluster node --REMOVE`

Defaults to `false`, for consistency with other wait-enabled operations, and also for backwards compatibility.

This allows writing scripts involving multiple scaling operations without the need to wait outside of Cloudbreak Shell.