### PR TITLE
CLOUD-78236 use redhat6 repo on amazonlinux

### DIFF
--- a/orchestrator-salt/src/main/resources/salt/salt/gateway/yum/hdp.repo
+++ b/orchestrator-salt/src/main/resources/salt/salt/gateway/yum/hdp.repo
@@ -1,6 +1,10 @@
 [{{ salt['pillar.get']('hdp:stack:repoid') }}]
 name={{ salt['pillar.get']('hdp:stack:repoid') }}
-{% set active_stack = 'hdp:stack:redhat' + grains['osmajorrelease'] -%}
+{% if grains['os'] == 'Amazon' %}
+    {% set active_stack = 'hdp:stack:redhat6' -%}
+{% else %}
+    {% set active_stack = 'hdp:stack:redhat' + grains['osmajorrelease'] -%}
+{% endif %}
 baseurl={{ salt['pillar.get'](active_stack) }}
 
 path=/


### PR DESCRIPTION
I don't think it ever worked on amazonlinux besides HDC. osmajorrelease returns 2016 or 2017 on amazonlinux. Also I'm not sure how it supposed to work on CB UI if I enable knox in the topology file there are no UI's exposed. I guess the UI just didn't send the required services to expose?