### PR TITLE
CLOUD-79673 Null check instance group templates for orchestrators

### DIFF
--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/HadoopConfigurationService.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/HadoopConfigurationService.java
@@ -119,7 +119,7 @@ public class HadoopConfigurationService {
         for (HostGroup hostGroup : hostGroups) {
             Map<String, Map<String, String>> componentConfig = new HashMap<>();
             Integer volumeCount = -1;
-            if (hostGroup.getConstraint().getInstanceGroup() != null) {
+            if (hostGroup.getConstraint().getInstanceGroup().getTemplate() != null) {
                 volumeCount = hostGroup.getConstraint().getInstanceGroup().getTemplate().getVolumeCount();
             }
             if (configUpdateNeeded(hostGroup)) {


### PR DESCRIPTION
The following exception occurs when using the yarn orchestrator as the template is null within the instance group.

```
2017-04-25 13:19:52,432 [reactorDispatcher-66] buildAmbariCluster:329 ERROR c.s.c.s.c.f.AmbariClusterConnector - [owner:spring] [type:springLog] [id:] [name:] Error while building the Ambari cluster. Message null, throwable: {}
java.lang.NullPointerException: null
	at com.sequenceiq.cloudbreak.service.cluster.HadoopConfigurationService.getHostGroupConfiguration(HadoopConfigurationService.java:123)
	at com.sequenceiq.cloudbreak.service.cluster.flow.AmbariClusterConnector.addBlueprint(AmbariClusterConnector.java:750)
	at com.sequenceiq.cloudbreak.service.cluster.flow.AmbariClusterConnector.buildAmbariCluster(AmbariClusterConnector.java:286)
	at com.sequenceiq.cloudbreak.core.cluster.AmbariClusterCreationService.buildAmbariCluster(AmbariClusterCreationService.java:28)
	at com.sequenceiq.cloudbreak.reactor.handler.cluster.InstallClusterHandler.accept(InstallClusterHandler.java:36)
	at com.sequenceiq.cloudbreak.reactor.handler.cluster.InstallClusterHandler.accept(InstallClusterHandler.java:18)
	at reactor.bus.EventBus$3.accept(EventBus.java:317)
	at reactor.bus.EventBus$3.accept(EventBus.java:310)
	at reactor.bus.routing.ConsumerFilteringRouter.route(ConsumerFilteringRouter.java:72)
	at reactor.bus.routing.TraceableDelegatingRouter.route(TraceableDelegatingRouter.java:51)
	at reactor.bus.EventBus.accept(EventBus.java:591)
	at reactor.bus.EventBus.accept(EventBus.java:63)
	at reactor.core.dispatch.AbstractLifecycleDispatcher.route(AbstractLifecycleDispatcher.java:160)
	at reactor.core.dispatch.MultiThreadDispatcher$MultiThreadTask.run(MultiThreadDispatcher.java:74)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:745)
```