### PR TITLE
CLOUD-74282 Remove un-necessary services from datalake cluster

### DIFF
--- a/core/src/main/resources/defaults/blueprints/hdp26-etl-edw-shared.bp
+++ b/core/src/main/resources/defaults/blueprints/hdp26-etl-edw-shared.bp
@@ -21,18 +21,6 @@
       "referenceConfiguration":"xasecure.audit.destination.solr.zookeepers"
     },
     {
-      "name":"KAFKA_SERVERS",
-      "referenceConfiguration":"atlas.kafka.bootstrap.servers"
-    },
-    {
-      "name":"SOLR_ZOOKEPERS_SERVERS",
-      "referenceConfiguration":"atlas.kafka.zookeeper.connect"
-    },
-    {
-      "name":"ATLAS_REST_ADDRESS",
-      "referenceConfiguration":"atlas.rest.address"
-    },
-    {
       "name":"LDAP_BIND_DN",
       "referenceConfiguration":"hadoop.security.group.mapping.ldap.bind.user"
     },
@@ -47,10 +35,6 @@
     {
       "name":"ADMIN_USERNAME",
       "referenceConfiguration":"admin_username"
-    },
-    {
-      "name":"ADMIN_PASSWORD",
-      "referenceConfiguration":"admin_password"
     },
     {
       "name":"RANGER_ADMIN_USERNAME",
@@ -99,10 +83,10 @@
       {
         "ranger-hive-plugin-properties": {
           "properties": {
-            "external_admin_username": "{{ ADMIN_USERNAME }}",
-            "external_admin_password": "{{ ADMIN_PASSWORD}}",
-            "external_ranger_admin_username": "{{ RANGER_ADMIN_USERNAME }}",
-            "external_ranger_admin_password": "{{ RANGER_ADMIN_PASSWORD }}"
+            "external_admin_username":"{{ ADMIN_USERNAME }}",
+            "external_admin_password":"{{ RANGER_ADMIN_PASSWORD }}",
+            "external_ranger_admin_username":"{{ RANGER_ADMIN_USERNAME }}",
+            "external_ranger_admin_password":"{{ RANGER_ADMIN_PASSWORD }}"
           }
         }
       },
@@ -141,17 +125,6 @@
           "xasecure.audit.destination.hdfs":"false",
           "xasecure.audit.destination.solr":"true",
           "xasecure.audit.destination.solr.zookeepers":"{{ SOLR_ZOOKEPERS_URL }}"
-        }
-      },
-      {
-        "application-properties":{
-          "atlas.cluster.name":"{{ REMOTE_CLUSTER_NAME }}",
-          "atlas.kafka.bootstrap.servers":"{{ KAFKA_SERVERS }}",
-          "atlas.kafka.zookeeper.connect":"{{ SOLR_ZOOKEPERS_SERVERS }}",
-          "atlas.kafka.zookeeper.connection.timeout.ms":"20000",
-          "atlas.kafka.zookeeper.session.timeout.ms":"40000",
-          "atlas.rest.address":"{{ ATLAS_REST_ADDRESS }}",
-          "atlas.notification.embedded": "true"
         }
       },
       {
@@ -272,25 +245,10 @@
             "name":"ZOOKEEPER_SERVER"
           },
           {
-            "name":"HBASE_MASTER"
-          },
-          {
             "name":"INFRA_SOLR_CLIENT"
           },
           {
             "name":"INFRA_SOLR"
-          },
-          {
-            "name":"KAFKA_BROKER"
-          },
-          {
-            "name":"ATLAS_SERVER"
-          },
-          {
-            "name":"HBASE_CLIENT"
-          },
-          {
-            "name":"ATLAS_CLIENT"
           },
           {
             "name" : "DRUID_OVERLORD",
@@ -334,15 +292,6 @@
           },
           {
             "name":"INFRA_SOLR_CLIENT"
-          },
-          {
-            "name":"HBASE_REGIONSERVER"
-          },
-          {
-            "name":"HBASE_CLIENT"
-          },
-          {
-            "name":"ATLAS_CLIENT"
           },
           {
             "name": "DRUID_HISTORICAL"

--- a/core/src/main/resources/defaults/blueprints/shared-services.bp
+++ b/core/src/main/resources/defaults/blueprints/shared-services.bp
@@ -111,7 +111,6 @@
             "db_password":"{{ RANGER_DB_PASSWORD }}",
             "db_name":"{{ RANGER_DB_NAME }}",
             "db_host":"{{ RANGER_DB_HOST }}",
-            "policymgr_external_url":"http://%HOSTGROUP::master%:6080",
             "DB_FLAVOR":"POSTGRES"
           }
         }
@@ -119,6 +118,7 @@
       {
         "ranger-env":{
           "properties":{
+            "admin_password":"{{ RANGER_ADMIN_PASSWORD }}",
             "ranger_admin_password":"{{ RANGER_ADMIN_PASSWORD }}",
             "is_solrCloud_enabled":"true",
             "ranger-hdfs-plugin-enabled":"No",
@@ -126,7 +126,7 @@
             "ranger-yarn-plugin-enabled":"No",
             "xasecure.audit.destination.hdfs.dir":"hdfs://%HOSTGROUP::master%:8020/ranger/audit",
             "ranger_privelege_user_jdbc_url":"jdbc:postgresql://{{ RANGER_DB_HOST }}",
-            "ranger-atlas-plugin-enabled":"Yes"
+            "ranger-atlas-plugin-enabled":"No"
           }
         }
       },
@@ -151,23 +151,6 @@
             "ranger.ldap.ad.domain":"{{ LDAP_DOMAIN }}",
             "ranger.ldap.ad.base.dn":"{{ LDAP_SYNC_SEARCH_BASE }}"
           }
-        }
-      },
-      {
-        "application-properties":{
-          "atlas.authentication.method.ldap.ad.bind.dn":"{{ LDAP_BIND_DN }}",
-          "atlas.authentication.method.ldap.type":"ad",
-          "atlas.authentication.method.ldap":"true",
-          "atlas.authentication.method.ldap.ad.url":"{{ LDAP_URL }}",
-          "atlas.authentication.method.ldap.ad.base.dn":"{{ LDAP_SYNC_SEARCH_BASE }}",
-          "atlas.authentication.method.ldap.ad.domain":"{{ LDAP_DOMAIN }}",
-          "atlas.authentication.method.ldap.ugi-groups":"false",
-          "atlas.authorizer.impl":"ranger"
-        }
-      },
-      {
-        "ranger-atlas-plugin-properties":{
-          "ranger-atlas-plugin-enabled":"Yes"
         }
       }
     ],
@@ -227,12 +210,6 @@
             "name":"SECONDARY_NAMENODE"
           },
           {
-            "name":"SPARK_CLIENT"
-          },
-          {
-            "name":"SPARK_JOBHISTORYSERVER"
-          },
-          {
             "name":"SQOOP"
           },
           {
@@ -264,21 +241,6 @@
           },
           {
             "name":"INFRA_SOLR"
-          },
-          {
-            "name":"HBASE_MASTER"
-          },
-          {
-            "name":"KAFKA_BROKER"
-          },
-          {
-            "name":"ATLAS_SERVER"
-          },
-          {
-            "name":"HBASE_CLIENT"
-          },
-          {
-            "name":"ATLAS_CLIENT"
           }
         ],
         "cardinality":"1"
@@ -306,15 +268,6 @@
           },
           {
             "name":"INFRA_SOLR_CLIENT"
-          },
-          {
-            "name":"HBASE_REGIONSERVER"
-          },
-          {
-            "name":"HBASE_CLIENT"
-          },
-          {
-            "name":"ATLAS_CLIENT"
           }
         ],
         "cardinality":"1+"
@@ -328,9 +281,6 @@
           },
           {
             "name": "TEZ_CLIENT"
-          },
-          {
-            "name": "SPARK_CLIENT"
           },
           {
             "name": "METRICS_MONITOR"


### PR DESCRIPTION
1. Removed kafka, solr, atlas, hbase from enterprise ephemeral cluster blueprint
2. Removed kafka, atlas, hbase and spark from shared services cluster blueprint 
3. Fixed remote ranger admin password