### PR TITLE
Enable autoscaling only if the cluster is in AVAILABLE state in Cloudbreak too

### DIFF
--- a/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ScalingStatus.java
+++ b/autoscale-api/src/main/java/com/sequenceiq/periscope/api/model/ScalingStatus.java
@@ -1,5 +1,5 @@
 package com.sequenceiq.periscope.api.model;
 
 public enum ScalingStatus {
-    FAILED, SUCCESS
+    FAILED, SUCCESS, ENABLED, DISABLED
 }

--- a/autoscale/src/main/java/com/sequenceiq/periscope/domain/History.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/domain/History.java
@@ -40,6 +40,10 @@ public class History {
 
     public static final String CRON = "cron";
 
+    public static final String ALERT_RULE = "alertRule";
+
+    public static final String PARAMETERS = "parameters";
+
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "history_generator")
     @SequenceGenerator(name = "history_generator", sequenceName = "sequence_table")
@@ -113,6 +117,12 @@ public class History {
             this.properties.put(TIME_ZONE, ta.getTimeZone());
             this.properties.put(CRON, ta.getCron());
             this.alertType = AlertType.TIME;
+        } else if (alert instanceof PrometheusAlert) {
+            PrometheusAlert pa = (PrometheusAlert) alert;
+            this.properties.put(ALERT_RULE, pa.getAlertRule());
+            this.properties.put(PERIOD, "" + pa.getPeriod());
+            this.properties.put(ALERT_STATE, pa.getAlertState().name());
+            this.properties.put(PARAMETERS, pa.getParameters().getValue());
         }
         this.properties.put(ALERT_DESCRIPTION, alert.getDescription());
         return this;

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/ClusterService.java
@@ -2,7 +2,8 @@ package com.sequenceiq.periscope.service;
 
 import java.util.List;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import javax.inject.Inject;
+
 import org.springframework.stereotype.Service;
 
 import com.google.common.collect.Lists;
@@ -19,16 +20,16 @@ import com.sequenceiq.periscope.repository.UserRepository;
 @Service
 public class ClusterService {
 
-    @Autowired
+    @Inject
     private ClusterRepository clusterRepository;
 
-    @Autowired
+    @Inject
     private UserRepository userRepository;
 
-    @Autowired
+    @Inject
     private SecurityConfigRepository securityConfigRepository;
 
-    @Autowired
+    @Inject
     private AlertService alertService;
 
     public Cluster create(PeriscopeUser user, AmbariStack stack, ClusterState clusterState) {

--- a/autoscale/src/main/java/com/sequenceiq/periscope/service/HistoryService.java
+++ b/autoscale/src/main/java/com/sequenceiq/periscope/service/HistoryService.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import com.sequenceiq.periscope.api.model.ScalingStatus;
+import com.sequenceiq.periscope.domain.Cluster;
 import com.sequenceiq.periscope.domain.History;
 import com.sequenceiq.periscope.domain.ScalingPolicy;
 import com.sequenceiq.periscope.repository.HistoryRepository;
@@ -24,6 +25,12 @@ public class HistoryService {
                 .withScalingPolicy(scalingPolicy)
                 .withAlert(scalingPolicy.getAlert())
                 .withCluster(scalingPolicy.getAlert().getCluster());
+        return historyRepository.save(history);
+    }
+
+    public History createEntry(ScalingStatus scalingStatus, String statusReason, int originalNodeCount, Cluster cluster) {
+        History history = new History(scalingStatus, statusReason, originalNodeCount)
+                .withCluster(cluster);
         return historyRepository.save(history);
     }
 

--- a/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/AutoscaleStackResponse.java
+++ b/core-api/src/main/java/com/sequenceiq/cloudbreak/api/model/AutoscaleStackResponse.java
@@ -45,6 +45,9 @@ public class AutoscaleStackResponse {
     @ApiModelProperty(ModelDescriptions.StackModelDescription.STACK_STATUS)
     private Status status;
 
+    @ApiModelProperty(ModelDescriptions.ClusterModelDescription.STATUS)
+    private Status clusterStatus;
+
     @ApiModelProperty(ModelDescriptions.StackModelDescription.CREATED)
     private Long created;
 
@@ -126,5 +129,13 @@ public class AutoscaleStackResponse {
 
     public void setCreated(Long created) {
         this.created = created;
+    }
+
+    public Status getClusterStatus() {
+        return clusterStatus;
+    }
+
+    public void setClusterStatus(Status clusterStatus) {
+        this.clusterStatus = clusterStatus;
     }
 }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToAutoscaleStackResponseJsonConverter.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/converter/StackToAutoscaleStackResponseJsonConverter.java
@@ -32,6 +32,7 @@ public class StackToAutoscaleStackResponseJsonConverter extends AbstractConversi
             result.setAmbariServerIp(gatewayIp);
             result.setUserName(cluster.getUserName());
             result.setPassword(cluster.getPassword());
+            result.setClusterStatus(cluster.getStatus());
         }
         return result;
     }


### PR DESCRIPTION
@keyki 
Changes:
 - Enable autoscaling only if the cluster is in AVAILABLE state in Cloudbreak too
 - Create history and notification when enabling and disabling autoscaling on a cluster
 - usage of Inject annotation instead of Autowired