### PR TITLE
BUG-72792 Allow region to be nullable, as region doesn't apply to orchestrators

### DIFF
--- a/core/src/main/resources/schema/app/20170125173700_BUG-72792_regions_should_be_nullable.sql
+++ b/core/src/main/resources/schema/app/20170125173700_BUG-72792_regions_should_be_nullable.sql
@@ -1,0 +1,9 @@
+-- // BUG-72792 regions should be nullable
+-- Migration SQL that makes the change goes here.
+
+ALTER TABLE stack ALTER COLUMN region DROP NOT NULL;
+
+-- //@UNDO
+-- SQL to undo the change goes here.
+
+ALTER TABLE stack ALTER COLUMN region SET NOT NULL;


### PR DESCRIPTION
While developing the YARN Native Services orchestrator, it was found that region within a stack cannot be null, but region doesn't apply to orchestrators.