### PR TITLE
Integrates installation of HDF into Cloudbreak

### DIFF
--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DefaultHDFEntries.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DefaultHDFEntries.java
@@ -9,17 +9,17 @@ import org.springframework.stereotype.Component;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-@ConfigurationProperties("cb.hdp")
+@ConfigurationProperties("cb.hdf")
 @Component
-public class DefaultHDPInfos {
+public class DefaultHDFEntries {
 
-    private Map<String, DefaultHDPInfo> entries = new HashMap<>();
+    private Map<String, DefaultHDFInfo> entries = new HashMap<>();
 
-    public Map<String, DefaultHDPInfo> getEntries() {
+    public Map<String, DefaultHDFInfo> getEntries() {
         return entries;
     }
 
-    public void setEntries(Map<String, DefaultHDPInfo> entries) {
+    public void setEntries(Map<String, DefaultHDFInfo> entries) {
         this.entries = entries;
     }
 }

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DefaultHDFInfo.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DefaultHDFInfo.java
@@ -1,0 +1,9 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class DefaultHDFInfo extends HDPInfo {
+
+
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DefaultHDPEntries.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/DefaultHDPEntries.java
@@ -1,0 +1,25 @@
+package com.sequenceiq.cloudbreak.cloud.model;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@ConfigurationProperties("cb.hdp")
+@Component
+public class DefaultHDPEntries {
+
+    private Map<String, DefaultHDPInfo> entries = new HashMap<>();
+
+    public Map<String, DefaultHDPInfo> getEntries() {
+        return entries;
+    }
+
+    public void setEntries(Map<String, DefaultHDPInfo> entries) {
+        this.entries = entries;
+    }
+}

--- a/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/HDPRepo.java
+++ b/cloud-api/src/main/java/com/sequenceiq/cloudbreak/cloud/model/HDPRepo.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class HDPRepo {
     public static final String REPO_ID_TAG = "repoid";
 
+    public static final String MPACK_TAG = "mpack";
+
     private Map<String, String> stack;
 
     private Map<String, String> util;

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -155,8 +155,7 @@ cb:
   hdp:
     entries:
       2.5:
-        version: 2.5.0.1-210
-        repoid: HDP-2.5
+        version: 2.5.5.0
         repo:
           stack:
             repoid: HDP-2.5
@@ -167,13 +166,26 @@ cb:
             redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6
             redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos7
       2.6:
-        version: 2.6.0.0-598
-        repoid: HDP-2.6
+        version: 2.6.0.3
         repo:
           stack:
             repoid: HDP-2.6
             redhat6: http://public-repo-1.hortonworks.com/HDP/centos6/2.x/updates/2.6.0.3
             redhat7: http://public-repo-1.hortonworks.com/HDP/centos7/2.x/updates/2.6.0.3
+          util:
+            repoid: HDP-UTILS-1.1.0.21
+            redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6
+            redhat7: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos7
+
+  hdf:
+    entries:
+      3.0:
+        version: 3.0.0.0-345
+        repo:
+          stack:
+            repoid: HDF-3.0
+            redhat6: http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos6/3.x/BUILDS/3.0.0.0-345
+            redhat7: http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos7/3.x/BUILDS/3.0.0.0-345
           util:
             repoid: HDP-UTILS-1.1.0.21
             redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6

--- a/cloud-common/src/main/resources/application.yml
+++ b/cloud-common/src/main/resources/application.yml
@@ -186,6 +186,7 @@ cb:
             repoid: HDF-3.0
             redhat6: http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos6/3.x/BUILDS/3.0.0.0-345
             redhat7: http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos7/3.x/BUILDS/3.0.0.0-345
+            mpack: http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos6/3.x/BUILDS/3.0.0.0-345/tars/hdf_ambari_mp/hdf-ambari-mpack-3.0.0.0-345.tar.gz
           util:
             repoid: HDP-UTILS-1.1.0.21
             redhat6: http://public-repo-1.hortonworks.com/HDP-UTILS-1.1.0.21/repos/centos6

--- a/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/core/bootstrap/service/host/ClusterHostServiceRunner.java
@@ -125,6 +125,8 @@ public class ClusterHostServiceRunner {
             putIfNotNull(kerberosConf, kerberosConfig.getKerberosPassword(), "password");
             putIfNotNull(kerberosConf, kerberosConfig.getKerberosUrl(), "url");
             putIfNotNull(kerberosConf, kerberosConfig.getKerberosRealm(), "realm");
+            putIfNotNull(kerberosConf, cluster.getUserName(), "clusterUser");
+            putIfNotNull(kerberosConf, cluster.getPassword(), "clusterPassword");
             krb.put("kerberos", kerberosConf);
             servicePillar.put("kerberos", new SaltPillarProperties("/kerberos/init.sls", krb));
         }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintUtils.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/blueprint/BlueprintUtils.java
@@ -46,6 +46,10 @@ public class BlueprintUtils {
         return root.get("Blueprints").get("stack_version").asText();
     }
 
+    public String getBlueprintStackName(JsonNode root) {
+        return root.get("Blueprints").get("stack_name").asText();
+    }
+
     public JsonNode convertStringToJsonNode(String json) {
         return jsonHelper.createJsonFromString(json);
     }

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -718,6 +718,7 @@ public class AmbariClusterConnector {
                 Map<String, String> utilRepo = hdpRepo.getUtil();
                 String stackRepoId = stackRepo.remove(HDPRepo.REPO_ID_TAG);
                 String utilRepoId = utilRepo.remove(HDPRepo.REPO_ID_TAG);
+                stackRepo.remove(HDPRepo.MPACK_TAG);
                 String[] typeVersion = stackRepoId.split("-");
                 String stackType = typeVersion[0];
                 String version = "";

--- a/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
+++ b/core/src/main/java/com/sequenceiq/cloudbreak/service/cluster/flow/AmbariClusterConnector.java
@@ -26,6 +26,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import javax.annotation.Resource;
@@ -38,6 +39,7 @@ import org.springframework.stereotype.Service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.google.common.collect.ImmutableMap;
 import com.sequenceiq.ambari.client.AmbariClient;
 import com.sequenceiq.ambari.client.AmbariConnectionException;
 import com.sequenceiq.cloudbreak.api.model.AdlsFileSystemConfiguration;
@@ -746,10 +748,17 @@ public class AmbariClusterConnector {
     private void addBlueprint(Stack stack, AmbariClient ambariClient, String blueprintText) {
         try {
             Cluster cluster = stack.getCluster();
-            Map<String, Map<String, Map<String, String>>> hostGroupConfig = hadoopConfigurationService.getHostGroupConfiguration(cluster);
-            blueprintText = ambariClient.extendBlueprintHostGroupConfiguration(blueprintText, hostGroupConfig);
-            Map<String, Map<String, String>> globalConfig = hadoopConfigurationService.getGlobalConfiguration(cluster);
-            blueprintText = ambariClient.extendBlueprintGlobalConfiguration(blueprintText, globalConfig);
+            HDPRepo hdpRepo = clusterComponentConfigProvider.getHDPRepo(cluster.getId());
+            String repoId = hdpRepo.getStack().get("repoid");
+            if (!repoId.startsWith("HDF") && !repoId.startsWith("hdf")) {
+                Map<String, Map<String, Map<String, String>>> hostGroupConfig = hadoopConfigurationService.getHostGroupConfiguration(cluster);
+                blueprintText = ambariClient.extendBlueprintHostGroupConfiguration(blueprintText, hostGroupConfig);
+                Map<String, Map<String, String>> globalConfig = hadoopConfigurationService.getGlobalConfiguration(cluster);
+                blueprintText = ambariClient.extendBlueprintGlobalConfiguration(blueprintText, globalConfig);
+                blueprintText = addHBaseClient(blueprintText);
+            } else {
+                blueprintText = addHDFConfigToBlueprint(stack, ambariClient, blueprintText);
+            }
             if (cluster.isSecure()) {
                 String gatewayHost = cluster.getAmbariIp();
                 if (stack.getInstanceGroups() != null && !stack.getInstanceGroups().isEmpty()) {
@@ -775,7 +784,6 @@ public class AmbariClusterConnector {
                             kerberosContainerDnResolver.resolveContainerDnForKerberos(cluster.getKerberosConfig()),
                             !cluster.getKerberosConfig().getKerberosTcpAllowed(), null);
                 }
-                blueprintText = addHBaseClient(blueprintText);
             }
             LOGGER.info("Adding generated blueprint to Ambari: {}", JsonUtil.minify(blueprintText));
             ambariClient.addBlueprint(blueprintText, cluster.getTopologyValidation());
@@ -789,6 +797,23 @@ public class AmbariClusterConnector {
                 throw new CloudbreakServiceException(e);
             }
         }
+    }
+
+    private String addHDFConfigToBlueprint(Stack stack, AmbariClient ambariClient, String blueprintText) {
+        List<String> nifiFqdns = stack.getInstanceGroupByInstanceGroupName("NiFi").getAllInstanceMetaData().stream()
+                .map(InstanceMetaData::getDiscoveryFQDN).collect(Collectors.toList());
+        AtomicInteger index = new AtomicInteger(0);
+        String nodeIdentities = nifiFqdns.stream()
+                .map(fqdn -> String.format("<property name=\"Node Identity %s\">CN=%s, OU=NIFI</property>", index.addAndGet(1), fqdn))
+                .collect(Collectors.joining());
+        blueprintText = ambariClient.extendBlueprintGlobalConfiguration(blueprintText, ImmutableMap.of("nifi-ambari-ssl-config", ImmutableMap.of(
+                "content", nodeIdentities)));
+        blueprintText = ambariClient.extendBlueprintGlobalConfiguration(blueprintText, ImmutableMap.of("nifi-ambari-ssl-config", ImmutableMap.of(
+                "nifi.initial.admin.identity", stack.getCluster().getUserName())));
+        blueprintText = ambariClient.extendBlueprintGlobalConfiguration(blueprintText, ImmutableMap.of("ams-grafana-env", ImmutableMap.of(
+                "metrics_grafana_username", stack.getCluster().getUserName(),
+                "metrics_grafana_password", stack.getCluster().getPassword())));
+        return blueprintText;
     }
 
     private String addHBaseClient(String blueprint) {

--- a/core/src/main/resources/defaults/blueprints/hdf30.bp
+++ b/core/src/main/resources/defaults/blueprints/hdf30.bp
@@ -1,0 +1,115 @@
+{
+  "Blueprints": {
+    "blueprint_name": "hdf",
+    "stack_name": "HDF",
+    "stack_version": "3.0"
+  },
+  "configurations": [
+    {
+      "nifi-ambari-config": {
+        "nifi.security.encrypt.configuration.password": "changemeplease",
+        "nifi.node.protocol.port": "9089",
+        "nifi.node.port": "9090",
+        "nifi.node.ssl.port": "9091",
+        "nifi.max_mem": "1g"
+      }
+    },
+    {
+      "nifi-properties": {
+        "nifi.sensitive.props.key": "changemeplease",
+        "nifi.security.user.login.identity.provider": "kerberos-provider",
+        "nifi.security.identity.mapping.pattern.kerb": "^(.*?)@(.*?)$",
+        "nifi.security.identity.mapping.value.kerb": "$1"
+      }
+    },
+    {
+      "nifi-ambari-ssl-config": {
+        "nifi.toolkit.tls.token": "changemeplease",
+        "nifi.node.ssl.isenabled": "true",
+        "nifi.security.needClientAuth": "false",
+        "nifi.toolkit.dn.prefix": "CN=",
+        "nifi.toolkit.dn.suffix": ", OU=NIFI",
+        "nifi.initial.admin.identity": "admin"
+      }
+    },
+    {
+      "nifi-env": {
+        "nifi_group": "nifi",
+        "nifi_user": "nifi"
+      }
+    },
+    {
+      "ams-grafana-env": {
+        "metrics_grafana_password": "admin"
+      }
+    }
+  ],
+  "host_groups": [
+    {
+      "name": "Services",
+      "components": [
+        {
+          "name": "NIFI_CA"
+        },
+        {
+          "name": "METRICS_COLLECTOR"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "METRICS_GRAFANA"
+        },
+        {
+          "name": "ZOOKEEPER_SERVER"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        },
+        {
+          "name": "DRPC_SERVER"
+        },
+        {
+          "name": "STORM_UI_SERVER"
+        },
+        {
+          "name": "NIMBUS"
+        },
+        {
+          "name": "KAFKA_BROKER"
+        }
+      ],
+      "cardinality": "1"
+    },
+    {
+      "name": "NiFi",
+      "components": [
+        {
+          "name": "NIFI_MASTER"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        }
+      ],
+      "cardinality": "1+"
+    },
+    {
+      "name": "Storm",
+      "components": [
+        {
+          "name": "SUPERVISOR"
+        },
+        {
+          "name": "METRICS_MONITOR"
+        },
+        {
+          "name": "ZOOKEEPER_CLIENT"
+        }
+      ],
+      "cardinality": "1+"
+    }
+  ]
+}

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/scripts/install-hdf-mpack.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/scripts/install-hdf-mpack.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -x
+#export hdf_ambari_mpack_url="http://public-repo-1.hortonworks.com/HDF/centos7/2.x/updates/2.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-2.1.2.0-10.tar.gz"
+export hdf_ambari_mpack_url="http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos6/3.x/BUILDS/3.0.0.0-345/tars/hdf_ambari_mp/hdf-ambari-mpack-3.0.0.0-345.tar.gz"
+echo yes | ambari-server install-mpack --mpack=${hdf_ambari_mpack_url} --verbose
+echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/hdf_mpack_installed

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/scripts/install-hdf-mpack.sh
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/scripts/install-hdf-mpack.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 set -x
-#export hdf_ambari_mpack_url="http://public-repo-1.hortonworks.com/HDF/centos7/2.x/updates/2.1.2.0/tars/hdf_ambari_mp/hdf-ambari-mpack-2.1.2.0-10.tar.gz"
-export hdf_ambari_mpack_url="http://s3.amazonaws.com/dev.hortonworks.com/HDF/centos6/3.x/BUILDS/3.0.0.0-345/tars/hdf_ambari_mp/hdf-ambari-mpack-3.0.0.0-345.tar.gz"
-echo yes | ambari-server install-mpack --mpack=${hdf_ambari_mpack_url} --verbose
+
+echo yes | ambari-server install-mpack --mpack={{ mpack }} --verbose
 echo $(date +%Y-%m-%d:%H:%M:%S) >> /var/hdf_mpack_installed

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/server.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/server.sls
@@ -100,3 +100,20 @@ run_amazon2017_sh_server:
     - unless: ls /var/log/amazon2017_server_sh.log
     - require:
       - file: add_amazon2017_patch_script_server
+
+{% if 'HDF' in salt['pillar.get']('hdp:stack:repoid') %}
+
+/opt/ambari-server/install-hdf-mpack.sh:
+  file.managed:
+    - makedirs: True
+    - source: salt://ambari/scripts/install-hdf-mpack.sh
+    - template: jinja
+    - mode: 744
+
+install_hdf_mpack:
+  cmd.run:
+    - name: /opt/ambari-server/install-hdf-mpack.sh
+    - shell: /bin/bash
+    - unless: test -f /var/hdf_mpack_installed
+
+{% endif %}

--- a/orchestrator-salt/src/main/resources/salt/salt/ambari/server.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/ambari/server.sls
@@ -109,6 +109,8 @@ run_amazon2017_sh_server:
     - source: salt://ambari/scripts/install-hdf-mpack.sh
     - template: jinja
     - mode: 744
+    - context:
+      mpack: {{ salt['pillar.get']('hdp:stack:mpack') }}
 
 install_hdf_mpack:
   cmd.run:

--- a/orchestrator-salt/src/main/resources/salt/salt/kerberos/common.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/kerberos/common.sls
@@ -54,6 +54,12 @@ run_kadm5_sh_script:
     - source: salt://kerberos/init.d/kpropd
     - mode: 755
 
+create_cluster_user:
+  cmd.run:
+    - name: 'kadmin.local -q "addprinc -pw {{ kerberos.clusterPassword }} {{ kerberos.clusterUser }}"'
+    - shell: /bin/bash
+    - unless: kadmin.local -q "list_principals *" | grep "^{{ kerberos.clusterUser }}@{{ kerberos.clusterPassword }} *"
+
 {% if grains['init'] == 'systemd' %}
 
 kpropd_service:

--- a/orchestrator-salt/src/main/resources/salt/salt/kerberos/settings.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/kerberos/settings.sls
@@ -3,6 +3,8 @@
 {% set password = salt['pillar.get']('kerberos:password') %}
 {% set user = salt['pillar.get']('kerberos:user') %}
 {% set url = salt['pillar.get']('kerberos:url') %}
+{% set clusterUser = salt['pillar.get']('kerberos:clusterUser') %}
+{% set clusterPassword = salt['pillar.get']('kerberos:clusterPassword') %}
 
 {% set servers = [] %}
 {%- set ipList = salt['mine.get']('G@roles:kerberos_server_master or G@roles:kerberos_server_slave', 'network.ipaddrs', expr_form = 'compound').values() %}
@@ -24,4 +26,6 @@
     'url': url,
     'kdcs': servers|join(" "),
     'enable_iprop': enable_iprop,
+    'clusterUser': clusterUser,
+    'clusterPassword': clusterPassword
 }) %}

--- a/orchestrator-salt/src/main/resources/salt/salt/top.sls
+++ b/orchestrator-salt/src/main/resources/salt/salt/top.sls
@@ -39,14 +39,12 @@ base:
     - prometheus.server
     - ambari.server
     - ambari.server-start
-    - grafana
 
   'roles:ambari_server_standby':
     - match: grain
     - prometheus.server
     - ambari.server
     - ambari.server-stop
-    - grafana
 
   'roles:ambari_agent':
     - match: grain

--- a/web/app/static/tags/stack/activecluster.tag
+++ b/web/app/static/tags/stack/activecluster.tag
@@ -729,7 +729,7 @@
                                                     <div class="form-group" name="ambari_stackRepoId1" ng-class="{ 'has-error': ambariStackDetailsreinstallpane.ambari_stackRepoId.$dirty && ambariStackDetailsreinstallpane.ambari_stackRepoId.$invalid }">
                                                         <label class="col-sm-3 control-label" for="ambari_stackRepoId">{{msg.cluster_form_hdp_repo_stack_repoid_label}}</label>
                                                         <div class="col-sm-9">
-                                                            <input type="string" name="ambari_stackRepoId" class="form-control" ng-model="reinstallClusterObject.ambariStackDetails.stackRepoId" id="ambari_stackRepoId" placeholder="{{msg.cluster_form_hdp_repo_stack_repoid_placeholder}}" ng-pattern="/^HDP-([\d\W]+)$/">
+                                                            <input type="string" name="ambari_stackRepoId" class="form-control" ng-model="reinstallClusterObject.ambariStackDetails.stackRepoId" id="ambari_stackRepoId" placeholder="{{msg.cluster_form_hdp_repo_stack_repoid_placeholder}}" ng-pattern="/^HD.-([\d\W]+)$/">
                                                             <div class="help-block" ng-show="ambariStackDetailsreinstallpane.ambari_stackRepoId.$dirty && ambariStackDetailsreinstallpane.ambari_stackRepoId.$invalid"><i class="fa fa-warning"></i> Should be a valid Repo Id like HDP-2.5
                                                             </div>
                                                         </div>


### PR DESCRIPTION
updated tags to not restrict stack repo id to be HDP
added custom blueprint for HDF
added code to generate node identities based on the VMs being provisioned and modify the blueprint based on those identities and values from the cluster creation wizard
updated ambari and hdp repo defaults for hdf 3.0
updated kerberos principal creation based on cluster user
added script run by salt that downloads and installs the HDF 3.0 mpack