### PR TITLE
CLOUD-74238 set the s3a buffer dir to the attached disk

### DIFF
--- a/core/src/main/resources/hdp/service-config.json
+++ b/core/src/main/resources/hdp/service-config.json
@@ -28,6 +28,22 @@
       ]
     },
     {
+      "name": "S3",
+      "configurations": [
+        {
+          "type": "core-site",
+          "global": [],
+          "host": [
+            {
+              "name": "fs.s3a.buffer.dir",
+              "prefix": "",
+              "directory": "temp"
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "HDFS",
       "configurations": [
         {


### PR DESCRIPTION
If HDP 2.6 is released we should consider using the fs.s3a.fast.upload option, because in that case it writes directly from memory to s3.